### PR TITLE
Bump version to 0.26.dev1

### DIFF
--- a/src/litdata/__about__.py
+++ b/src/litdata/__about__.py
@@ -14,7 +14,7 @@
 
 import time
 
-__version__ = "0.2.26"
+__version__ = "0.2.26.dev1"
 __author__ = "Lightning AI et al."
 __author_email__ = "pytorch@lightning.ai"
 __license__ = "Apache-2.0"


### PR DESCRIPTION
Bumps the version so it will be easier for users to differentiate between the latest stable release and the current dev version via the main branch when reporting LitData issues.