### PR TITLE
Always send the rank when broadcasting

### DIFF
--- a/src/litdata/processing/data_processor.py
+++ b/src/litdata/processing/data_processor.py
@@ -934,7 +934,7 @@ class DataProcessor:
             raise ValueError("Either the reader or the weights needs to be defined.")
 
         # Ensure the input dir is the same across all nodes
-        self.input_dir = broadcast_object("input_dir", self.input_dir)
+        self.input_dir = broadcast_object("input_dir", self.input_dir, rank=_get_node_rank())
 
         if self.output_dir:
             # Ensure the output dir is the same across all nodes

--- a/src/litdata/processing/data_processor.py
+++ b/src/litdata/processing/data_processor.py
@@ -938,7 +938,10 @@ class DataProcessor:
 
         if self.output_dir:
             # Ensure the output dir is the same across all nodes
-            self.output_dir = broadcast_object("output_dir", self.output_dir, rank=_get_node_rank())
+            print(f"Sending request for output_dir, {self.output_dir=}, rank=", _get_node_rank())
+            result = broadcast_object("output_dir", self.output_dir, rank=_get_node_rank())
+            print(f"Broadcast result was", result, "rank=", _get_node_rank())
+            self.output_dir = result
             print(f"Storing the files under {self.output_dir.path if self.output_dir.path else self.output_dir.url}")
 
         self.random_seed = random_seed

--- a/src/litdata/processing/data_processor.py
+++ b/src/litdata/processing/data_processor.py
@@ -938,10 +938,7 @@ class DataProcessor:
 
         if self.output_dir:
             # Ensure the output dir is the same across all nodes
-            print(f"Sending request for output_dir, {self.output_dir=}, rank=", _get_node_rank())
-            result = broadcast_object("output_dir", self.output_dir, rank=_get_node_rank())
-            print(f"Broadcast result was", result, "rank=", _get_node_rank())
-            self.output_dir = result
+            self.output_dir = broadcast_object("output_dir", self.output_dir, rank=_get_node_rank())
             print(f"Storing the files under {self.output_dir.path if self.output_dir.path else self.output_dir.url}")
 
         self.random_seed = random_seed

--- a/src/litdata/utilities/broadcast.py
+++ b/src/litdata/utilities/broadcast.py
@@ -123,11 +123,8 @@ class _ImmutableDistributedMap:
 
         self.private_client: _HTTPClient = _HTTPClient(lightning_app_state_url, auth_token=token, use_retry=False)
 
-    def set_and_get(self, key: str, value: Any, rank: Optional[int] = None) -> Any:
-        payload = {"key": key, "value": pickle.dumps(value, 0).decode()}
-
-        if rank is not None:
-            payload["rank"] = str(rank)
+    def set_and_get(self, key: str, value: Any, rank: int) -> Any:
+        payload = {"key": key, "value": pickle.dumps(value, 0).decode(), "rank": str(rank)}
 
         # Try the public address first
         try:
@@ -145,7 +142,7 @@ class _ImmutableDistributedMap:
         return pickle.loads(bytes(value, "utf-8"))  # noqa: S301
 
 
-def broadcast_object(key: str, obj: Any, rank: Optional[int] = None) -> Any:
+def broadcast_object(key: str, obj: Any, rank: int) -> Any:
     """This function enables to broadcast object across machines."""
     if os.getenv("LIGHTNING_APP_EXTERNAL_URL") is not None:
         value = None

--- a/tests/utilities/test_broadcast.py
+++ b/tests/utilities/test_broadcast.py
@@ -20,7 +20,7 @@ def test_broadcast(monkeypatch):
     resp.json = fn
     session.post.return_value = resp
     monkeypatch.setattr(requests, "Session", mock.MagicMock(return_value=session))
-    assert broadcast_object("key", "value") == "value"
+    assert broadcast_object("key", "value", rank=0) == "value"
 
 
 @mock.patch.dict(


### PR DESCRIPTION
Given the current implementation of `broadcast_object()`, it doesn't really make sense to send None as the rank. If all ranks send `rank=None` then the backend logic can't work. This PR makes the rank argument required. 
