### PR TITLE
Nit: specify testpaths for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,9 @@ exclude_lines = [
 
 
 [tool.pytest.ini_options]
+testpaths = [
+    "tests",
+]
 norecursedirs = [
     ".git",
     ".github",


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

To run tests, you need to use `pytest tests`.

By specifying testpaths for pytest, we can directly use `pytest`.

---

Without this, if you run `pytest`, it logs errors as it tries running `examples/` too.

```
=============================================================== short test summary info ===============================================================
ERROR examples/getting_started/stream.py - botocore.exceptions.ClientError: An error occurred (403) when calling the HeadObject operation: Forbidden
ERROR examples/multi_modal/cl_run.py
ERROR examples/multi_modal/create_labelencoder.py
ERROR examples/multi_modal/dataloader.py
ERROR examples/multi_modal/generate.py
ERROR examples/multi_modal/loop.py
ERROR examples/multi_modal/train.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 7 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
=========================================================== 16 warnings, 7 errors in 3.66s ============================================================
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
