### PR TITLE
Add batch_size to map, optimize

### DIFF
--- a/litdata/processing/functions.py
+++ b/litdata/processing/functions.py
@@ -41,11 +41,13 @@ if _TORCH_GREATER_EQUAL_2_1_0:
 def _get_indexed_paths(data: Any) -> Dict[int, str]:
     flattened_item, _ = tree_flatten(data)
 
-    return {
+    indexed_paths = {
         index: element
         for index, element in enumerate(flattened_item)
         if isinstance(element, str) and os.path.exists(element)
     }
+
+    return indexed_paths
 
 
 def _get_input_dir(inputs: Sequence[Any]) -> Optional[str]:
@@ -66,6 +68,12 @@ def _get_input_dir(inputs: Sequence[Any]) -> Optional[str]:
         return "/" + os.path.join(*str(list(indexed_paths.values())[0]).split("/")[:4])
 
     return "/" + os.path.join(*str(absolute_path).split("/")[:4])
+
+
+def _get_default_num_workers() -> int:
+    if torch.cuda.is_available():
+        return torch.cuda.device_count()
+    return os.cpu_count() or 1
 
 
 class LambdaDataTransformRecipe(DataTransformRecipe):
@@ -159,6 +167,7 @@ def map(
     reorder_files: bool = True,
     error_when_not_empty: bool = False,
     reader: Optional[BaseReader] = None,
+    batch_size: Optional[int] = None,
 ) -> None:
     """This function map a callbable over a collection of files possibly in a distributed way.
 
@@ -176,6 +185,7 @@ def map(
         reorder_files: By default, reorders the files by file size to distribute work equally among all workers.
             Set this to ``False`` if the order in which samples are processed should be preserved.
         error_when_not_empty: Whether we should error if the output folder isn't empty.
+        batch_size: Group the inputs into batches of batch_size length.
 
     """
     if not isinstance(inputs, Sequence):
@@ -210,10 +220,13 @@ def map(
 
         input_dir = _resolve_dir(_get_input_dir(inputs))
 
+        if isinstance(batch_size, int) and batch_size > 1:
+            inputs = [inputs[pos : pos + batch_size] for pos in range(0, len(inputs), batch_size)]
+
         data_processor = DataProcessor(
             input_dir=input_dir,
             output_dir=_output_dir,
-            num_workers=num_workers or os.cpu_count(),
+            num_workers=num_workers or _get_default_num_workers(),
             fast_dev_run=fast_dev_run,
             num_downloaders=num_downloaders,
             num_uploaders=num_uploaders,
@@ -245,6 +258,7 @@ def optimize(
     num_uploaders: Optional[int] = None,
     reorder_files: bool = True,
     reader: Optional[BaseReader] = None,
+    batch_size: Optional[int] = None,
 ) -> None:
     """This function converts a dataset into chunks possibly in a distributed way.
 
@@ -264,6 +278,7 @@ def optimize(
         num_uploaders: The numbers of uploaders per worker.
         reorder_files: By default, reorders the files by file size to distribute work equally among all workers.
             Set this to ``False`` if the order in which samples are processed should be preserved.
+        batch_size: Group the inputs into batches of batch_size length.
 
     """
     if not isinstance(inputs, Sequence):
@@ -300,10 +315,13 @@ def optimize(
 
         input_dir = _resolve_dir(_get_input_dir(inputs))
 
+        if isinstance(batch_size, int) and batch_size > 1:
+            inputs = [inputs[pos : pos + batch_size] for pos in range(0, len(inputs), batch_size)]
+
         data_processor = DataProcessor(
             input_dir=input_dir,
             output_dir=_output_dir,
-            num_workers=num_workers or os.cpu_count(),
+            num_workers=num_workers or _get_default_num_workers(),
             fast_dev_run=fast_dev_run,
             num_downloaders=num_downloaders,
             num_uploaders=num_uploaders,

--- a/tests/processing/test_data_processor.py
+++ b/tests/processing/test_data_processor.py
@@ -1024,3 +1024,22 @@ def test_map_is_last(num_workers, expected, tmpdir):
     )
 
     assert sorted(os.listdir(tmpdir)) == expected
+
+
+def map_batch_size_fn(indexes, output_dir):
+    path = os.path.join(output_dir, str(indexes))
+    with open(path, "w") as f:
+        f.write("hello world")
+
+
+def test_map_batch_size(tmpdir):
+    map(
+        map_batch_size_fn,
+        list(range(5)),
+        output_dir=str(tmpdir),
+        error_when_not_empty=False,
+        num_workers=1,
+        batch_size=2,
+    )
+
+    assert sorted(os.listdir(tmpdir)) == ["[0, 1]", "[2, 3]", "[4]"]

--- a/tests/processing/test_data_processor.py
+++ b/tests/processing/test_data_processor.py
@@ -1043,7 +1043,7 @@ def test_map_batch_size(tmpdir):
     )
 
     assert sorted(os.listdir(tmpdir)) == ["[0, 1]", "[2, 3]", "[4]"]
-    
+
 
 def no_op(index):
     pass


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

This PR adds batch size to the map & optimize operators.

This enables to do batched inference:

```python
from lightning.data import map, StreamingDataset
import open_clip, torch
from PIL import Image
import os
from lightning.data.streaming.serializers import JPEGSerializer

dataset = StreamingDataset(input_dir="pipeline/output_dir_step_2")

class ClipEmbedder:

    def __init__(self):
        self.model, _, self.preprocess = open_clip.create_model_and_transforms('ViT-B-32', pretrained='laion2b_s34b_b79k')
        self.dataset = StreamingDataset(input_dir="output_dir_step_2")
        self.serializer = JPEGSerializer()

    def __call__(self, indexes, output_dir, device):
        images = torch.stack([self.serializer.deserialize(dataset[index][1]).cuda() for index in indexes])
        image = self.preprocess.transforms[-1](images.float() / 255.)
        self.model = self.model.to(device)
        with torch.no_grad(), torch.cuda.amp.autocast():
            images_features = self.model.encode_image(image)
            images_features /= images_features.norm(dim=-1, keepdim=True)
            images_features = torch.split(images_features.cpu(), len(indexes))[0]
            for index, image_feature in zip(indexes, images_features):
                torch.save(image_feature, os.path.join(output_dir, f"{index}.pt"))

map(
    fn=ClipEmbedder(),
    inputs=list(range(len(dataset))),
    output_dir="pipeline/output_dir_step_3",
    num_workers=4,
    batch_size=32,
)
```

Fixes #\<issue_number>

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19489.org.readthedocs.build/en/19489/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda

Moved from https://github.com/Lightning-AI/pytorch-lightning/pull/19489