### PR TITLE
Fix infinite sleep when loading local compressed dataset.

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,3 +7,4 @@ pytest-random-order ==1.1.1
 pandas
 lightning
 lightning-cloud == 0.5.68 # Must be pinned to ensure compatibility
+zstd

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -35,8 +35,6 @@ if _TORCH_GREATER_EQUAL_2_1_0:
 logger = Logger(__name__)
 
 
-_END_TOKEN = "END"  # noqa: S105
-
 # Note: The timeout here should not be too short. We need to prevent the caller from aggressively
 # querying the queue and consuming too many CPU cycles.
 _DEFAULT_TIMEOUT = 0.1

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -12,12 +12,11 @@
 # limitations under the License.
 
 import contextlib
-import multiprocessing
 import os
 import warnings
 from logging import Logger
-from queue import Empty
-from threading import Thread
+from queue import Empty, Queue
+from threading import Event, Thread
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from litdata.constants import _TORCH_GREATER_EQUAL_2_1_0
@@ -65,8 +64,9 @@ class PrepareChunksThread(Thread):
         self._chunks_index_to_be_deleted: List[int] = []
         self._max_cache_size = max_cache_size
         self._parent_cache_dir = os.path.dirname(self._config._cache_dir)
-        self._to_download_queue: multiprocessing.Queue = multiprocessing.Queue()
-        self._to_delete_queue: multiprocessing.Queue = multiprocessing.Queue()
+        self._to_download_queue: Queue = Queue()
+        self._to_delete_queue: Queue = Queue()
+        self._stop_event = Event()
 
         # Check whether a dataset slice fits on the node
         num_bytes_per_nodes = self._config.num_bytes // self._distributed_env.num_nodes
@@ -90,7 +90,8 @@ class PrepareChunksThread(Thread):
 
     def stop(self) -> None:
         """Receive the list of the chunk indices to download for the current epoch."""
-        self._to_download_queue.put(_END_TOKEN)
+        # self._to_download_queue.put(_END_TOKEN)
+        self._stop_event.set()
 
     def _maybe_delete_chunks(self) -> None:
         reached_pre_download = self._pre_download_counter == self._max_pre_download
@@ -124,12 +125,11 @@ class PrepareChunksThread(Thread):
 
     def run(self) -> None:
         while True:
+            if self._stop_event.is_set():
+                self._has_exited = True
+                return
             if self._pre_download_counter < self._max_pre_download:
                 chunk_index = _get_from_queue(self._to_download_queue)
-                if chunk_index == _END_TOKEN:
-                    self._has_exited = True
-                    return
-
                 if chunk_index is not None:
                     self._config.download_chunk_from_index(chunk_index)
 
@@ -295,6 +295,11 @@ class BinaryReader:
         state["_prepare_thread"] = None
         return state
 
+    def __del__(self) -> None:
+        if self._prepare_thread and not self._prepare_thread._has_exited:
+            self._prepare_thread.stop()
+            self._prepare_thread = None
+
 
 def _get_folder_size(path: str) -> int:
     """Collect the size of each files within a folder.
@@ -310,7 +315,7 @@ def _get_folder_size(path: str) -> int:
     return size
 
 
-def _get_from_queue(queue: multiprocessing.Queue, timeout: float = _DEFAULT_TIMEOUT) -> Optional[Any]:
+def _get_from_queue(queue: Queue, timeout: float = _DEFAULT_TIMEOUT) -> Optional[Any]:
     try:
         return queue.get(timeout=timeout)
     except Empty:

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -255,7 +255,11 @@ class BinaryReader:
 
         # We need to request deletion after the latest element has been loaded.
         # Otherwise, this could trigger segmentation fault error depending on the item loader used.
-        if self._config and self._config._remote_dir and index.chunk_index != self._last_chunk_index:
+        if (
+            self._config
+            and (self._config._remote_dir or self._config._compressor)
+            and index.chunk_index != self._last_chunk_index
+        ):
             assert self._prepare_thread
             assert self._last_chunk_index is not None
 

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -20,10 +20,10 @@ from unittest import mock
 import numpy as np
 import pytest
 import torch
+from litdata.constants import _ZSTD_AVAILABLE
 from litdata.processing import functions
 from litdata.streaming import Cache
 from litdata.streaming import dataset as dataset_module
-from litdata.constants import _ZSTD_AVAILABLE
 from litdata.streaming.dataloader import StreamingDataLoader
 from litdata.streaming.dataset import (
     _INDEX_FILENAME,

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -306,7 +306,7 @@ def test_streaming_dataset_distributed_full_shuffle_even(drop_last, tmpdir, comp
         pytest.param("zstd", marks=pytest.mark.skipif(condition=not _ZSTD_AVAILABLE, reason="Requires: ['zstd']")),
     ],
 )
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(60)
 def test_streaming_dataset_distributed_full_shuffle_even_multi_nodes(drop_last, tmpdir, compression):
     seed_everything(42)
 

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -23,6 +23,7 @@ import torch
 from litdata.processing import functions
 from litdata.streaming import Cache
 from litdata.streaming import dataset as dataset_module
+from litdata.constants import _ZSTD_AVAILABLE
 from litdata.streaming.dataloader import StreamingDataLoader
 from litdata.streaming.dataset import (
     _INDEX_FILENAME,
@@ -46,7 +47,15 @@ def seed_everything(random_seed):
     torch.manual_seed(random_seed)
 
 
-def test_streaming_dataset(tmpdir, monkeypatch):
+@pytest.mark.parametrize(
+    "compression",
+    [
+        pytest.param(None),
+        pytest.param("zstd", marks=pytest.mark.skipif(condition=not _ZSTD_AVAILABLE, reason="Requires: ['zstd']")),
+    ],
+)
+@pytest.mark.timeout(15)
+def test_streaming_dataset(tmpdir, monkeypatch, compression):
     seed_everything(42)
 
     dataset = StreamingDataset(input_dir=str(tmpdir))
@@ -56,22 +65,27 @@ def test_streaming_dataset(tmpdir, monkeypatch):
     with pytest.raises(ValueError, match="The provided dataset"):
         _ = dataset[0]
 
-    cache = Cache(str(tmpdir), chunk_size=10)
-    for i in range(12):
+    cache = Cache(str(tmpdir), chunk_size=10, compression=compression)
+    for i in range(60):
         cache[i] = i
     cache.done()
     cache.merge()
 
     dataset = StreamingDataset(input_dir=str(tmpdir))
 
-    assert len(dataset) == 12
+    assert len(dataset) == 60
+    for i in range(60):
+        assert dataset[i] == i
+
     dataset_iter = iter(dataset)
-    assert len(dataset_iter) == 12
+    assert len(dataset_iter) == 60
+    for i in range(60):
+        assert next(dataset_iter) == i
 
     dataloader = DataLoader(dataset, num_workers=2, batch_size=1)
-    assert len(dataloader) == 12
+    assert len(dataloader) == 60
     dataloader = DataLoader(dataset, num_workers=2, batch_size=2)
-    assert len(dataloader) == 6
+    assert len(dataloader) == 30
 
 
 def test_should_replace_path():
@@ -85,10 +99,18 @@ def test_should_replace_path():
 
 
 @pytest.mark.parametrize("drop_last", [False, True])
-def test_streaming_dataset_distributed_no_shuffle(drop_last, tmpdir):
+@pytest.mark.parametrize(
+    "compression",
+    [
+        pytest.param(None),
+        pytest.param("zstd", marks=pytest.mark.skipif(condition=not _ZSTD_AVAILABLE, reason="Requires: ['zstd']")),
+    ],
+)
+@pytest.mark.timeout(30)
+def test_streaming_dataset_distributed_no_shuffle(drop_last, tmpdir, compression):
     seed_everything(42)
 
-    cache = Cache(str(tmpdir), chunk_size=10)
+    cache = Cache(str(tmpdir), chunk_size=10, compression=compression)
     for i in range(101):
         cache[i] = i
 

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -203,10 +203,18 @@ def test_streaming_dataset_distributed_no_shuffle(drop_last, tmpdir, compression
 
 
 @pytest.mark.parametrize("drop_last", [False, True])
-def test_streaming_dataset_distributed_full_shuffle_odd(drop_last, tmpdir):
+@pytest.mark.parametrize(
+    "compression",
+    [
+        pytest.param(None),
+        pytest.param("zstd", marks=pytest.mark.skipif(condition=not _ZSTD_AVAILABLE, reason="Requires: ['zstd']")),
+    ],
+)
+@pytest.mark.timeout(30)
+def test_streaming_dataset_distributed_full_shuffle_odd(drop_last, tmpdir, compression):
     seed_everything(42)
 
-    cache = Cache(input_dir=str(tmpdir), chunk_size=10)
+    cache = Cache(input_dir=str(tmpdir), chunk_size=10, compression=compression)
     for i in range(1097):
         cache[i] = i
 
@@ -243,10 +251,18 @@ def test_streaming_dataset_distributed_full_shuffle_odd(drop_last, tmpdir):
 
 
 @pytest.mark.parametrize("drop_last", [False, True])
-def test_streaming_dataset_distributed_full_shuffle_even(drop_last, tmpdir):
+@pytest.mark.parametrize(
+    "compression",
+    [
+        pytest.param(None),
+        pytest.param("zstd", marks=pytest.mark.skipif(condition=not _ZSTD_AVAILABLE, reason="Requires: ['zstd']")),
+    ],
+)
+@pytest.mark.timeout(30)
+def test_streaming_dataset_distributed_full_shuffle_even(drop_last, tmpdir, compression):
     seed_everything(42)
 
-    cache = Cache(str(tmpdir), chunk_size=10)
+    cache = Cache(str(tmpdir), chunk_size=10, compression=compression)
     for i in range(1222):
         cache[i] = i
 
@@ -283,10 +299,18 @@ def test_streaming_dataset_distributed_full_shuffle_even(drop_last, tmpdir):
 
 
 @pytest.mark.parametrize("drop_last", [False, True])
-def test_streaming_dataset_distributed_full_shuffle_even_multi_nodes(drop_last, tmpdir):
+@pytest.mark.parametrize(
+    "compression",
+    [
+        pytest.param(None),
+        pytest.param("zstd", marks=pytest.mark.skipif(condition=not _ZSTD_AVAILABLE, reason="Requires: ['zstd']")),
+    ],
+)
+@pytest.mark.timeout(30)
+def test_streaming_dataset_distributed_full_shuffle_even_multi_nodes(drop_last, tmpdir, compression):
     seed_everything(42)
 
-    cache = Cache(str(tmpdir), chunk_size=10)
+    cache = Cache(str(tmpdir), chunk_size=10, compression=compression)
     for i in range(1222):
         cache[i] = i
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

When use the StreamingDataset when zstd-compressed dataset which stored in local dir, the StreamingDataset will sleep forever after reading several samples.
This bug is caused by unsent delete request to the `PrepareChunksThread`.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
