### PR TITLE
Fix: Resolve the default weights of the combined dataset

### DIFF
--- a/src/litdata/streaming/combined.py
+++ b/src/litdata/streaming/combined.py
@@ -59,8 +59,6 @@ class CombinedStreamingDataset(IterableDataset):
         self._weights = weights
         self._iterate_over_all = iterate_over_all
 
-        num_datasets = len(datasets)
-
         if iterate_over_all and weights:
             raise ValueError(
                 "When `iterate_over_all` is set to True, the weights argument shouldn't be provided.",
@@ -70,10 +68,14 @@ class CombinedStreamingDataset(IterableDataset):
         self._iterate_over_all = iterate_over_all
 
         if weights is None:
-            # Inversely weighted based on length
-            self._weights = [1 / float(num_datasets)] * num_datasets
+            # Weighted based on the dataset length
+            dataset_lens = [len(d) for d in datasets]
+            total_len = sum(dataset_lens)
+            assert total_len > 0
+            self._weights = [len / total_len for len in dataset_lens]
         else:
-            self._weights = [w / sum(weights) for w in weights]
+            weights_sum = sum(weights)
+            self._weights = [w / weights_sum for w in weights]
 
         self._iterator: Optional[_CombinedDatasetIterator] = None
         self._use_streaming_dataloader = False

--- a/tests/streaming/test_combined.py
+++ b/tests/streaming/test_combined.py
@@ -57,6 +57,9 @@ class Range:
     def __iter__(self):
         yield from self.values
 
+    def __len__(self):
+        return len(self.values)
+
 
 def test_combined_dataset_iterate_over_all_4_datasets():
     dataset = TestCombinedStreamingDataset(
@@ -82,6 +85,8 @@ def test_combined_dataset_num_samples_yield_iterate_over_all():
 def test_drop_last_and_shuffle():
     dataset_mock_1 = MagicMock()
     dataset_mock_2 = MagicMock()
+    dataset_mock_1.__len__.return_value = 1
+    dataset_mock_2.__len__.return_value = 1
 
     dataset = TestCombinedStreamingDataset([dataset_mock_1, dataset_mock_2], 42, iterate_over_all=True)
     StreamingDataLoader(dataset, shuffle=True, drop_last=True)
@@ -193,7 +198,7 @@ def test_combined_dataset_state_dict():
         ([2, 0.5], [0.8, 0.2]),
         ([1, 1, 1], [1 / 3, 1 / 3, 1 / 3]),
         ([0.3, 0, 0], [1.0, 0, 0]),
-        (None, [0.5, 0.5]),
+        (None, [1 / 3, 2 / 3]),
     ],
 )
 def test_combined_dataset_normalizes_weights(weights, expected):


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This PR rectifies the default weights of the CombinedStreamingDataset, so all samples have the same likelihood to be sampled.

Fixes #185

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
