### PR TITLE
Fix: error while splitting dataset with `splits=[0.1, 0.2, 0.7]` and support split of 0.0

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -18,14 +18,14 @@ jobs:
       actions-ref: main
 
   check-schema:
-    uses: Lightning-AI/utilities/.github/workflows/check-schema.yml@v0.11.2
+    uses: Lightning-AI/utilities/.github/workflows/check-schema.yml@v0.11.3.post0
     with:
       azure-dir: ""
 
   check-package:
-    uses: Lightning-AI/utilities/.github/workflows/check-package.yml@v0.11.2
+    uses: Lightning-AI/utilities/.github/workflows/check-package.yml@v0.11.3.post0
     with:
-      actions-ref: v0.11.2
+      actions-ref: v0.11.3.post0
       import-name: "litdata"
       artifact-name: dist-packages-${{ github.sha }}
       testing-matrix: |
@@ -35,6 +35,6 @@ jobs:
         }
 
   check-docs:
-    uses: Lightning-AI/utilities/.github/workflows/check-docs.yml@v0.11.2
+    uses: Lightning-AI/utilities/.github/workflows/check-docs.yml@v0.11.3.post0
     with:
       requirements-file: "requirements/docs.txt"

--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -71,7 +71,7 @@ class ChunksConfig:
         assert self._chunks is not None
         self._item_loader.setup(self._config, self._chunks, serializers, region_of_interest)
         self._intervals = self._item_loader.generate_intervals()
-        self._length = self._intervals[-1][-1]
+        self._length = self._intervals[-1][-1] if len(self._intervals) > 0 else 0
         self._downloader = None
 
         if remote_dir:

--- a/src/litdata/utilities/train_test_split.py
+++ b/src/litdata/utilities/train_test_split.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from copy import deepcopy
 from typing import Any, Dict, List
@@ -36,8 +37,11 @@ def train_test_split(
     if any(not isinstance(split, float) for split in splits):
         raise ValueError("Each split should be a float.")
 
-    if not all(0 < _f <= 1 for _f in splits):
+    if not all(0 <= _f <= 1 for _f in splits):
         raise ValueError("Each Split should be a float with each value in [0,1].")
+
+    if any(split == 0 for split in splits):
+        logging.warning("Warning: some splits are 0, this will lead to empty datasets")
 
     if sum(splits) > 1:
         raise ValueError("Splits' sum must be less than 1.")

--- a/tests/utilities/test_train_test_split.py
+++ b/tests/utilities/test_train_test_split.py
@@ -2,7 +2,7 @@ import pytest
 from litdata import train_test_split
 from litdata.constants import _ZSTD_AVAILABLE
 from litdata.streaming.cache import Cache
-from litdata.streaming.dataset import StreamingDataset
+from litdata import StreamingDataset
 
 
 @pytest.mark.parametrize(
@@ -49,3 +49,26 @@ def test_split_a_subsampled_dataset(tmpdir, compression):
     split_datasets = train_test_split(_sub_sampled_streaming_dataset, _split_fraction)
 
     assert all(len(split_datasets[i]) == int(300 * split) for i, split in enumerate(_split_fraction))
+
+    # ------------- splits with 0 fraction of samples -------------
+
+    _split_fraction = [0.0, 0.0, 1.0]
+
+    split_datasets = train_test_split(
+        _sub_sampled_streaming_dataset, _split_fraction)
+
+    assert all(len(split_datasets[i]) == int(300 * split) for i, split in enumerate(_split_fraction))
+
+    # ------------- test if some splits get 0 samples -------------
+
+    _sub_sampled_streaming_dataset = StreamingDataset(
+        input_dir=str(tmpdir), subsample=0.05)
+
+    assert len(_sub_sampled_streaming_dataset) == 50  # 1000 * 0.05
+
+    _split_fraction = [0.01, 0.01, 0.98]
+
+    split_datasets = train_test_split(
+        _sub_sampled_streaming_dataset, _split_fraction)
+
+    assert all(len(split_datasets[i]) == int(50 * split) for i, split in enumerate(_split_fraction))

--- a/tests/utilities/test_train_test_split.py
+++ b/tests/utilities/test_train_test_split.py
@@ -1,8 +1,7 @@
 import pytest
-from litdata import train_test_split
+from litdata import StreamingDataset, train_test_split
 from litdata.constants import _ZSTD_AVAILABLE
 from litdata.streaming.cache import Cache
-from litdata import StreamingDataset
 
 
 @pytest.mark.parametrize(
@@ -54,21 +53,18 @@ def test_split_a_subsampled_dataset(tmpdir, compression):
 
     _split_fraction = [0.0, 0.0, 1.0]
 
-    split_datasets = train_test_split(
-        _sub_sampled_streaming_dataset, _split_fraction)
+    split_datasets = train_test_split(_sub_sampled_streaming_dataset, _split_fraction)
 
     assert all(len(split_datasets[i]) == int(300 * split) for i, split in enumerate(_split_fraction))
 
     # ------------- test if some splits get 0 samples -------------
 
-    _sub_sampled_streaming_dataset = StreamingDataset(
-        input_dir=str(tmpdir), subsample=0.05)
+    _sub_sampled_streaming_dataset = StreamingDataset(input_dir=str(tmpdir), subsample=0.05)
 
     assert len(_sub_sampled_streaming_dataset) == 50  # 1000 * 0.05
 
     _split_fraction = [0.01, 0.01, 0.98]
 
-    split_datasets = train_test_split(
-        _sub_sampled_streaming_dataset, _split_fraction)
+    split_datasets = train_test_split(_sub_sampled_streaming_dataset, _split_fraction)
 
     assert all(len(split_datasets[i]) == int(50 * split) for i, split in enumerate(_split_fraction))


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Under active development. 🚧

Fixes #182 & Fixes #186 

Fixes error while splitting dataset with `splits=[0.1, 0.2, 0.7]` and other small fixes.
Feature: Adds support for split of 0.0

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
