### PR TITLE
🛠️ Fix: Ensure `chunk_bytes` in `index.json` matches actual chunk file size

### DIFF
--- a/src/litdata/streaming/writer.py
+++ b/src/litdata/streaming/writer.py
@@ -235,12 +235,11 @@ class BinaryWriter:
         sample_data = b"".join([item.data for item in items])
         data = num_items.tobytes() + offsets.tobytes() + sample_data
 
-        current_chunk_bytes = sum([item.bytes for item in items])
-
         # Whether to encrypt the data at the chunk level
         if self._encryption and self._encryption.level == EncryptionLevel.CHUNK:
             data = self._encryption.encrypt(data)
-            current_chunk_bytes = len(data)
+
+        current_chunk_bytes = len(data)
 
         if self._chunk_bytes and current_chunk_bytes > self._chunk_bytes:
             warnings.warn(

--- a/tests/streaming/test_writer.py
+++ b/tests/streaming/test_writer.py
@@ -251,6 +251,27 @@ def test_writer_unordered_indexes(tmpdir):
     assert data["chunks"][2]["chunk_size"] == 2
 
 
+def test_chunk_bytes_consistency(tmpdir):
+    cache_dir = os.path.join(tmpdir, "chunks")
+    os.makedirs(cache_dir, exist_ok=True)
+
+    binary_writer = BinaryWriter(cache_dir, chunk_size=5)
+
+    for i in range(100):
+        binary_writer[i] = i
+
+    binary_writer.done()
+    binary_writer.merge()
+
+    with open(os.path.join(cache_dir, "index.json")) as f:
+        config_data = json.load(f)
+
+    for chunk in config_data["chunks"]:
+        chunk_file = os.path.join(cache_dir, chunk["filename"])
+        chunk_size = os.path.getsize(chunk_file)
+        assert chunk_size == chunk["chunk_bytes"]
+
+
 def test_writer_save_checkpoint(tmpdir):
     cache_dir = os.path.join(tmpdir, "chunks")
     os.makedirs(cache_dir, exist_ok=True)


### PR DESCRIPTION
## What does this PR do?
This PR fixes the inconsistency between the `chunk_bytes` value in index.json and the actual file size of chunk files.

Fixes #477.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
