### PR TITLE
Don't raise a runtimeError if the downloader doesn't exist.

### DIFF
--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -83,7 +83,7 @@ class ChunksConfig:
             return
 
         if self._downloader is None:
-            raise RuntimeError("The downloader should be defined.")
+            return
 
         self._downloader.download_chunk_from_index(chunk_index)
 
@@ -101,7 +101,9 @@ class ChunksConfig:
         with open(local_chunkpath, "rb") as f:
             data = f.read()
 
-        os.remove(local_chunkpath)
+        # delete the files only if they were downloaded
+        if self._downloader is not None:
+            os.remove(local_chunkpath)
 
         data = self._compressor.decompress(data)
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This PR resolves an issue where the config would raise a runtimeError if the downloader was missing, but the reality is you can have compressed files locally without the need of downloading them back. 

However, this happened because as the downloader wasn't defined, we deleted the compressed files. 

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
