### PR TITLE
Fix: Ensure Compression Algorithm is Installed Before Reading Compressed Data

### DIFF
--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -85,11 +85,12 @@ class ChunksConfig:
 
         if self._compressor_name:
             if len(_COMPRESSORS) == 0:
-                raise ValueError("No compresion algorithms are installed.")
-
+                raise ValueError(
+                    "No compression algorithms are installed. To use zstd compression,  run `pip install zstd`."
+                )
             if self._compressor_name not in _COMPRESSORS:
                 raise ValueError(
-                    f"The provided compression {self._compressor_name} isn't available in {sorted(_COMPRESSORS)}"
+                    f"The provided compression {self._compressor_name} isn't available in {sorted(_COMPRESSORS)}",
                 )
             self._compressor = _COMPRESSORS[self._compressor_name]
 

--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -83,7 +83,14 @@ class ChunksConfig:
         self._compressor_name = self._config["compression"]
         self._compressor: Optional[Compressor] = None
 
-        if self._compressor_name in _COMPRESSORS:
+        if self._compressor_name:
+            if len(_COMPRESSORS) == 0:
+                raise ValueError("No compresion algorithms are installed.")
+
+            if self._compressor_name not in _COMPRESSORS:
+                raise ValueError(
+                    f"The provided compression {self._compressor_name} isn't available in {sorted(_COMPRESSORS)}"
+                )
             self._compressor = _COMPRESSORS[self._compressor_name]
 
         self._skip_chunk_indexes_deletion: Optional[List[int]] = None


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?
- This PR addresses the first bug from issue #341 by raising a ValueError if the data being read is compressed but the compression algorithm is not installed.

> Added the same version of the check as seen in [L93 from `writer.py`](https://github.com/Lightning-AI/litdata/blob/ee4ff912b07eb8e8d9be80d6d20f134a46c0005a/src/litdata/streaming/writer.py#L93).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
