### PR TITLE
Bad overriding of thread._delete

### DIFF
--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -84,7 +84,7 @@ class PrepareChunksThread(Thread):
         for chunk_index in chunk_indexes:
             self._to_delete_queue.put(chunk_index)
 
-    def _delete(self, chunk_index: int) -> None:
+    def _apply_delete(self, chunk_index: int) -> None:
         """Inform the item loader of the chunk to delete."""
         if self._config.can_delete(chunk_index):
             chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
@@ -118,7 +118,7 @@ class PrepareChunksThread(Thread):
         # Get the current cache size and decide whether we need to start cleanup. Otherwise, keep track of it
         while self._max_cache_size and self._chunks_index_to_be_deleted and self._can_delete_chunk():
             # Delete the oldest chunk
-            self._delete(self._chunks_index_to_be_deleted.pop(0))
+            self._apply_delete(self._chunks_index_to_be_deleted.pop(0))
 
         return
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This PR fixes an issue where the `PrepareChunksThread` would override the `_delete` method if the base class leading to un-cleaned threads and failures on deletion due to the missing argument.

Fixes #273

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
