### PR TITLE
Fix typo in resolver.py

### DIFF
--- a/src/litdata/streaming/resolver.py
+++ b/src/litdata/streaming/resolver.py
@@ -218,7 +218,7 @@ def _assert_dir_is_empty(output_dir: Dir, append: bool = False, overwrite: bool 
     obj = parse.urlparse(output_dir.url)
 
     if obj.scheme != "s3":
-        raise ValueError(f"The provided folder should start with s3://. Found {output_dir.path}.")
+        raise ValueError(f"The provided folder should start with s3://. Found {output_dir.url}.")
 
     s3 = boto3.client("s3")
 
@@ -283,7 +283,7 @@ def _assert_dir_has_index_file(
     obj = parse.urlparse(output_dir.url)
 
     if obj.scheme != "s3":
-        raise ValueError(f"The provided folder should start with s3://. Found {output_dir.path}.")
+        raise ValueError(f"The provided folder should start with s3://. Found {output_dir.url}.")
 
     s3 = boto3.client("s3")
 


### PR DESCRIPTION
Error message refers to output_dir.path instead of output_dir.url

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
