### PR TITLE
Reset state_dict after resume

### DIFF
--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -269,7 +269,7 @@ class StreamingDataset(IterableDataset):
 
         self.has_triggered_download = False
         self.last_time = time()
-
+        self._state_dict = None
         return self
 
     def _resume(self, workers_chunks: List[List[int]], workers_intervals: List[Any]) -> None:


### PR DESCRIPTION
<details>
  <summary><b>Reset of state_dict after resume. </b></summary>

- [ No] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [Yes] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ No] Did you make sure to update the docs?
- [No] Did you write any new necessary tests?

</details>

## What does this PR do?

Currently, resume from restart is triggered by a check that self._state_dict is not None when dataset iterator is created
```python
if self._state_dict:
            self._resume(workers_chunks, workers_intervals)
```
However, the self._state_dict is never reset after restart. At the next epoch, when a new dataset iterator is created, the resume is triggered again from the same state_dict. To fix this bug, I assign None to the self._state_dict after resume. 

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Yes