### PR TITLE
Fix AttributeError in `BinaryReader` Destructor Due to Non-Existent `_prepare_thread` Attribute

### DIFF
--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -336,10 +336,9 @@ class BinaryReader:
         return state
 
     def __del__(self) -> None:
-        if self._prepare_thread and not self._prepare_thread._has_exited:
+        if hasattr(self, '_prepare_thread') and self._prepare_thread and not self._prepare_thread._has_exited:
             self._prepare_thread.force_stop()
             self._prepare_thread = None
-
 
 def _get_folder_size(path: str) -> int:
     """Collect the size of each files within a folder.

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -336,9 +336,10 @@ class BinaryReader:
         return state
 
     def __del__(self) -> None:
-        if hasattr(self, '_prepare_thread') and self._prepare_thread and not self._prepare_thread._has_exited:
+        if hasattr(self, "_prepare_thread") and self._prepare_thread and not self._prepare_thread._has_exited:
             self._prepare_thread.force_stop()
             self._prepare_thread = None
+
 
 def _get_folder_size(path: str) -> int:
     """Collect the size of each files within a folder.


### PR DESCRIPTION
This pull request resolves an issue in the `BinaryReader` class where executing the destructor (`__del__` method) attempts to access a non-existent attribute `_prepare_thread`, resulting in an `AttributeError`. This change ensures that the destructor checks for the existence of `_prepare_thread` before attempting to access it, thereby preventing errors during object cleanup.
