### PR TITLE
Mention how the progress bar updates

### DIFF
--- a/src/litdata/processing/data_processor.py
+++ b/src/litdata/processing/data_processor.py
@@ -931,7 +931,10 @@ class DataProcessor:
 
         self._cleanup_cache()
 
-        print(f"Starting {self.num_workers} workers with {num_items} items.")
+        print(
+            f"Starting {self.num_workers} workers with {num_items} items."
+            f" The progress bar is only updated when a worker finishes."
+        )
 
         if self.input_dir is None and self.src_resolver is not None and self.input_dir:
             self.input_dir = self.src_resolver(self.input_dir)


### PR DESCRIPTION
## What does this PR do?

The progress bar updates when a worker finishes, not when a worker yields. If you don't know this and your workers take a long time to finish, it looks like it froze