### PR TITLE
Fix:  dataloader state dict indexerror

### DIFF
--- a/src/litdata/streaming/dataloader.py
+++ b/src/litdata/streaming/dataloader.py
@@ -485,9 +485,7 @@ class StreamingDataLoaderCollateFn:
             batch = self.collate_fn([item[__SAMPLES_KEY__] for item in items])
             return {
                 __SAMPLES_KEY__: batch,
-                __NUM_SAMPLES_YIELDED_KEY__: [
-                    torch.cumsum([torch.tensor(item[__NUM_SAMPLES_YIELDED_KEY__]) for item in items][-1], dim=0)
-                ],
+                __NUM_SAMPLES_YIELDED_KEY__: list(torch.tensor(items[-1][__NUM_SAMPLES_YIELDED_KEY__]).reshape(-1, 1)),
             }
 
         return self.collate_fn(items)

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -148,6 +148,7 @@ def test_custom_collate():
     assert next(dataloader_iter) == "received"
     assert dataloader._num_samples_yielded_combined[0] == [dataset._datasets[0].counter, dataset._datasets[1].counter]
 
+
 def test_custom_collate_multiworker():
     dataset = TestCombinedStreamingDataset(
         [TestStatefulDatasetDict(10, 1), TestStatefulDatasetDict(10, -1)],


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This fixes the issue reported in #196. 

Note: I had to change part of another unittest in this fix. I think the existing test was written expecting `_num_samples_yielded_combined` to be the combined total # of samples yielded by the `CombinedStreamingDataset`.

However, I believe the `StreamingDataLoader._num_samples_yielded_combined` field is a dictionary which maps the worker_id to a list containing the number of samples yielded from each dataset within a `CombinedStreamingDataset`. 

Is my understanding of "combined" in `_num_samples_yielded_combined` correct?