### PR TITLE
Added call to setup function of serializer class to set data format

### DIFF
--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -37,9 +37,10 @@ class BaseItemLoader(ABC):
         self._config = config
         self._chunks = chunks
         self._serializers = serializers
+        self._data_format = self._config["data_format"]
 
         # setup the serializers on restart
-        for data_format in self._config["data_format"]:
+        for data_format in self._data_format:
             serializer = self._serializers[self._data_format_to_key(data_format)]
             serializer.setup(data_format)
 
@@ -125,10 +126,10 @@ class PyTreeLoader(BaseItemLoader):
 
     def deserialize(self, raw_item_data: bytes) -> "PyTree":
         """Deserialize the raw bytes into their python equivalent."""
-        idx = len(self._config["data_format"]) * 4
+        idx = len(self._data_format) * 4
         sizes = np.frombuffer(raw_item_data[:idx], np.uint32)
         data = []
-        for size, data_format in zip(sizes, self._config["data_format"]):
+        for size, data_format in zip(sizes, self._data_format):
             serializer = self._serializers[self._data_format_to_key(data_format)]
             data_bytes = raw_item_data[idx : idx + size]
             data.append(serializer.deserialize(data_bytes))

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -38,6 +38,7 @@ class BaseItemLoader(ABC):
         self._chunks = chunks
         self._serializers = serializers
         self._data_format = self._config["data_format"]
+        self._shift_idx = len(self._data_format) * 4
 
         # setup the serializers on restart
         for data_format in self._data_format:
@@ -126,7 +127,7 @@ class PyTreeLoader(BaseItemLoader):
 
     def deserialize(self, raw_item_data: bytes) -> "PyTree":
         """Deserialize the raw bytes into their python equivalent."""
-        idx = len(self._data_format) * 4
+        idx = self._shift_idx
         sizes = np.frombuffer(raw_item_data[:idx], np.uint32)
         data = []
         for size, data_format in zip(sizes, self._data_format):

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -126,6 +126,7 @@ class PyTreeLoader(BaseItemLoader):
         for size, data_format in zip(sizes, self._config["data_format"]):
             serializer = self._serializers[self._data_format_to_key(data_format)]
             data_bytes = raw_item_data[idx : idx + size]
+            serializer.setup(data_format)
             data.append(serializer.deserialize(data_bytes))
             idx += size
         return tree_unflatten(data, self._config["data_spec"])

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -131,7 +131,6 @@ class PyTreeLoader(BaseItemLoader):
         for size, data_format in zip(sizes, self._config["data_format"]):
             serializer = self._serializers[self._data_format_to_key(data_format)]
             data_bytes = raw_item_data[idx : idx + size]
-            serializer.setup(data_format)
             data.append(serializer.deserialize(data_bytes))
             idx += size
         return tree_unflatten(data, self._config["data_spec"])

--- a/tests/streaming/test_item_loader.py
+++ b/tests/streaming/test_item_loader.py
@@ -1,0 +1,12 @@
+from unittest.mock import MagicMock
+
+from litdata.streaming.item_loader import PyTreeLoader
+
+
+def test_serializer_setup():
+    config_mock = MagicMock()
+    config_mock.__getitem__.return_value = ["fake:12"]
+    serializer_mock = MagicMock()
+    item_loader = PyTreeLoader()
+    item_loader.setup(config_mock, [], {"fake": serializer_mock})
+    serializer_mock.setup._mock_mock_calls[0].args[0] == "fake:12"


### PR DESCRIPTION
<details>
  <summary><b>Fixed bug. No calls were made to the setup function of serializer class. Reading failed for serializers that required setup, for instance, serializers for no_header_numpy fails</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

We wrote a code that writes dataset with numpy arrays. Litdata StreamingDataset fails to read the data. It seems that numpy arrays were serialized as no_header_numpy that requires call to setup function to set data format in serializer class. However, that call is not anywhere in the current code. 

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
