### PR TITLE
Enable compatibility with Numpy 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ lint.extend-select = [
     "SIM",  # see: https://pypi.org/project/flake8-simplify
     "RET",  # see: https://pypi.org/project/flake8-return
     "PT",  # see: https://pypi.org/project/flake8-pytest-style
+    "NPY201",  # see: https://docs.astral.sh/ruff/rules/numpy2-deprecation
     "RUF100" # yesqa
 ]
 lint.ignore = [

--- a/src/litdata/constants.py
+++ b/src/litdata/constants.py
@@ -59,7 +59,28 @@ _TORCH_DTYPES_MAPPING = {
     19: torch.bool,
 }
 
-_NUMPY_SCTYPES = [v for values in np.core.sctypes.values() for v in values]  # All NumPy scalar types
+_NUMPY_SCTYPES = [  # All NumPy scalar types from np.core.sctypes.values()
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.float16,
+    np.float32,
+    np.float64,
+    np.longdouble,
+    np.complex64,
+    np.complex128,
+    np.clongdouble,
+    bool,
+    object,
+    bytes,
+    str,
+    np.void,
+]
 _NUMPY_DTYPES_MAPPING = {i: np.dtype(v) for i, v in enumerate(_NUMPY_SCTYPES)}
 
 _TIME_FORMAT = "%Y-%m-%d_%H-%M-%S.%fZ"

--- a/src/litdata/constants.py
+++ b/src/litdata/constants.py
@@ -59,7 +59,7 @@ _TORCH_DTYPES_MAPPING = {
     19: torch.bool,
 }
 
-_NUMPY_SCTYPES = [v for values in np.sctypes.values() for v in values]
+_NUMPY_SCTYPES = [v for values in np.core.sctypes.values() for v in values]  # All NumPy scalar types
 _NUMPY_DTYPES_MAPPING = {i: np.dtype(v) for i, v in enumerate(_NUMPY_SCTYPES)}
 
 _TIME_FORMAT = "%Y-%m-%d_%H-%M-%S.%fZ"


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/.github/CONTRIBUTING.md), Pull Request section? Broken link...
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Make litdata work with NumPy 2.0 by changing `np.sctypes.values()` to a list of dtypes obtained from `np.core.sctypes.values()`. Also added [NPY201](https://docs.astral.sh/ruff/rules/numpy2-deprecation) ruff lint rule and remove upper `numpy<2.0` pin in requirements.txt.

Fixes #175.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
