### PR TITLE
Change S3Client to use user-provided storage_options even in Studio 

### DIFF
--- a/src/litdata/streaming/client.py
+++ b/src/litdata/streaming/client.py
@@ -37,7 +37,7 @@ class S3Client:
             os.getenv("AWS_SHARED_CREDENTIALS_FILE") == os.getenv("AWS_CONFIG_FILE") == "/.credentials/.aws_credentials"
         )
 
-        if has_shared_credentials_file or not _IS_IN_STUDIO:
+        if has_shared_credentials_file or not _IS_IN_STUDIO or self._storage_options:
             self._client = boto3.client(
                 "s3",
                 **{


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue in the S3Client class where user-provided storage_options are ignored in the Lightning AI Studio environment. The client now uses user-supplied credentials when provided in storage_options.

Fixes #414