### PR TITLE
Add support for passing the start_method to optimize

### DIFF
--- a/src/litdata/processing/data_processor.py
+++ b/src/litdata/processing/data_processor.py
@@ -913,7 +913,7 @@ class DataProcessor:
         msg = f"Setting multiprocessing start_method to {start_method}. "
         if in_notebook() == "fork":
             msg += "Tip: Libraries relying on lock can hang with `fork`. To use `spawn` in notebooks, "
-            msg += "move the code to files and import it within the notebook."
+            msg += "move your code to files and import it within the notebook."
 
         print(msg)
 

--- a/src/litdata/processing/data_processor.py
+++ b/src/litdata/processing/data_processor.py
@@ -18,6 +18,7 @@ import os
 import random
 import shutil
 import signal
+import sys
 import tempfile
 import traceback
 from abc import abstractmethod
@@ -878,6 +879,7 @@ class DataProcessor:
         reader: Optional[BaseReader] = None,
         state_dict: Optional[Dict[int, int]] = None,
         use_checkpoint: bool = False,
+        start_method: Optional[str] = None,
     ):
         """The `DatasetOptimiser` provides an efficient way to process data across multiple machine into chunks to make
         training faster.
@@ -899,11 +901,23 @@ class DataProcessor:
             state_dict: The writer state dict. This is used to decide how to append data to an existing dataset.
             use_checkpoint: Whether to create checkpoints while processing the data, which can be used to resume the
                 processing from the last checkpoint if the process is interrupted. (`Default: False`)
+            start_method: The start method used by python multiprocessing package. Default to spawn unless running
+                inside an interactive shell like Ipython.
 
         """
         import multiprocessing as mp
 
-        mp.set_start_method("spawn", force=True)
+        # spawn doesn't work in IPython
+        start_method = start_method or ("fork" if in_notebook() else "spawn")
+
+        msg = f"Setting multiprocessing start_method to {start_method}. "
+        if in_notebook() == "fork":
+            msg += "Tip: Libraries relying on lock can hang with `fork`. To use `spawn` in notebooks, "
+            msg += "move the code to files and import it within the notebook."
+
+        print(msg)
+
+        mp.set_start_method(start_method, force=True)
 
         self.input_dir = _resolve_dir(input_dir)
         self.output_dir = _resolve_dir(output_dir)
@@ -1082,8 +1096,10 @@ class DataProcessor:
         if _TQDM_AVAILABLE:
             pbar.close()
 
-        for w in self.workers:
-            w.join()
+        # TODO: Check whether this is still required.
+        if num_nodes == 1:
+            for w in self.workers:
+                w.join()
 
         print("Workers are finished.")
         result = data_recipe._done(len(user_items), self.delete_cached_files, self.output_dir)
@@ -1344,3 +1360,9 @@ class DataProcessor:
                 self.checkpoint_chunks_info[i] = checkpoint["chunks"]
                 self.checkpoint_next_index[i] = checkpoint["done_till_index"]
         return
+
+
+def in_notebook():
+    """Returns ``True`` if the module is running in IPython kernel, ``False`` if in IPython shell or other Python
+    shell."""
+    return "ipykernel" in sys.modules

--- a/src/litdata/processing/data_processor.py
+++ b/src/litdata/processing/data_processor.py
@@ -14,6 +14,7 @@
 import concurrent
 import json
 import logging
+import multiprocessing
 import os
 import random
 import shutil
@@ -905,19 +906,17 @@ class DataProcessor:
                 inside an interactive shell like Ipython.
 
         """
-        import multiprocessing as mp
-
         # spawn doesn't work in IPython
         start_method = start_method or ("fork" if in_notebook() else "spawn")
 
         msg = f"Setting multiprocessing start_method to {start_method}. "
-        if in_notebook() == "fork":
+        if in_notebook() and start_method == "fork":
             msg += "Tip: Libraries relying on lock can hang with `fork`. To use `spawn` in notebooks, "
             msg += "move your code to files and import it within the notebook."
 
         print(msg)
 
-        mp.set_start_method(start_method, force=True)
+        multiprocessing.set_start_method(start_method, force=True)
 
         self.input_dir = _resolve_dir(input_dir)
         self.output_dir = _resolve_dir(output_dir)

--- a/src/litdata/processing/data_processor.py
+++ b/src/litdata/processing/data_processor.py
@@ -1362,7 +1362,7 @@ class DataProcessor:
         return
 
 
-def in_notebook():
+def in_notebook() -> bool:
     """Returns ``True`` if the module is running in IPython kernel, ``False`` if in IPython shell or other Python
     shell."""
     return "ipykernel" in sys.modules

--- a/src/litdata/processing/functions.py
+++ b/src/litdata/processing/functions.py
@@ -311,6 +311,7 @@ def optimize(
     batch_size: Optional[int] = None,
     mode: Optional[Literal["append", "overwrite"]] = None,
     use_checkpoint: bool = False,
+    start_method: Optional[str] = None,
 ) -> None:
     """This function converts a dataset into chunks, possibly in a distributed way.
 
@@ -340,6 +341,8 @@ def optimize(
             Defaults to None.
         use_checkpoint: Whether to create checkpoints while processing the data, which can be used to resume the
             processing from the last checkpoint if the process is interrupted. (`Default: False`)
+        start_method: The start method used by python multiprocessing package. Default to spawn unless running
+            inside an interactive shell like Ipython.
 
     """
     if mode is not None and mode not in ["append", "overwrite"]:
@@ -430,6 +433,7 @@ def optimize(
             reader=reader,
             state_dict=state_dict,
             use_checkpoint=use_checkpoint,
+            start_method=start_method,
         )
 
         with optimize_dns_context(True):

--- a/tests/processing/test_data_processor.py
+++ b/tests/processing/test_data_processor.py
@@ -1241,3 +1241,20 @@ def test_data_chunk_recipe():
     data_recipe = DataChunkRecipe(chunk_size=2)
     assert data_recipe.chunk_bytes is None
     assert data_recipe.chunk_size == 2
+
+
+def test_data_processor_start_method(monkeypatch):
+    with pytest.raises(ValueError, match="cannot find context for 'blabla'"):
+        DataProcessor(None, start_method="blabla")
+
+    mp_mock = mock.MagicMock()
+
+    monkeypatch.setattr(data_processor_module, "multiprocessing", mp_mock)
+
+    DataProcessor(None)
+    mp_mock.set_start_method.assert_called_with("spawn", force=True)
+
+    monkeypatch.setattr(data_processor_module, "in_notebook", mock.MagicMock(return_value=True))
+
+    DataProcessor(None)
+    mp_mock.set_start_method.assert_called_with("fork", force=True)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This PR resolves an issue where setting start_method=spawn doesn't work in Jupyter in the function passed to optimize lives in the cell.

Now, the user can pass their desired start_method to the optimize function but in case they doesn't, we will select 'fork' within notebooks and spawn otherwise.   

Fixes #295

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
