### PR TITLE
Fix duplicated workflows on PR

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -2,9 +2,11 @@ name: CI testing
 
 # see: https://help.github.com/en/actions/reference/events-that-trigger-workflows
 on: # Trigger the workflow on push or pull request, but only for the main branch
-  push: {}
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, reopened, ready_for_review, synchronize]
 
 defaults:
   run:


### PR DESCRIPTION
It's confusing me in #237 that workflows run duplicated. You don't know which one is from the current branch or from main. I think this was misconfigured. 