### PR TITLE
Bugfix: inconsistent  streaming dataloader state (specific to StreamingDataset)

### DIFF
--- a/src/litdata/streaming/combined.py
+++ b/src/litdata/streaming/combined.py
@@ -134,6 +134,11 @@ class CombinedStreamingDataset(IterableDataset):
         for dataset in self._datasets:
             dataset.set_drop_last(drop_last)
 
+    def reset_state_dict(self) -> None:
+        """Reset the state of the dataset."""
+        for dataset in self._datasets:
+            dataset.reset_state_dict()
+
     def _check_datasets(self, datasets: List[StreamingDataset]) -> None:
         if any(not isinstance(d, StreamingDataset) for d in datasets):
             raise RuntimeError("The provided datasets should be instances of the StreamingDataset.")

--- a/src/litdata/streaming/dataloader.py
+++ b/src/litdata/streaming/dataloader.py
@@ -701,7 +701,8 @@ class StreamingDataLoader(DataLoader):
 
         # Inform we are resuming and disable resetting the StreamingDataLoader state.
         # This is toggle back to False when the `__iter__` method of the StreamingDataLoader completes.
-        self.restore = True
+        if obj["num_samples_yielded"] < len(self.dataset):
+            self.restore = True
 
         if isinstance(self.dataset, CombinedStreamingDataset):
             self.dataset._set_use_streaming_dataloader(True)

--- a/src/litdata/streaming/dataloader.py
+++ b/src/litdata/streaming/dataloader.py
@@ -615,6 +615,7 @@ class StreamingDataLoader(DataLoader):
             self.current_epoch += 1
             self._num_samples_yielded_combined = {}
             self._num_samples_yielded_streaming = 0
+            self.dataset.reset_state_dict()
 
         self.dataset.set_epoch(self.current_epoch)
 

--- a/src/litdata/streaming/dataloader.py
+++ b/src/litdata/streaming/dataloader.py
@@ -701,14 +701,24 @@ class StreamingDataLoader(DataLoader):
 
         # Inform we are resuming and disable resetting the StreamingDataLoader state.
         # This is toggle back to False when the `__iter__` method of the StreamingDataLoader completes.
-        if obj["num_samples_yielded"] < len(self.dataset):  # type: ignore
-            self.restore = True
+        # if obj["num_samples_yielded"] < len(self.dataset):  # type: ignore
+        #     self.restore = True
 
         if isinstance(self.dataset, CombinedStreamingDataset):
             self.dataset._set_use_streaming_dataloader(True)
             self.dataset.load_state_dict(obj)
+
+            # Inform that the dataloader is resuming.
+            # TODO: Check if the number of samples yielded is less than the length of the dataset.
+            # Also, len is not available for CombinedStreamingDataset incase of provided weights.
+            self.restore = True
+
         elif isinstance(self.dataset, StreamingDataset):
             self.dataset.load_state_dict(obj["dataset"])
+
+            # Inform that the dataloader is resuming.
+            if self._num_samples_yielded_streaming < len(self.dataset):
+                self.restore = True
         else:
             raise RuntimeError("The provided dataset should be a `StreamingDataset` or a `CombinedStreamingDataset`.")
 

--- a/src/litdata/streaming/dataloader.py
+++ b/src/litdata/streaming/dataloader.py
@@ -701,7 +701,7 @@ class StreamingDataLoader(DataLoader):
 
         # Inform we are resuming and disable resetting the StreamingDataLoader state.
         # This is toggle back to False when the `__iter__` method of the StreamingDataLoader completes.
-        if obj["num_samples_yielded"] < len(self.dataset):
+        if obj["num_samples_yielded"] < len(self.dataset):  # type: ignore
             self.restore = True
 
         if isinstance(self.dataset, CombinedStreamingDataset):

--- a/src/litdata/streaming/dataloader.py
+++ b/src/litdata/streaming/dataloader.py
@@ -701,8 +701,7 @@ class StreamingDataLoader(DataLoader):
 
         # Inform we are resuming and disable resetting the StreamingDataLoader state.
         # This is toggle back to False when the `__iter__` method of the StreamingDataLoader completes.
-        # if obj["num_samples_yielded"] < len(self.dataset):  # type: ignore
-        #     self.restore = True
+        # self.restore = True
 
         if isinstance(self.dataset, CombinedStreamingDataset):
             self.dataset._set_use_streaming_dataloader(True)

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -547,6 +547,7 @@ def _replay_chunks_sampling(
             if indexes[worker_idx] >= size:
                 indexes[worker_idx] -= size
                 chunks_index[worker_idx] += 1
+                # TODO: find robust soln, as it only seems to work for 1 worker
                 # chunks_index[worker_idx] = (chunks_index[worker_idx] + 1) % len(intervals)
             else:
                 # We've reached the chunk where resuming needs to take place (for this worker)

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -543,6 +543,7 @@ def _replay_chunks_sampling(
             if indexes[worker_idx] >= size:
                 indexes[worker_idx] -= size
                 chunks_index[worker_idx] += 1
+                # chunks_index[worker_idx] = (chunks_index[worker_idx] + 1) % len(intervals)
             else:
                 # We've reached the chunk where resuming needs to take place (for this worker)
                 break

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -338,12 +338,14 @@ class StreamingDataset(IterableDataset):
         # Prevent to create more batch on a given process
         if self.global_index >= self.stop_length:
             self.current_epoch += 1
+            self.reset_state_dict()
             raise StopIteration
 
         # Lazily re-populate the interval to reduce memory usage.
         if len(self.current_indexes) == 0:
             if self.chunk_index == self.num_chunks:
                 self.current_epoch += 1
+                self.reset_state_dict()
                 raise StopIteration
 
             # reset index

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -422,7 +422,6 @@ class StreamingDataset(IterableDataset):
         assert self.cache
 
         state: Dict[str, Any] = self._state_dict
-
         if state["shuffle"] != self.shuffle:
             raise ValueError(
                 "The provided `shuffle` state doesn't match the current one. "
@@ -474,6 +473,12 @@ class StreamingDataset(IterableDataset):
             raise ValueError(
                 "The provided `drop_last` state doesn't match the current one. "
                 f"Found `{self.drop_last}` instead of `{state['drop_last']}`."
+            )
+
+        if state["num_samples_yielded"] > len(self):
+            raise ValueError(
+                "The provided `num_samples_yielded` state is greater than the dataset length. "
+                f"Found `{state['num_samples_yielded']}` instead of `{len(self)}`."
             )
 
     def reset(self) -> None:

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -407,6 +407,9 @@ class StreamingDataset(IterableDataset):
             # the state is restored within the workers
             self._state_dict = state_dict
 
+    def reset_state_dict(self) -> None:
+        self._state_dict = None
+
     def _validate_state_dict(self) -> None:
         assert self._state_dict
         assert self.worker_env

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -388,7 +388,7 @@ class StreamingDataset(IterableDataset):
 
         return {
             "num_samples_yielded": num_samples_yielded,
-            "num_workers": num_workers,
+            "num_workers": num_workers if num_workers > 0 else 1,
             "batch_size": batch_size,
             "current_epoch": self.current_epoch,
             "input_dir_path": self.input_dir.path,

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -552,8 +552,6 @@ def _replay_chunks_sampling(
             if indexes[worker_idx] >= size:
                 indexes[worker_idx] -= size
                 chunks_index[worker_idx] += 1
-                # TODO: find robust soln, as it only seems to work for 1 worker
-                # chunks_index[worker_idx] = (chunks_index[worker_idx] + 1) % len(intervals)
             else:
                 # We've reached the chunk where resuming needs to take place (for this worker)
                 break

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -390,7 +390,7 @@ class StreamingDataset(IterableDataset):
 
         return {
             "num_samples_yielded": num_samples_yielded,
-            "num_workers": num_workers if num_workers > 0 else 1,
+            "num_workers": num_workers or 1,
             "batch_size": batch_size,
             "current_epoch": self.current_epoch,
             "input_dir_path": self.input_dir.path,

--- a/tests/streaming/test_combined.py
+++ b/tests/streaming/test_combined.py
@@ -17,6 +17,9 @@ class TestCombinedStreamingDataset(CombinedStreamingDataset):
     def _check_datasets(self, datasets) -> None:
         pass
 
+    def reset_state_dict(self):
+        pass
+
 
 def test_combined_dataset_num_samples_yield():
     dataset = TestCombinedStreamingDataset(

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -56,6 +56,9 @@ class TestCombinedStreamingDataset(CombinedStreamingDataset):
     def _check_datasets(self, datasets) -> None:
         pass
 
+    def reset_state_dict(self):
+        pass
+
 
 def test_streaming_dataloader():
     dataset = TestCombinedStreamingDataset(

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -248,3 +248,42 @@ def test_dataloader_with_loading_states(tmpdir):
         assert dataloader.current_epoch == 2, "Current epoch should be 2"
         count += 1
     assert count >= 25, "There should be at least 25 batches in the second epoch"
+
+
+@pytest.mark.timeout(120)
+def test_dataloader_states_with_persistent_workers(tmpdir):
+    cache = Cache(input_dir=str(tmpdir), chunk_bytes="64MB")
+    for i in range(100):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    dataset = StreamingDataset(str(tmpdir), shuffle=True)
+
+    # Test dataloader with persistent workers
+    dataloader = StreamingDataLoader(dataset, batch_size=4, num_workers=2)
+    assert len(dataloader) == 25, "Dataloader length should be 25 (100 items / batch size 4)"
+
+    # Verify dataloader state after partial iteration
+    for batch_idx, batch in enumerate(dataloader):
+        assert dataloader.current_epoch == 1, "Current epoch should be 1"
+        if batch_idx == 10:
+            break
+
+    prev_dataloader_state = dataloader.state_dict()
+    dataloader = StreamingDataLoader(dataset, batch_size=4, num_workers=2, persistent_workers=True)
+    dataloader.load_state_dict(prev_dataloader_state)
+
+    # Verify remaining batches in the first epoch
+    count = 0
+    for _ in dataloader:
+        assert dataloader.current_epoch == 1, "Current epoch should be 1"
+        count += 1
+    assert count == 15, "There should be atleast 15 batches remaining in the first epoch"
+
+    # Verify batches in the second epoch
+    count = 0
+    for _ in dataloader:
+        assert dataloader.current_epoch == 2, "Current epoch should be 2"
+        count += 1
+    assert count >= 25, "There should be at least 25 batches in the second epoch"

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -304,12 +304,13 @@ def test_dataloader_states_with_persistent_workers(tmpdir):
     assert count >= 25, "There should be at least 25 batches in the third epoch"
 
 
+@pytest.mark.timeout(60)
 def test_resume_dataloader_with_new_dataset(tmpdir):
     dataset_1_path = tmpdir.join("dataset_1")
     dataset_2_path = tmpdir.join("dataset_2")
     for dataset in [dataset_1_path, dataset_2_path]:
         cache = Cache(input_dir=str(dataset), chunk_bytes="64MB")
-        for i in range(100):
+        for i in range(50):
             cache[i] = i
         cache.done()
         cache.merge()

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -260,7 +260,6 @@ def test_dataloader_states_with_persistent_workers(tmpdir):
 
     dataset = StreamingDataset(str(tmpdir), shuffle=True)
 
-    # Test dataloader with persistent workers
     dataloader = StreamingDataLoader(dataset, batch_size=4, num_workers=2)
     assert len(dataloader) == 25, "Dataloader length should be 25 (100 items / batch size 4)"
 

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -234,13 +234,14 @@ def test_dataloader_with_loading_states(tmpdir):
         if batch_idx == 10:
             break
     dataloader.load_state_dict(dataloader.state_dict())
-
+    assert dataloader.restore
     # Verify remaining batches in the first epoch
     count = 0
     for _ in dataloader:
         assert dataloader.current_epoch == 1, "Current epoch should be 1"
         count += 1
     assert count == 15, "There should be atleast 15 batches remaining in the first epoch"
+    assert not dataloader.restore
 
     # Verify batches in the second epoch
     count = 0
@@ -251,6 +252,7 @@ def test_dataloader_with_loading_states(tmpdir):
 
     # Verify that the datalaoder can resume after complete last epoch
     dataloader.load_state_dict(dataloader.state_dict())
+    assert not dataloader.restore
     count = 0
     for _ in dataloader:
         assert dataloader.current_epoch == 3, "Current epoch should be 3"
@@ -280,6 +282,7 @@ def test_dataloader_states_with_persistent_workers(tmpdir):
     prev_dataloader_state = dataloader.state_dict()
     dataloader = StreamingDataLoader(dataset, batch_size=4, num_workers=2, persistent_workers=True)
     dataloader.load_state_dict(prev_dataloader_state)
+    assert dataloader.restore
 
     # Verify remaining batches in the first epoch
     count = 0
@@ -287,6 +290,7 @@ def test_dataloader_states_with_persistent_workers(tmpdir):
         assert dataloader.current_epoch == 1, "Current epoch should be 1"
         count += 1
     assert count == 15, "There should be atleast 15 batches remaining in the first epoch"
+    assert not dataloader.restore
 
     # Verify batches in the second epoch
     count = 0
@@ -297,6 +301,7 @@ def test_dataloader_states_with_persistent_workers(tmpdir):
 
     # Verify that the datalaoder can resume after complete last epoch
     dataloader.load_state_dict(dataloader.state_dict())
+    assert not dataloader.restore
     count = 0
     for _ in dataloader:
         assert dataloader.current_epoch == 3, "Current epoch should be 3"

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -249,6 +249,14 @@ def test_dataloader_with_loading_states(tmpdir):
         count += 1
     assert count >= 25, "There should be at least 25 batches in the second epoch"
 
+    # Verify that the datalaoder can resume after complete last epoch
+    dataloader.load_state_dict(dataloader.state_dict())
+    count = 0
+    for _ in dataloader:
+        assert dataloader.current_epoch == 3, "Current epoch should be 3"
+        count += 1
+    assert count >= 25, "There should be at least 25 batches in the third epoch"
+
 
 @pytest.mark.timeout(120)
 def test_dataloader_states_with_persistent_workers(tmpdir):
@@ -286,3 +294,11 @@ def test_dataloader_states_with_persistent_workers(tmpdir):
         assert dataloader.current_epoch == 2, "Current epoch should be 2"
         count += 1
     assert count >= 25, "There should be at least 25 batches in the second epoch"
+
+    # Verify that the datalaoder can resume after complete last epoch
+    dataloader.load_state_dict(dataloader.state_dict())
+    count = 0
+    for _ in dataloader:
+        assert dataloader.current_epoch == 3, "Current epoch should be 3"
+        count += 1
+    assert count >= 25, "There should be at least 25 batches in the third epoch"

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -325,34 +325,3 @@ def test_resume_dataloader_with_new_dataset(tmpdir):
     dataloader.load_state_dict(dataloader_state)
     for _ in dataloader:
         assert dataloader.current_epoch == 2, "Current epoch should be 2"
-
-
-def test_dataloader_resume_after_epoch_completion(tmpdir):
-    cache = Cache(input_dir=str(tmpdir), chunk_bytes="64MB")
-    for i in range(50):
-        cache[i] = i
-    cache.done()
-    cache.merge()
-
-    dataset = StreamingDataset(str(tmpdir), shuffle=True)
-    # Test dataloader without explicit num workers
-    dataloader = StreamingDataLoader(dataset, batch_size=4)
-    for _ in dataloader:
-        pass
-    assert dataloader.current_epoch == 1
-    dataloader.load_state_dict(dataloader.state_dict())
-    # force restore
-    dataloader.restore = True
-    batch = next(iter(dataloader))
-    assert len(batch) == 4, "Batch size should be 4"
-
-    # Test dataloader with num workers > 1
-    dataloader = StreamingDataLoader(dataset, batch_size=4, num_workers=2)
-    for _ in dataloader:
-        pass
-    assert dataloader.current_epoch == 1
-    dataloader.load_state_dict(dataloader.state_dict())
-    # force restore
-    dataloader.restore = True
-    batch = next(iter(dataloader))
-    assert len(batch) == 4, "Batch size should be 4"


### PR DESCRIPTION
## What does this PR do?

Fixes #263 && #316.
- [x] Resuming dataloader with New Dataset Fails
- [x] Iterating over the dataloader after loading state with complete one epoch iteration throws error.
- [x] Iterating over the dataloader after loading state with partial first epoch iteration do not reset after completing the epoch.
- [x] Throws num workers error when loading state with num_worksers=0 



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
