### PR TITLE
Feat: Add support for parquet files

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,37 @@ The `overwrite` mode will delete the existing data and start from fresh.
 </details>
 
 <details>
+  <summary> ✅ Index parquet datasets</summary>
+&nbsp;
+
+If your dataset is already in Parquet format, you can index it directly and use it with StreamingDataset & DataLoader.
+
+Assumption:
+Your dataset directory contains one or more Parquet files.
+
+```python
+import litdata as ld
+
+pq_data_uri = "gs://deep-litdata-parquet/my-parquet-data"
+
+ld.index_parquet_dataset(pq_data_uri)
+```
+
+When using a Streaming Dataset, ensure you use `ParquetLoader`:
+
+```python
+import litdata as ld
+from litdata.streaming.item_loader import ParquetLoader
+
+ds = ld.StreamingDataset('gs://deep-litdata-parquet/my-parquet-data', item_loader = ParquetLoader())
+
+for _ds in ds:
+    print(f"{_ds=}")
+```
+
+</details>
+
+<details>
   <summary> ✅ Use compression</summary>
 &nbsp;
 

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -5,3 +5,4 @@ pyarrow
 tqdm
 lightning-sdk ==0.1.17 # Must be pinned to ensure compatibility
 google-cloud-storage
+polars

--- a/src/litdata/__init__.py
+++ b/src/litdata/__init__.py
@@ -18,6 +18,7 @@ from litdata.streaming.combined import CombinedStreamingDataset
 from litdata.streaming.dataloader import StreamingDataLoader
 from litdata.streaming.dataset import StreamingDataset
 from litdata.streaming.item_loader import TokensLoader
+from litdata.streaming.writer import write_parquet_index
 from litdata.utilities.train_test_split import train_test_split
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     "walk",
     "train_test_split",
     "merge_datasets",
+    "write_parquet_index",
 ]
 if RequirementCache("lightning_sdk"):
     from lightning_sdk import Machine  # noqa: F401

--- a/src/litdata/__init__.py
+++ b/src/litdata/__init__.py
@@ -18,7 +18,7 @@ from litdata.streaming.combined import CombinedStreamingDataset
 from litdata.streaming.dataloader import StreamingDataLoader
 from litdata.streaming.dataset import StreamingDataset
 from litdata.streaming.item_loader import TokensLoader
-from litdata.streaming.writer import write_parquet_index
+from litdata.streaming.writer import index_parquet_dataset
 from litdata.utilities.breakpoint import breakpoint
 from litdata.utilities.train_test_split import train_test_split
 
@@ -32,7 +32,7 @@ __all__ = [
     "walk",
     "train_test_split",
     "merge_datasets",
-    "write_parquet_index",
+    "index_parquet_dataset",
     "breakpoint",
 ]
 if RequirementCache("lightning_sdk"):

--- a/src/litdata/constants.py
+++ b/src/litdata/constants.py
@@ -36,6 +36,7 @@ _GOOGLE_STORAGE_AVAILABLE = RequirementCache("google.cloud.storage")
 _AZURE_STORAGE_AVAILABLE = RequirementCache("azure.storage.blob")
 _TQDM_AVAILABLE = RequirementCache("tqdm")
 _LIGHTNING_SDK_AVAILABLE = RequirementCache("lightning_sdk")
+_POLARS_AVAILABLE = RequirementCache("polars")
 
 # DON'T CHANGE ORDER
 _TORCH_DTYPES_MAPPING = {

--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -69,7 +69,8 @@ class ChunksConfig:
         else:
             self._chunks = load_subsampled_chunks(subsampled_files, _original_chunks)
 
-        self._config["data_spec"] = treespec_loads(self._config["data_spec"])
+        if self._config["data_spec"] is not None:
+            self._config["data_spec"] = treespec_loads(self._config["data_spec"])
 
         assert self._chunks is not None
         self._item_loader.setup(self._config, self._chunks, serializers, region_of_interest)
@@ -228,7 +229,7 @@ class ChunksConfig:
 
         filesize_bytes = chunk["chunk_bytes"]
 
-        if self._config and self._config.get("encryption") is None:
+        if self._config and self._config.get("encryption") is None and (not local_chunkpath.endswith(".parquet")):
             filesize_bytes += (1 + chunk["chunk_size"]) * 4
 
         return local_chunkpath, begin, filesize_bytes

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -497,7 +497,7 @@ class ParquetLoader(BaseItemLoader):
 
         return self.cached_parquet(chunk_filepath).row(index - begin)
 
-    @functools.cache
+    @functools.lru_cache
     def cached_parquet(self, chunk_filepath):
         return self._get_polars().scan_parquet(chunk_filepath).collect()
 

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -321,7 +321,7 @@ class TokensLoader(BaseItemLoader):
         offset = (1 + chunk["chunk_size"] + 1) * 4
         mmap = np.memmap(chunk_filepath, mode="r", order="C", offset=offset)
         self._mmaps[chunk_index] = mmap
-        self._buffers[chunk_index] = memoryview(mmap)
+        self._buffers[chunk_index] = memoryview(mmap)  # type: ignore
 
     def pre_load_chunk(self, chunk_index: int, chunk_filepath: str) -> None:
         # This is called within the prepare chunks thread, so we overlap data loading with data reading.
@@ -391,10 +391,11 @@ class ParquetLoader(BaseItemLoader):
         if not _POLARS_AVAILABLE:
             raise ModuleNotFoundError("Please, run: `pip install polars`")
         self._chunk_filepaths: Dict[str, bool] = {}
+        self._polars: Any = None
 
     def _get_polars(self) -> Any:
         """Lazy load and store the `polars` module."""
-        if hasattr(self, "_polars") is False or self._polars is None:
+        if self._polars is None:
             import polars as pl
 
             self._polars = pl

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -495,7 +495,7 @@ class ParquetLoader(BaseItemLoader):
 
         return self.get_df(chunk_filepath).row(index - begin)
 
-    def get_df(self, chunk_filepath):
+    def get_df(self, chunk_filepath: str) -> Any:
         if chunk_filepath not in self._df:
             self._df[chunk_filepath] = self._get_polars().scan_parquet(chunk_filepath).collect()
         return self._df[chunk_filepath]

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 import torch
 
-from litdata.constants import _NUMPY_DTYPES_MAPPING, _TORCH_DTYPES_MAPPING
+from litdata.constants import _NUMPY_DTYPES_MAPPING, _POLARS_AVAILABLE, _TORCH_DTYPES_MAPPING
 from litdata.streaming.serializers import Serializer
 from litdata.utilities._pytree import PyTree, tree_unflatten
 from litdata.utilities.encryption import Encryption, EncryptionLevel
@@ -384,3 +384,88 @@ class TokensLoader(BaseItemLoader):
     @classmethod
     def encode_data(cls, data: List[bytes], _: List[int], flattened: List[Any]) -> Tuple[bytes, Optional[int]]:
         return data[0], flattened[0].shape[0]
+
+
+class ParquetLoader(BaseItemLoader):
+    def __init__(self):
+        if not _POLARS_AVAILABLE:
+            raise ModuleNotFoundError("Please, run: `pip install polars`")
+        self._chunk_filepaths: Dict[str, bool] = {}
+
+    def _get_polars(self):
+        """Lazy load and store the `polars` module."""
+        if hasattr(self, "_polars") is False or self._polars is None:
+            import polars as pl
+
+            self._polars = pl
+        return self._polars
+
+    def setup(
+        self,
+        config: Dict,
+        chunks: List,
+        serializers: Dict[str, Serializer],
+        region_of_interest: Optional[List[Tuple[int, int]]] = None,
+    ) -> None:
+        self._config = config
+        self._chunks = chunks
+        self._serializers = {**serializers}
+        self._data_format = self._config["data_format"]
+        self._shift_idx = len(self._data_format) * 4
+        self.region_of_interest = region_of_interest
+
+    def state_dict(self) -> Dict:
+        return {}
+
+    def generate_intervals(self) -> List[Interval]:
+        intervals = []
+        begin = 0
+        end = 0
+        for idx, curr_chunk in enumerate(self._chunks):
+            end += curr_chunk["chunk_size"]
+            start_idx, end_idx = begin, end
+            if self.region_of_interest is not None:
+                start_idx = begin + self.region_of_interest[idx][0]
+                end_idx = begin + self.region_of_interest[idx][1]
+
+            intervals.append(Interval(begin, start_idx, end_idx, end))
+            begin += curr_chunk["chunk_size"]
+        return intervals
+
+    def pre_load_chunk(self, chunk_index: int, chunk_filepath: str) -> None:
+        """Logic to load the chunk in background to gain some time."""
+        pass
+
+    def load_item_from_chunk(
+        self,
+        index: int,
+        chunk_index: int,
+        chunk_filepath: str,
+        begin: int,
+        filesize_bytes: int,
+    ) -> Any:
+        """Returns an item loaded from a chunk."""
+        if chunk_filepath in self._chunk_filepaths and not os.path.isfile(chunk_filepath):
+            del self._chunk_filepaths[chunk_filepath]
+
+        if chunk_filepath not in self._chunk_filepaths:
+            exists = os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes
+
+            while not exists:
+                sleep(0.1)
+                # file_exist = os.path.exists(chunk_filepath)
+                # file_size = os.stat(chunk_filepath).st_size
+                # print(f"still in exist fn: {file_exist=}; {file_size=}; {filesize_bytes=}")
+                exists = os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes
+
+            self._chunk_filepaths[chunk_filepath] = True
+
+        return self._get_polars().scan_parquet(chunk_filepath).collect().row(index - begin)
+
+    def delete(self, chunk_index: int, chunk_filepath: str) -> None:
+        """Delete a chunk from the local filesystem."""
+        if os.path.exists(chunk_filepath):
+            os.remove(chunk_filepath)
+
+    def encode_data(self, data: List[bytes], sizes: List[int], flattened: List[Any]) -> Any:
+        pass

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -504,7 +504,8 @@ class ParquetLoader(BaseItemLoader):
         """Delete a chunk from the local filesystem."""
         if os.path.exists(chunk_filepath):
             os.remove(chunk_filepath)
-        del self._df[chunk_filepath]
+        if chunk_filepath in self._df:
+            del self._df[chunk_filepath]
 
     def encode_data(self, data: List[bytes], sizes: List[int], flattened: List[Any]) -> Any:
         pass

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -504,7 +504,7 @@ class ParquetLoader(BaseItemLoader):
         """Delete a chunk from the local filesystem."""
         if os.path.exists(chunk_filepath):
             os.remove(chunk_filepath)
-        del self.df
+        del self._df
 
     def encode_data(self, data: List[bytes], sizes: List[int], flattened: List[Any]) -> Any:
         pass

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -504,7 +504,7 @@ class ParquetLoader(BaseItemLoader):
         """Delete a chunk from the local filesystem."""
         if os.path.exists(chunk_filepath):
             os.remove(chunk_filepath)
-        del self._df
+        del self._df[chunk_filepath]
 
     def encode_data(self, data: List[bytes], sizes: List[int], flattened: List[Any]) -> Any:
         pass

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -24,8 +24,13 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 import torch
 
-from litdata.constants import _NUMPY_DTYPES_MAPPING, _POLARS_AVAILABLE, _TORCH_DTYPES_MAPPING
-from litdata.constants import _FORCE_DOWNLOAD_TIME, _MAX_WAIT_TIME, _NUMPY_DTYPES_MAPPING, _TORCH_DTYPES_MAPPING
+from litdata.constants import (
+    _FORCE_DOWNLOAD_TIME,
+    _MAX_WAIT_TIME,
+    _NUMPY_DTYPES_MAPPING,
+    _POLARS_AVAILABLE,
+    _TORCH_DTYPES_MAPPING,
+)
 from litdata.streaming.serializers import Serializer
 from litdata.utilities._pytree import PyTree, tree_unflatten
 from litdata.utilities.encryption import Encryption, EncryptionLevel

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -425,15 +425,6 @@ class ParquetLoader(BaseItemLoader):
         if not _POLARS_AVAILABLE:
             raise ModuleNotFoundError("Please, run: `pip install polars`")
         self._chunk_filepaths: Dict[str, bool] = {}
-        self._polars: Any = None
-
-    def _get_polars(self) -> Any:
-        """Lazy load and store the `polars` module."""
-        if self._polars is None:
-            import polars as pl
-
-            self._polars = pl
-        return self._polars
 
     def setup(
         self,
@@ -496,8 +487,10 @@ class ParquetLoader(BaseItemLoader):
         return self.get_df(chunk_filepath).row(index - begin)
 
     def get_df(self, chunk_filepath: str) -> Any:
+        import polars as pl
+
         if chunk_filepath not in self._df:
-            self._df[chunk_filepath] = self._get_polars().scan_parquet(chunk_filepath).collect()
+            self._df[chunk_filepath] = pl.scan_parquet(chunk_filepath).collect()
         return self._df[chunk_filepath]
 
     def delete(self, chunk_index: int, chunk_filepath: str) -> None:

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -495,7 +495,11 @@ class ParquetLoader(BaseItemLoader):
 
             self._chunk_filepaths[chunk_filepath] = True
 
-        return self._get_polars().scan_parquet(chunk_filepath).collect().row(index - begin)
+        return self.cached_parquet(chunk_filepath).row(index - begin)
+
+    @functools.cache
+    def cached_parquet(self, chunk_filepath):
+        return self._get_polars().scan_parquet(chunk_filepath).collect()
 
     def delete(self, chunk_index: int, chunk_filepath: str) -> None:
         """Delete a chunk from the local filesystem."""

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -321,7 +321,7 @@ class TokensLoader(BaseItemLoader):
         offset = (1 + chunk["chunk_size"] + 1) * 4
         mmap = np.memmap(chunk_filepath, mode="r", order="C", offset=offset)
         self._mmaps[chunk_index] = mmap
-        self._buffers[chunk_index] = memoryview(mmap)  # type: ignore
+        self._buffers[chunk_index] = memoryview(mmap)
 
     def pre_load_chunk(self, chunk_index: int, chunk_filepath: str) -> None:
         # This is called within the prepare chunks thread, so we overlap data loading with data reading.
@@ -387,12 +387,12 @@ class TokensLoader(BaseItemLoader):
 
 
 class ParquetLoader(BaseItemLoader):
-    def __init__(self):
+    def __init__(self) -> None:
         if not _POLARS_AVAILABLE:
             raise ModuleNotFoundError("Please, run: `pip install polars`")
         self._chunk_filepaths: Dict[str, bool] = {}
 
-    def _get_polars(self):
+    def _get_polars(self) -> Any:
         """Lazy load and store the `polars` module."""
         if hasattr(self, "_polars") is False or self._polars is None:
             import polars as pl

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -504,7 +504,7 @@ class ParquetLoader(BaseItemLoader):
         """Delete a chunk from the local filesystem."""
         if os.path.exists(chunk_filepath):
             os.remove(chunk_filepath)
-        del self._parquet_data
+        del self.df
 
     def encode_data(self, data: List[bytes], sizes: List[int], flattened: List[Any]) -> Any:
         pass

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -441,9 +441,6 @@ class ParquetLoader(BaseItemLoader):
         self.region_of_interest = region_of_interest
         self._df: Dict[str, Any] = {}
 
-    def state_dict(self) -> Dict:
-        return {}
-
     def generate_intervals(self) -> List[Interval]:
         intervals = []
         begin = 0

--- a/src/litdata/streaming/sampler.py
+++ b/src/litdata/streaming/sampler.py
@@ -22,6 +22,26 @@ logger = logging.Logger(__name__)
 
 @dataclass
 class ChunkedIndex:
+    """Represents an index within a chunked dataset.
+
+    Attributes:
+        index (int): The global index of the data point across all chunks.
+        chunk_index (int): The index of the chunk where the data point resides.
+        chunk_indexes (Optional[List[int]]): A list specifying the range of indexes
+            allowed to read for this data point, in the form
+            [start, can_read_from, can_read_till, end]. Defaults to None.
+        is_last_index (bool): Indicates whether this is the last index in the dataset.
+            Defaults to False.
+
+    Suppose there are 3 chunk files:
+    - chunk-0.bin: Contains data points with global indexes 0-4.
+    - chunk-1.bin: Contains data points with global indexes 5-9.
+    - chunk-2.bin: Contains data points with global indexes 10-14.
+
+        A `ChunkedIndex` instance for the 6th data point (global index 5) would look like:
+            ChunkedIndex(index=5, chunk_index=1, chunk_indexes=[4,4,8,8], is_last_index=False)
+    """
+
     index: int
     chunk_index: int
     chunk_indexes: Optional[List[int]] = None

--- a/src/litdata/streaming/writer.py
+++ b/src/litdata/streaming/writer.py
@@ -532,14 +532,14 @@ class BinaryWriter:
         return checkpoint_filepath
 
 
-def write_parquet_index(pq_directory: str, cache_dir: Optional[str] = None):
+def write_parquet_index(pq_directory: str, cache_dir: Optional[str] = None) -> None:
     if not _POLARS_AVAILABLE:
         raise ModuleNotFoundError("Please, run: `pip install polars`")
 
     import polars as pl
 
     pq_chunks_info = []
-    config = {
+    config: Dict[str, Any] = {
         "compression": None,
         "chunk_size": None,
         "chunk_bytes": None,

--- a/src/litdata/streaming/writer.py
+++ b/src/litdata/streaming/writer.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from litdata.constants import _INDEX_FILENAME
+from litdata.constants import _INDEX_FILENAME, _POLARS_AVAILABLE
 from litdata.processing.utilities import get_worker_rank
 from litdata.streaming.compression import _COMPRESSORS, Compressor
 from litdata.streaming.item_loader import BaseItemLoader, PyTreeLoader
@@ -530,3 +530,9 @@ class BinaryWriter:
             json.dump(checkPoint, f)
 
         return checkpoint_filepath
+
+
+def write_parquet_index(pq_directory: str):
+    if not _POLARS_AVAILABLE:
+        raise ModuleNotFoundError("Please, run: `pip install polars`")
+    ...

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -29,7 +29,11 @@ class ParquetDir(ABC):
 
 
 class LocalParquetDir(ParquetDir):
-    def __init__(self, dir_path, cache_path=None, storage_options={}):
+    def __init__(
+        dir_path: Optional[Union[str, Dir]],
+        cache_path: Optional[str] = None,
+        storage_options: Optional[Dict] = {},
+    ):
         super().__init__(dir_path, cache_path, storage_options)
 
     def __iter__(self) -> Generator[Tuple[str, str], None, None]:

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -4,7 +4,7 @@ import json
 import os
 from abc import ABC, abstractmethod
 from time import time
-from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
 from litdata.constants import _INDEX_FILENAME
 from litdata.streaming.resolver import Dir, _resolve_dir
@@ -51,6 +51,7 @@ class LocalParquetDir(ParquetDir):
         # write to index.json file
         if self.cache_path is None:
             self.cache_path = self.dir.path
+        assert self.cache_path is not None
         with open(os.path.join(self.cache_path, _INDEX_FILENAME), "w") as f:
             data = {"chunks": chunks_info, "config": config, "updated_at": str(time())}
             json.dump(data, f, sort_keys=True)
@@ -113,7 +114,7 @@ class S3ParquetDir(ParquetDir):
         print(f"Index file written to: {s3_index_path}")
 
 
-_PARQUET_DIR = {
+_PARQUET_DIR: Dict[str, Type[ParquetDir]] = {
     "s3://": S3ParquetDir,
     "local:": LocalParquetDir,
     "": LocalParquetDir,

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -41,7 +41,6 @@ class LocalParquetDir(ParquetDir):
     def __iter__(self) -> Generator[Tuple[str, str], None, None]:
         assert self.dir.path is not None
         assert self.dir.path != "", "Dir path can't be empty"
-        assert self.dir.url is None, f"Dir url isn't empty. Got: {self.dir.url}"
 
         for file_name in os.listdir(self.dir.path):
             if file_name.endswith(".parquet"):

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -1,4 +1,4 @@
-"""contains utility functions to return parquet files from local, s3, or hf."""
+"""contains utility functions to return parquet files from local, s3, or gs."""
 
 import json
 import os
@@ -8,6 +8,7 @@ from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
 from litdata.constants import _INDEX_FILENAME
 from litdata.streaming.resolver import Dir, _resolve_dir
+from litdata.utilities.dataset_utilities import _try_create_cache_dir
 
 
 class ParquetDir(ABC):
@@ -59,24 +60,33 @@ class LocalParquetDir(ParquetDir):
         print(f"Index file written to: {os.path.join(self.cache_path, _INDEX_FILENAME)}")
 
 
-class S3ParquetDir(ParquetDir):
+class CloudParquetDir(ParquetDir):
     def __init__(
         self,
         dir_path: Optional[Union[str, Dir]],
         cache_path: Optional[str] = None,
-        storage_options: Optional[Dict] = {},
+        storage_options: Optional[Dict] = None,
     ):
         super().__init__(dir_path, cache_path, storage_options)
+        if self.cache_path is None:
+            self.cache_path = _try_create_cache_dir(self.dir.path)
 
         import fsspec
 
-        # Initialize the S3 filesystem
-        self.fs = fsspec.filesystem("s3", self.storage_options)
+        assert self.dir.url is not None
+
+        _CLOUD_PROVIDER = ("s3", "gs")
+
+        for provider in _CLOUD_PROVIDER:
+            if self.dir.url.startswith(provider):
+                # Initialize the cloud filesystem
+                self.fs = fsspec.filesystem(provider, storage_options=self.storage_options)
+                print(f"using provider: {provider}")
+                break
 
     def __iter__(self) -> Generator[Tuple[str, str], None, None]:
         assert self.dir.url is not None
-        assert self.dir.url.startswith("s3")
-        assert self.cache_dir is not None
+        assert self.cache_path is not None
 
         # List all files and directories in the top-level of the specified directory
         files = self.fs.ls(self.dir.url, detail=True)
@@ -84,47 +94,46 @@ class S3ParquetDir(ParquetDir):
         # Iterate through the items and check for Parquet files
         for file_info in files:
             if file_info["type"] == "file" and file_info["name"].endswith(".parquet"):
-                print(file_info["name"])
                 file_name = os.path.basename(file_info["name"])
                 assert self.cache_path is not None
                 local_path = os.path.join(self.cache_path, file_name)
 
                 # Download the file
-                with self.fs.open(file_info["name"], "rb") as s3_file, open(local_path, "wb") as local_file:
-                    local_file.write(s3_file.read())
+                with self.fs.open(file_info["name"], "rb") as cloud_file, open(local_path, "wb") as local_file:
+                    local_file.write(cloud_file.read())
 
-                print(f"Downloaded {file_info['name']} to {local_path}")
                 yield file_name, local_path
 
     def write_index(self, chunks_info: List[Dict[str, Any]], config: Dict[str, Any]) -> None:
-        assert self.cache_dir is not None
+        assert self.cache_path is not None
         assert self.dir.url is not None
 
-        index_file_path = os.path.join(self.cache_dir, _INDEX_FILENAME)
-        s3_index_path = os.path.join(self.dir.url, _INDEX_FILENAME)
+        index_file_path = os.path.join(self.cache_path, _INDEX_FILENAME)
+        cloud_index_path = os.path.join(self.dir.url, _INDEX_FILENAME)
         # write to index.json file
         with open(index_file_path, "w") as f:
             data = {"chunks": chunks_info, "config": config, "updated_at": str(time())}
             json.dump(data, f, sort_keys=True)
 
-        # upload file to s3
-        with open(index_file_path, "rb") as local_file, self.fs.open(s3_index_path, "wb") as s3_file:
-            s3_file.write(local_file.read())
+        # upload file to cloud
+        with open(index_file_path, "rb") as local_file, self.fs.open(cloud_index_path, "wb") as cloud_file:
+            cloud_file.write(local_file.read())
 
-        print(f"Index file written to: {s3_index_path}")
+        print(f"Index file written to: {cloud_index_path}")
 
 
 _PARQUET_DIR: Dict[str, Type[ParquetDir]] = {
-    "s3://": S3ParquetDir,
+    "s3://": CloudParquetDir,
+    "gs://": CloudParquetDir,
     "local:": LocalParquetDir,
     "": LocalParquetDir,
 }
 
 
 def get_parquet_indexer_cls(
-    dir_path: str, cache_dir: Optional[str] = None, storage_options: Optional[Dict] = {}
+    dir_path: str, cache_path: Optional[str] = None, storage_options: Optional[Dict] = {}
 ) -> ParquetDir:
     for k, cls in _PARQUET_DIR.items():
         if str(dir_path).startswith(k):
-            return cls(dir_path, cache_dir, storage_options)
+            return cls(dir_path, cache_path, storage_options)
     raise ValueError(f"The provided `dir_path` {dir_path} doesn't have a ParquetDir class associated.")

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -30,6 +30,7 @@ class ParquetDir(ABC):
 
 class LocalParquetDir(ParquetDir):
     def __init__(
+        self,
         dir_path: Optional[Union[str, Dir]],
         cache_path: Optional[str] = None,
         storage_options: Optional[Dict] = {},

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -1,0 +1,124 @@
+"""contains utility functions to return parquet files from local, s3, or hf."""
+
+import json
+import os
+from abc import ABC, abstractmethod
+from time import time
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+
+from litdata.constants import _INDEX_FILENAME
+from litdata.streaming.resolver import Dir, _resolve_dir
+
+
+class ParquetDir(ABC):
+    def __init__(
+        self,
+        dir_path: Optional[Union[str, Dir]],
+        cache_path: Optional[str] = None,
+        storage_options: Optional[Dict] = {},
+    ):
+        self.dir = _resolve_dir(dir_path)
+        self.cache_path = cache_path
+        self.storage_options = storage_options
+
+    @abstractmethod
+    def __iter__(self) -> Generator[Tuple[str, str], None, None]: ...
+
+    @abstractmethod
+    def write_index(self, chunks_info: List[Dict[str, Any]], config: Dict[str, Any]) -> None: ...
+
+
+class LocalParquetDir(ParquetDir):
+    def __init__(self, dir_path, cache_path=None, storage_options={}):
+        super().__init__(dir_path, cache_path, storage_options)
+
+    def __iter__(self) -> Generator[Tuple[str, str], None, None]:
+        assert self.dir.path is not None
+        assert self.dir.path != "", "Dir path can't be empty"
+        assert self.dir.url is None, f"Dir url isn't empty. Got: {self.dir.url}"
+
+        for file_name in os.listdir(self.dir.path):
+            if file_name.endswith(".parquet"):
+                file_path = os.path.join(self.dir.path, file_name)
+                yield file_name, file_path
+
+    def write_index(self, chunks_info: List[Dict[str, Any]], config: Dict[str, Any]) -> None:
+        # write to index.json file
+        if self.cache_path is None:
+            self.cache_path = self.dir.path
+        with open(os.path.join(self.cache_path, _INDEX_FILENAME), "w") as f:
+            data = {"chunks": chunks_info, "config": config, "updated_at": str(time())}
+            json.dump(data, f, sort_keys=True)
+
+        print(f"Index file written to: {os.path.join(self.cache_path, _INDEX_FILENAME)}")
+
+
+class S3ParquetDir(ParquetDir):
+    def __init__(
+        self,
+        dir_path: Optional[Union[str, Dir]],
+        cache_path: Optional[str] = None,
+        storage_options: Optional[Dict] = {},
+    ):
+        super().__init__(dir_path, cache_path, storage_options)
+
+        import fsspec
+
+        # Initialize the S3 filesystem
+        self.fs = fsspec.filesystem("s3", self.storage_options)
+
+    def __iter__(self) -> Generator[Tuple[str, str], None, None]:
+        assert self.dir.url is not None
+        assert self.dir.url.startswith("s3")
+        assert self.cache_dir is not None
+
+        # List all files and directories in the top-level of the specified directory
+        files = self.fs.ls(self.dir.url, detail=True)
+
+        # Iterate through the items and check for Parquet files
+        for file_info in files:
+            if file_info["type"] == "file" and file_info["name"].endswith(".parquet"):
+                print(file_info["name"])
+                file_name = os.path.basename(file_info["name"])
+                assert self.cache_path is not None
+                local_path = os.path.join(self.cache_path, file_name)
+
+                # Download the file
+                with self.fs.open(file_info["name"], "rb") as s3_file, open(local_path, "wb") as local_file:
+                    local_file.write(s3_file.read())
+
+                print(f"Downloaded {file_info['name']} to {local_path}")
+                yield file_name, local_path
+
+    def write_index(self, chunks_info: List[Dict[str, Any]], config: Dict[str, Any]) -> None:
+        assert self.cache_dir is not None
+        assert self.dir.url is not None
+
+        index_file_path = os.path.join(self.cache_dir, _INDEX_FILENAME)
+        s3_index_path = os.path.join(self.dir.url, _INDEX_FILENAME)
+        # write to index.json file
+        with open(index_file_path, "w") as f:
+            data = {"chunks": chunks_info, "config": config, "updated_at": str(time())}
+            json.dump(data, f, sort_keys=True)
+
+        # upload file to s3
+        with open(index_file_path, "rb") as local_file, self.fs.open(s3_index_path, "wb") as s3_file:
+            s3_file.write(local_file.read())
+
+        print(f"Index file written to: {s3_index_path}")
+
+
+_PARQUET_DIR = {
+    "s3://": S3ParquetDir,
+    "local:": LocalParquetDir,
+    "": LocalParquetDir,
+}
+
+
+def get_parquet_indexer_cls(
+    dir_path: str, cache_dir: Optional[str] = None, storage_options: Optional[Dict] = {}
+) -> ParquetDir:
+    for k, cls in _PARQUET_DIR.items():
+        if str(dir_path).startswith(k):
+            return cls(dir_path, cache_dir, storage_options)
+    raise ValueError(f"The provided `dir_path` {dir_path} doesn't have a ParquetDir class associated.")

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
 from litdata.constants import _INDEX_FILENAME
 from litdata.streaming.resolver import Dir, _resolve_dir
-from litdata.utilities.dataset_utilities import _try_create_cache_dir
 
 
 class ParquetDir(ABC):
@@ -68,7 +67,8 @@ class CloudParquetDir(ParquetDir):
     ):
         super().__init__(dir_path, cache_path, storage_options)
         if self.cache_path is None:
-            self.cache_path = _try_create_cache_dir(self.dir.path)
+            self.cache_path = os.path.join(os.path.expanduser("~"), ".cache", ".litdata-cache-index-pq")
+            os.makedirs(self.cache_path, exist_ok=True)  # Ensure the directory exists
 
         import fsspec
 
@@ -79,7 +79,7 @@ class CloudParquetDir(ParquetDir):
         for provider in _CLOUD_PROVIDER:
             if self.dir.url.startswith(provider):
                 # Initialize the cloud filesystem
-                self.fs = fsspec.filesystem(provider, storage_options=self.storage_options)
+                self.fs = fsspec.filesystem(provider, *self.storage_options)
                 print(f"using provider: {provider}")
                 break
 

--- a/tests/streaming/test_writer.py
+++ b/tests/streaming/test_writer.py
@@ -307,5 +307,5 @@ def test_parquet_index_write(tmpdir):
         assert len(data["chunks"]) == 5
         for cnk in data["chunks"]:
             assert cnk["chunk_size"] == 5
-        assert data["config"]["item_loader"] == "ParquetReader"
+        assert data["config"]["item_loader"] == "ParquetLoader"
         assert data["config"]["data_format"] == ["String", "Date", "Float64", "Float64"]

--- a/tests/streaming/test_writer.py
+++ b/tests/streaming/test_writer.py
@@ -25,7 +25,7 @@ from lightning_utilities.core.imports import RequirementCache
 from litdata.streaming.compression import _ZSTD_AVAILABLE
 from litdata.streaming.reader import BinaryReader
 from litdata.streaming.sampler import ChunkedIndex
-from litdata.streaming.writer import BinaryWriter, write_parquet_index
+from litdata.streaming.writer import BinaryWriter, index_parquet_dataset
 from litdata.utilities.format import _FORMAT_TO_RATIO
 
 
@@ -298,7 +298,7 @@ def test_parquet_index_write(tmpdir):
     index_file_path = os.path.join(tmpdir, "data", "index.json")
     assert not os.path.exists(index_file_path)
     # call the write_parquet_index fn
-    write_parquet_index(os.path.join(tmpdir, "data"))
+    index_parquet_dataset(os.path.join(tmpdir, "data"))
     assert os.path.exists(index_file_path)
 
     # Read JSON file into a dictionary

--- a/tests/streaming/test_writer.py
+++ b/tests/streaming/test_writer.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime as dt
 import json
 import os
 import random
@@ -23,7 +24,7 @@ from lightning_utilities.core.imports import RequirementCache
 from litdata.streaming.compression import _ZSTD_AVAILABLE
 from litdata.streaming.reader import BinaryReader
 from litdata.streaming.sampler import ChunkedIndex
-from litdata.streaming.writer import BinaryWriter
+from litdata.streaming.writer import BinaryWriter, write_parquet_index
 from litdata.utilities.format import _FORMAT_TO_RATIO
 
 
@@ -268,3 +269,42 @@ def test_writer_save_checkpoint(tmpdir):
     for file in os.listdir(os.path.join(cache_dir, ".checkpoints")):
         assert file.__contains__("checkpoint-0")
         assert file.endswith(".json")
+
+
+def test_parquet_index_write(tmpdir):
+    import polars as pl
+
+    os.mkdir(os.path.join(tmpdir, "data"))
+
+    for i in range(5):
+        df = pl.DataFrame(
+            {
+                "name": ["Tom", "Jerry", "Micky", "Oggy", "Doraemon"],
+                "birthdate": [
+                    dt.date(1997, 1, 10),
+                    dt.date(1985, 2, 15),
+                    dt.date(1983, 3, 22),
+                    dt.date(1981, 4, 30),
+                    dt.date(1984, 12, 3),
+                ],
+                "weight": [57.9, 72.5, 53.6, 83.1, 69.4],  # (kg)
+                "height": [1.56, 1.77, 1.65, 1.75, 1.63],  # (m)
+            }
+        )
+        file_path = os.path.join(tmpdir, "data", f"tmp-{i}.parquet")
+        df.write_parquet(file_path)
+
+    index_file_path = os.path.join(tmpdir, "data", "index.json")
+    assert not os.path.exists(index_file_path)
+    # call the write_parquet_index fn
+    write_parquet_index(os.path.join(tmpdir, "data"))
+    assert os.path.exists(index_file_path)
+
+    # Read JSON file into a dictionary
+    with open(index_file_path) as f:
+        data = json.load(f)
+        assert len(data["chunks"]) == 5
+        for cnk in data["chunks"]:
+            assert cnk["chunk_size"] == 5
+        assert data["config"]["item_loader"] == "ParquetReader"
+        assert data["config"]["data_format"] == ["String", "Date", "Float64", "Float64"]


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #191 

- Index parquet dataset stored in local or cloud (s3 or gs).

```python
import litdata as ld

pq_data_uri = "gs://deep-litdata-parquet/my-parquet-data"

ld.index_parquet_dataset(pq_data_uri)
```

- Use it as normal optimized dataset

```python
import litdata as ld
from litdata.streaming.item_loader import ParquetLoader

ds = ld.StreamingDataset('gs://deep-litdata-parquet/my-parquet-data', item_loader = ParquetLoader())

for _ds in ds:
    print(f"{_ds=}")
```

---

## Benchmark on Data prep machine

<img width="559" alt="Screenshot 2025-02-01 at 4 18 41 PM" src="https://github.com/user-attachments/assets/0e566505-5835-432a-a879-461065426b45" />



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
