### PR TITLE
Using count-locks for multi-node-single-cache support

### DIFF
--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -123,11 +123,14 @@ class ChunksConfig:
             if self._downloader is not None:
                 # We don't want to redownload the base, but we should mark
                 # it as having been requested by something
-                self._downloader._increment_local_lock(local_chunkpath)
+                self._downloader._increment_local_lock(local_chunkpath.replace(f".{self._compressor_name}"))
+                pass
             return
 
         if self._downloader is None:
             return
+
+        self._downloader._increment_local_lock(local_chunkpath.replace(f".{self._compressor_name}", ""))
 
         self._downloader.download_chunk_from_index(chunk_index)
 

--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -120,6 +120,10 @@ class ChunksConfig:
 
         if os.path.exists(local_chunkpath):
             self.try_decompress(local_chunkpath)
+            if self._downloader is not None:
+                # We don't want to redownload the base, but we should mark
+                # it as having been requested by something
+                self._downloader._increment_local_lock(local_chunkpath)
             return
 
         if self._downloader is None:

--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -123,7 +123,7 @@ class ChunksConfig:
             if self._downloader is not None:
                 # We don't want to redownload the base, but we should mark
                 # it as having been requested by something
-                self._downloader._increment_local_lock(local_chunkpath.replace(f".{self._compressor_name}"))
+                self._downloader._increment_local_lock(local_chunkpath.replace(f".{self._compressor_name}", ""))
                 pass
             return
 

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -40,10 +40,27 @@ class Downloader(ABC):
         self._chunks = chunks
         self._storage_options = storage_options or {}
 
+    def _increment_local_lock(self, chunkpath: str) -> None:
+        countpath = chunkpath + ".cnt"
+        with suppress(Timeout), FileLock(
+            countpath + ".lock", timeout=3
+        ):
+            try:
+                with open(countpath, "r") as count_f:
+                    curr_count = int(count_f.read().strip())
+            except Exception:
+                curr_count = 0
+            curr_count += 1
+            with open(countpath, "w+") as count_f:
+                count_f.write(str(curr_count))
+
     def download_chunk_from_index(self, chunk_index: int) -> None:
         chunk_filename = self._chunks[chunk_index]["filename"]
         local_chunkpath = os.path.join(self._cache_dir, chunk_filename)
         remote_chunkpath = os.path.join(self._remote_dir, chunk_filename)
+
+        # First mark this chunk path as in-use
+        self._increment_local_lock(local_chunkpath)
         self.download_file(remote_chunkpath, local_chunkpath, chunk_filename)
 
     def download_file(self, remote_chunkpath: str, local_chunkpath: str, remote_chunk_filename: str = "") -> None:

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -52,6 +52,13 @@ class Downloader(ABC):
             with open(countpath, "w+") as count_f:
                 count_f.write(str(curr_count))
 
+            # Delete the lock file
+            try:
+                if os.path.exists(countpath + ".lock"):
+                    os.remove(countpath)
+            except FileNotFoundError:
+                pass
+
     def download_chunk_from_index(self, chunk_index: int) -> None:
         chunk_filename = self._chunks[chunk_index]["filename"]
         local_chunkpath = os.path.join(self._cache_dir, chunk_filename)

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -57,8 +57,6 @@ class Downloader(ABC):
         local_chunkpath = os.path.join(self._cache_dir, chunk_filename)
         remote_chunkpath = os.path.join(self._remote_dir, chunk_filename)
 
-        # First mark this chunk path as in-use
-        self._increment_local_lock(local_chunkpath)
         self.download_file(remote_chunkpath, local_chunkpath, chunk_filename)
 
     def download_file(self, remote_chunkpath: str, local_chunkpath: str, remote_chunk_filename: str = "") -> None:

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -52,13 +52,6 @@ class Downloader(ABC):
             with open(countpath, "w+") as count_f:
                 count_f.write(str(curr_count))
 
-            # Delete the lock file
-            try:
-                if os.path.exists(countpath + ".lock"):
-                    os.remove(countpath)
-            except FileNotFoundError:
-                pass
-
     def download_chunk_from_index(self, chunk_index: int) -> None:
         chunk_filename = self._chunks[chunk_index]["filename"]
         local_chunkpath = os.path.join(self._cache_dir, chunk_filename)

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -100,7 +100,7 @@ class PrepareChunksThread(Thread):
             except Exception:
                 return 1
 
-    def _decrement_local_lock(self, chunk_index: str) -> int:
+    def _decrement_local_lock(self, chunk_index: int) -> int:
         """Remove a count from the local lock, return the remaining count."""
         chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
 
@@ -385,8 +385,7 @@ class BinaryReader:
             assert self._last_chunk_index is not None
 
             # inform the chunk has been completely consumed
-            if self.config._downloader:
-                self._prepare_thread._decrement_local_lock(self._last_chunk_index)
+            self._prepare_thread._decrement_local_lock(self._last_chunk_index)
             self._prepare_thread.delete([self._last_chunk_index])
 
         if index.chunk_index != self._last_chunk_index:

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -101,8 +101,9 @@ class PrepareChunksThread(Thread):
                 return 1
 
     def _decrement_local_lock(self, chunk_index: str) -> int:
-        """Remove a count from the local lock, return the remaining count"""
+        """Remove a count from the local lock, return the remaining count."""
         chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
+
         countpath = chunk_filepath + ".cnt"
         with suppress(Timeout), FileLock(countpath + ".lock", timeout=3):
             if not os.path.exists(countpath):
@@ -115,6 +116,7 @@ class PrepareChunksThread(Thread):
             curr_count -= 1
             if curr_count <= 0:
                 os.remove(countpath)
+                os.remove(countpath + ".lock")
             else:
                 with open(countpath, "w+") as count_f:
                     count_f.write(str(curr_count))
@@ -123,27 +125,28 @@ class PrepareChunksThread(Thread):
 
     def _apply_delete(self, chunk_index: int) -> None:
         """Inform the item loader of the chunk to delete."""
-        if self._config.can_delete(chunk_index):
-            chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
+        # TODO: Fix the can_delete method
+        can_delete_chunk = self._config.can_delete(chunk_index)
+        chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
 
-            remaining_locks = self._remaining_locks(chunk_filepath)
-            if remaining_locks > 0:  # Can't delete this, something has it
-                if _DEBUG:
-                    print(f"Skip delete {chunk_filepath} by {self._rank}, current lock count: {remaining_locks}")
-                return
-
-            self._item_loader.delete(chunk_index, chunk_filepath)
-
+        remaining_locks = self._remaining_locks(chunk_filepath)
+        if remaining_locks > 0:  # Can't delete this, something has it
             if _DEBUG:
-                print(f"Deleted {chunk_filepath} by {self._rank}")
+                print(f"Skip delete {chunk_filepath} by {self._rank or 0}, current lock count: {remaining_locks}")
+            return
 
-            for lock_extension in [".lock", ".cnt.lock"]:
-                try:
-                    locak_chunk_path = chunk_filepath + lock_extension
-                    if os.path.exists(locak_chunk_path):
-                        os.remove(locak_chunk_path)
-                except FileNotFoundError:
-                    pass
+        self._item_loader.delete(chunk_index, chunk_filepath)
+
+        if _DEBUG:
+            print(f"Deleted {chunk_filepath} by {self._rank or 0}. Debug: {can_delete_chunk}")
+
+        for lock_extension in [".lock", ".cnt.lock"]:
+            try:
+                locak_chunk_path = chunk_filepath + lock_extension
+                if os.path.exists(locak_chunk_path):
+                    os.remove(locak_chunk_path)
+            except FileNotFoundError:
+                pass
 
     def stop(self) -> None:
         """Receive the list of the chunk indices to download for the current epoch."""
@@ -370,6 +373,7 @@ class BinaryReader:
             item = self._item_loader.load_item_from_chunk(
                 index.index, index.chunk_index, chunk_filepath, begin, filesize_bytes
             )
+
         # We need to request deletion after the latest element has been loaded.
         # Otherwise, this could trigger segmentation fault error depending on the item loader used.
         if (
@@ -381,6 +385,8 @@ class BinaryReader:
             assert self._last_chunk_index is not None
 
             # inform the chunk has been completely consumed
+            if self.config._downloader:
+                self._prepare_thread._decrement_local_lock(self._last_chunk_index)
             self._prepare_thread.delete([self._last_chunk_index])
 
         if index.chunk_index != self._last_chunk_index:
@@ -393,6 +399,7 @@ class BinaryReader:
 
         if index.is_last_index and self._prepare_thread:
             # inform the thread it is time to stop
+            self._prepare_thread._decrement_local_lock(index.chunk_index)
             self._prepare_thread.stop()
             self._prepare_thread = None
 

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -94,20 +94,17 @@ class PrepareChunksThread(Thread):
         countpath = chunkpath + ".cnt"
         if not os.path.exists(countpath):
             return 0
-        else:
-            with open(countpath, "r") as count_f:
-                try:
-                    return int(count_f.read().strip())
-                except Exception:
-                    return 1
+        with open(countpath) as count_f:
+            try:
+                return int(count_f.read().strip())
+            except Exception:
+                return 1
 
     def _decrement_local_lock(self, chunk_index: str) -> int:
         """Remove a count from the local lock, return the remaining count"""
         chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
         countpath = chunk_filepath + ".cnt"
-        with suppress(Timeout), FileLock(
-            countpath + ".lock", timeout=3
-        ):
+        with suppress(Timeout), FileLock(countpath + ".lock", timeout=3):
             if not os.path.exists(countpath):
                 return 0
             with open(countpath) as count_f:
@@ -130,7 +127,7 @@ class PrepareChunksThread(Thread):
             chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
 
             remaining_locks = self._remaining_locks(chunk_filepath)
-            if remaining_locks > 0: # Can't delete this, something has it
+            if remaining_locks > 0:  # Can't delete this, something has it
                 if _DEBUG:
                     print(f"Skip delete {chunk_filepath} by {self._rank}, current lock count: {remaining_locks}")
                 return

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -115,8 +115,11 @@ class PrepareChunksThread(Thread):
                     curr_count = 1
             curr_count -= 1
             if curr_count <= 0:
-                os.remove(countpath)
-                os.remove(countpath + ".lock")
+                with contextlib.suppress(FileNotFoundError, PermissionError):
+                    os.remove(countpath)
+
+                with contextlib.suppress(FileNotFoundError, PermissionError):
+                    os.remove(countpath + ".lock")
             else:
                 with open(countpath, "w+") as count_f:
                     count_f.write(str(curr_count))

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -129,7 +129,8 @@ class PrepareChunksThread(Thread):
         if self._config.can_delete(chunk_index):
             chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
 
-            if self._remaining_locks(chunk_filepath) > 0: # Can't delete this, something has it
+            remaining_locks = self._remaining_locks(chunk_filepath)
+            if remaining_locks > 0: # Can't delete this, something has it
                 if _DEBUG:
                     print(f"Skip delete {chunk_filepath} by {self._rank}, current lock count: {remaining_locks}")
                 return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock
 import pytest
 import torch.distributed
 
+from litdata.constants import _POLARS_AVAILABLE
 from litdata.streaming.reader import PrepareChunksThread
 
 
@@ -135,14 +136,15 @@ def pq_data():
 
 @pytest.fixture
 def write_pq_data(pq_data, tmp_path):
-    import polars as pl
+    if _POLARS_AVAILABLE:
+        import polars as pl
 
-    os.mkdir(os.path.join(tmp_path, "pq-dataset"))
+        os.mkdir(os.path.join(tmp_path, "pq-dataset"))
 
-    for i in range(5):
-        df = pl.DataFrame(pq_data)
-        file_path = os.path.join(tmp_path, "pq-dataset", f"tmp-{i}.parquet")
-        df.write_parquet(file_path)
+        for i in range(5):
+            df = pl.DataFrame(pq_data)
+            file_path = os.path.join(tmp_path, "pq-dataset", f"tmp-{i}.parquet")
+            df.write_parquet(file_path)
 
 
 @pytest.fixture

--- a/tests/processing/test_functions.py
+++ b/tests/processing/test_functions.py
@@ -501,12 +501,13 @@ def test_optimize_race_condition(tmpdir):
     #     "curl https://www.gutenberg.org/cache/epub/24440/pg24440.txt --output tempdir/custom_texts/book1.txt",
     #     "curl https://www.gutenberg.org/cache/epub/26393/pg26393.txt --output tempdir/custom_texts/book2.txt",
     # ]
+    # The files were moved to S3
     shutil.rmtree(f"{tmpdir}/custom_texts", ignore_errors=True)
     os.makedirs(f"{tmpdir}/custom_texts", exist_ok=True)
 
     urls = [
-        "https://www.gutenberg.org/cache/epub/24440/pg24440.txt",
-        "https://www.gutenberg.org/cache/epub/26393/pg26393.txt",
+        "https://pl-flash-data.s3.us-east-1.amazonaws.com/pg24440.txt",
+        "https://pl-flash-data.s3.us-east-1.amazonaws.com/pg26393.txt",
     ]
 
     for i, url in enumerate(urls):
@@ -518,12 +519,7 @@ def test_optimize_race_condition(tmpdir):
                 for chunk in r.iter_content(chunk_size=8192):
                     f.write(chunk)
 
-    print("=" * 100)
-
     train_files = sorted(glob.glob(str(Path(f"{tmpdir}/custom_texts") / "*.txt")))
-    print("=" * 100)
-    print(train_files)
-    print("=" * 100)
     optimize(
         fn=tokenize,
         inputs=train_files,

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -11,7 +11,7 @@ from litdata.streaming.item_loader import PyTreeLoader
 from litdata.streaming.reader import _END_TOKEN, PrepareChunksThread, _get_folder_size
 from litdata.streaming.resolver import Dir
 from litdata.utilities.env import _DistributedEnv
-from tests.streaming.utils import filter_lock_files
+from tests.streaming.utils import filter_lock_files, get_lock_files
 
 
 def test_reader_chunk_removal(tmpdir):
@@ -35,6 +35,7 @@ def test_reader_chunk_removal(tmpdir):
         assert cache[index] == i
 
     assert len(filter_lock_files(os.listdir(cache_dir))) == 14
+    assert len(get_lock_files(os.listdir(cache_dir))) == 0
 
     cache = Cache(input_dir=Dir(path=cache_dir, url=remote_dir), chunk_size=2, max_cache_size=2800)
 
@@ -42,7 +43,7 @@ def test_reader_chunk_removal(tmpdir):
     os.makedirs(cache_dir, exist_ok=True)
 
     for i in range(25):
-        assert len(filter_lock_files(os.listdir(cache_dir))) <= 3
+        # assert len(filter_lock_files(os.listdir(cache_dir))) <= 7
         index = ChunkedIndex(*cache._get_chunk_index_from_index(i), is_last_index=i == 24)
         assert cache[index] == i
 

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -50,6 +50,42 @@ def test_reader_chunk_removal(tmpdir):
     assert len(filter_lock_files(os.listdir(cache_dir))) in [2, 3]
 
 
+def test_reader_chunk_removal_compressed(tmpdir):
+    cache_dir = os.path.join(tmpdir, "cache_dir")
+    remote_dir = os.path.join(tmpdir, "remote_dir")
+    os.makedirs(cache_dir, exist_ok=True)
+    cache = Cache(input_dir=Dir(path=cache_dir, url=remote_dir), chunk_size=2, max_cache_size=28020, compression="zstd")
+
+    for i in range(25):
+        cache[i] = i
+
+    cache.done()
+    cache.merge()
+
+    shutil.copytree(cache_dir, remote_dir)
+    shutil.rmtree(cache_dir)
+    os.makedirs(cache_dir, exist_ok=True)
+
+    for i in range(25):
+        index = ChunkedIndex(*cache._get_chunk_index_from_index(i), is_last_index=i == 24)
+        assert cache[index] == i
+
+    assert len(filter_lock_files(os.listdir(cache_dir))) == 14
+    assert len(get_lock_files(os.listdir(cache_dir))) == 0
+
+    cache = Cache(input_dir=Dir(path=cache_dir, url=remote_dir), chunk_size=2, max_cache_size=2800, compression="zstd")
+
+    shutil.rmtree(cache_dir)
+    os.makedirs(cache_dir, exist_ok=True)
+
+    for i in range(25):
+        assert len(filter_lock_files(os.listdir(cache_dir))) <= 3
+        index = ChunkedIndex(*cache._get_chunk_index_from_index(i), is_last_index=i == 24)
+        assert cache[index] == i
+
+    assert len(filter_lock_files(os.listdir(cache_dir))) in [2, 3]
+
+
 def test_get_folder_size(tmpdir):
     array = np.zeros((10, 10))
 

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -43,7 +43,7 @@ def test_reader_chunk_removal(tmpdir):
     os.makedirs(cache_dir, exist_ok=True)
 
     for i in range(25):
-        # assert len(filter_lock_files(os.listdir(cache_dir))) <= 7
+        assert len(filter_lock_files(os.listdir(cache_dir))) <= 3
         index = ChunkedIndex(*cache._get_chunk_index_from_index(i), is_last_index=i == 24)
         assert cache[index] == i
 

--- a/tests/streaming/utils.py
+++ b/tests/streaming/utils.py
@@ -1,2 +1,6 @@
 def filter_lock_files(files):
-    return [f for f in files if not f.endswith(".lock")]
+    return [f for f in files if not f.endswith(".lock") and not f.endswith(".cnt")]
+
+
+def get_lock_files(files):
+    return [f for f in files if f.endswith(".lock") or f.endswith("cnt")]

--- a/tests/streaming/utils.py
+++ b/tests/streaming/utils.py
@@ -3,4 +3,4 @@ def filter_lock_files(files):
 
 
 def get_lock_files(files):
-    return [f for f in files if f.endswith(".lock") or f.endswith("cnt")]
+    return [f for f in files if f.endswith((".lock", ".cnt"))]

--- a/tests/streaming/utils.py
+++ b/tests/streaming/utils.py
@@ -1,5 +1,5 @@
 def filter_lock_files(files):
-    return [f for f in files if not f.endswith(".lock") and not f.endswith(".cnt")]
+    return [f for f in files if not f.endswith((".lock", ".cnt"))]
 
 
 def get_lock_files(files):


### PR DESCRIPTION

<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #408.

The basic approach is to be _much_ more strict at tracking the current number of readers that expect a specific file to exist, incrementing a lock when these are downloaded (or requested), and decrementing the lock whenever a reader is "done" with a shard.

At the moment it _does_ lead to stable multi-node runs that share the same cache, however mostly due to the fact that the majority of files are never allowed to delete, as there are more lock calls than unlock calls. Debugging this now. This suggests that it is the single lock limitation that is causing the underlying multi-node issue, and getting the rest of this correct should resolve it overall.

This PR doesn't address the unzipping part, which likely just needs a timeout.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
