### PR TITLE
Fix: Allow using `Machine` types in `map`

### DIFF
--- a/src/litdata/processing/functions.py
+++ b/src/litdata/processing/functions.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from functools import partial
 from pathlib import Path
 from types import FunctionType
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union
 from urllib import parse
 
 import torch
@@ -51,6 +51,9 @@ from litdata.streaming.resolver import (
 from litdata.utilities._pytree import tree_flatten
 from litdata.utilities.encryption import Encryption
 from litdata.utilities.format import _get_tqdm_iterator_if_available
+
+if TYPE_CHECKING:
+    from lightning_sdk import Machine
 
 
 def _is_remote_file(path: str) -> bool:
@@ -194,7 +197,7 @@ def map(
     num_workers: Optional[int] = None,
     fast_dev_run: Union[bool, int] = False,
     num_nodes: Optional[int] = None,
-    machine: Optional[str] = None,
+    machine: Optional[Union["Machine", str]] = None,
     num_downloaders: Optional[int] = None,
     num_uploaders: Optional[int] = None,
     reorder_files: bool = True,
@@ -312,7 +315,7 @@ def optimize(
     num_workers: Optional[int] = None,
     fast_dev_run: bool = False,
     num_nodes: Optional[int] = None,
-    machine: Optional[str] = None,
+    machine: Optional[Union["Machine", str]] = None,
     num_downloaders: Optional[int] = None,
     num_uploaders: Optional[int] = None,
     reorder_files: bool = True,

--- a/src/litdata/streaming/resolver.py
+++ b/src/litdata/streaming/resolver.py
@@ -366,7 +366,7 @@ def _resolve_time_template(path: str) -> str:
 def _execute(
     name: str,
     num_nodes: int,
-    machine: Optional["Machine"] = None,
+    machine: Optional[Union["Machine", str]] = None,
     command: Optional[str] = None,
     interruptible: bool = False,
 ) -> None:


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes typing issues with the latest SDK. In recent versions of `lightning_sdk` the Machine type has changed a bit so things like `map(..., machine="CPU")` won't work and need to be `map(..., machine=Machine.CPU)`. This PR just updates the type annotations to properly reflect the machine types you can use.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
