### PR TITLE
Fix empty tensor deserialization

### DIFF
--- a/src/litdata/streaming/serializers.py
+++ b/src/litdata/streaming/serializers.py
@@ -184,7 +184,13 @@ class TensorSerializer(Serializer):
         shape = []
         for shape_idx in range(shape_size):
             shape.append(np.frombuffer(data[8 + 4 * shape_idx : 8 + 4 * (shape_idx + 1)], np.uint32).item())
-        tensor = torch.frombuffer(data[8 + 4 * (shape_idx + 1) : len(data)], dtype=dtype)
+        idx_start = 8 + 4 * (shape_idx + 1)
+        idx_end = len(data)
+        if idx_end > idx_start:
+            tensor = torch.frombuffer(data[idx_start : idx_end], dtype=dtype)
+        else:
+            assert idx_start == idx_end, "The starting index should never be greater than end ending index."
+            tensor = torch.empty(shape, dtype=dtype)
         shape = torch.Size(shape)
         if tensor.shape == shape:
             return tensor
@@ -211,7 +217,11 @@ class NoHeaderTensorSerializer(Serializer):
 
     def deserialize(self, data: bytes) -> torch.Tensor:
         assert self._dtype
-        return torch.frombuffer(data, dtype=self._dtype)
+        if len(data) > 0:
+            tensor = torch.frombuffer(data, dtype=self._dtype)
+        else:
+            tensor = torch.empty((0,), dtype=self._dtype)
+        return tensor
 
     def can_serialize(self, item: torch.Tensor) -> bool:
         return isinstance(item, torch.Tensor) and type(item) == torch.Tensor and len(item.shape) == 1

--- a/src/litdata/streaming/serializers.py
+++ b/src/litdata/streaming/serializers.py
@@ -187,7 +187,7 @@ class TensorSerializer(Serializer):
         idx_start = 8 + 4 * (shape_idx + 1)
         idx_end = len(data)
         if idx_end > idx_start:
-            tensor = torch.frombuffer(data[idx_start : idx_end], dtype=dtype)
+            tensor = torch.frombuffer(data[idx_start:idx_end], dtype=dtype)
         else:
             assert idx_start == idx_end, "The starting index should never be greater than end ending index."
             tensor = torch.empty(shape, dtype=dtype)

--- a/tests/streaming/test_serializer.py
+++ b/tests/streaming/test_serializer.py
@@ -244,3 +244,31 @@ def test_get_serializers():
 
     assert isinstance(serializers["no_header_tensor"], CustomSerializer)
     assert isinstance(serializers["custom"], CustomSerializer)
+
+
+def test_deserialize_empty_tensor():
+    serializer = TensorSerializer()
+    t = torch.ones((0, 3)).int()
+    data, name = serializer.serialize(t)
+    new_t = serializer.deserialize(data)
+    assert torch.equal(t, new_t)
+
+    t = torch.ones((0, 3)).float()
+    data, name = serializer.serialize(t)
+    new_t = serializer.deserialize(data)
+    assert torch.equal(t, new_t)
+
+
+def test_deserialize_empty_no_header_tensor():
+    serializer = NoHeaderTensorSerializer()
+    t = torch.ones((0, )).int()
+    data, name = serializer.serialize(t)
+    serializer.setup(name)
+    new_t = serializer.deserialize(data)
+    assert torch.equal(t, new_t)
+
+    t = torch.ones((0, )).float()
+    data, name = serializer.serialize(t)
+    serializer.setup(name)
+    new_t = serializer.deserialize(data)
+    assert torch.equal(t, new_t)

--- a/tests/streaming/test_serializer.py
+++ b/tests/streaming/test_serializer.py
@@ -261,13 +261,13 @@ def test_deserialize_empty_tensor():
 
 def test_deserialize_empty_no_header_tensor():
     serializer = NoHeaderTensorSerializer()
-    t = torch.ones((0, )).int()
+    t = torch.ones((0,)).int()
     data, name = serializer.serialize(t)
     serializer.setup(name)
     new_t = serializer.deserialize(data)
     assert torch.equal(t, new_t)
 
-    t = torch.ones((0, )).float()
+    t = torch.ones((0,)).float()
     data, name = serializer.serialize(t)
     serializer.setup(name)
     new_t = serializer.deserialize(data)


### PR DESCRIPTION
## What does this PR do?

When trying to deserialize tensors that were empty in the first place, the torch.frombuffer` method would fail due to an empty buffer. This PR fixes the issue by simply checking the buffer length and if the latter is 0, initializing a fresh tensor with no data but the correct shape and dtype.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
