### PR TITLE
Fix configuration of a custom serializers for one of the predefined types

### DIFF
--- a/src/litdata/streaming/serializers.py
+++ b/src/litdata/streaming/serializers.py
@@ -17,6 +17,7 @@ import pickle
 import tempfile
 from abc import ABC, abstractmethod
 from collections import OrderedDict
+from copy import deepcopy
 from typing import Any, Dict, Optional, Tuple, Union
 
 import numpy as np
@@ -394,9 +395,7 @@ _SERIALIZERS = OrderedDict(
 
 
 def _get_serializers(serializers: Optional[Dict[str, Serializer]]) -> Dict[str, Serializer]:
+    _serializers = deepcopy(_SERIALIZERS)
     if serializers:
-        serializers = OrderedDict(**serializers)
-        serializers.update(_SERIALIZERS)
-    else:
-        serializers = _SERIALIZERS
-    return serializers
+        _serializers.update(serializers)
+    return _serializers

--- a/src/litdata/streaming/serializers.py
+++ b/src/litdata/streaming/serializers.py
@@ -395,7 +395,13 @@ _SERIALIZERS = OrderedDict(
 
 
 def _get_serializers(serializers: Optional[Dict[str, Serializer]]) -> Dict[str, Serializer]:
-    _serializers = deepcopy(_SERIALIZERS)
-    if serializers:
-        _serializers.update(serializers)
-    return _serializers
+    if serializers is None:
+        serializers = {}
+    serializers = OrderedDict(serializers)
+
+    for key, value in _SERIALIZERS.items():
+        if key not in serializers:
+            serializers[key] = deepcopy(value)
+
+    return serializers
+

--- a/src/litdata/streaming/serializers.py
+++ b/src/litdata/streaming/serializers.py
@@ -404,4 +404,3 @@ def _get_serializers(serializers: Optional[Dict[str, Serializer]]) -> Dict[str, 
             serializers[key] = deepcopy(value)
 
     return serializers
-

--- a/tests/streaming/test_serializer.py
+++ b/tests/streaming/test_serializer.py
@@ -23,6 +23,7 @@ import torch
 from litdata.imports import RequirementCache
 from litdata.streaming.serializers import (
     _AV_AVAILABLE,
+    _get_serializers,
     _NUMPY_DTYPES_MAPPING,
     _SERIALIZERS,
     _TORCH_DTYPES_MAPPING,
@@ -233,3 +234,13 @@ def test_wav_deserialization(tmpdir):
     assert vframes.shape == torch.Size([301, 512, 512, 3])
     assert aframes.shape == torch.Size([1, 0])
     assert info == {"video_fps": 25.0}
+
+
+def test_get_serializers():
+    class CustomSerializer(NoHeaderTensorSerializer):
+        pass
+
+    serializers = _get_serializers({"no_header_tensor": CustomSerializer(), "custom": CustomSerializer()})
+
+    assert isinstance(serializers["no_header_tensor"], CustomSerializer)
+    assert isinstance(serializers["custom"], CustomSerializer)

--- a/tests/streaming/test_serializer.py
+++ b/tests/streaming/test_serializer.py
@@ -23,7 +23,6 @@ import torch
 from litdata.imports import RequirementCache
 from litdata.streaming.serializers import (
     _AV_AVAILABLE,
-    _get_serializers,
     _NUMPY_DTYPES_MAPPING,
     _SERIALIZERS,
     _TORCH_DTYPES_MAPPING,
@@ -37,6 +36,7 @@ from litdata.streaming.serializers import (
     PILSerializer,
     TensorSerializer,
     VideoSerializer,
+    _get_serializers,
 )
 
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This is only a suggestion. When experimenting with litdata I tried to fix the `no_header_tensor` serializer issue by replacing it with a custom subclass. I noticed that my custom subclass was not applied and tracked it down to the modified bit.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
