### PR TITLE
upd: Add hf file download progress and update local file path

### DIFF
--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -12,10 +12,10 @@
 # limitations under the License.
 
 import contextlib
+import logging
 import os
 import warnings
 from contextlib import suppress
-from logging import Logger
 from queue import Empty, Queue
 from threading import Event, Thread
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -33,7 +33,7 @@ from litdata.utilities.env import _DistributedEnv, _WorkerEnv
 warnings.filterwarnings("ignore", message=".*The given buffer is not writable.*")
 
 
-logger = Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 _END_TOKEN = "END"  # noqa: S105
@@ -453,7 +453,9 @@ def _get_folder_size(path: str, config: ChunksConfig) -> int:
                 size += config.filename_to_size_map[filename]
         elif not filename.endswith((".cnt", ".lock", ".json", ".zstd.bin")):
             # ignore .cnt, .lock, .json and .zstd files for warning
-            logger.warning(f"File {filename} is not a valid chunk file. It will be ignored.")
+            logger.warning(
+                f"Skipping {filename}: Not a valid chunk file. It will be excluded from cache size calculation."
+            )
     return size
 
 

--- a/src/litdata/streaming/writer.py
+++ b/src/litdata/streaming/writer.py
@@ -573,14 +573,14 @@ def index_parquet_dataset(
     }
 
     pq_dir_class = get_parquet_indexer_cls(pq_dir_url, cache_dir, storage_options, remove_after_indexing, num_workers)
+
     if _TQDM_AVAILABLE:
         from tqdm.auto import tqdm as _tqdm
 
         pbar = _tqdm(
-            desc="Progress",
+            desc="Indexing progress",
             total=len(pq_dir_class.files),
             smoothing=0,
-            position=-1,
             mininterval=1,
             leave=True,
             dynamic_ncols=True,

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -13,11 +13,7 @@ from time import sleep, time
 from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 from urllib import parse
 
-from litdata.constants import (
-    _FSSPEC_AVAILABLE,
-    _HF_HUB_AVAILABLE,
-    _INDEX_FILENAME,
-)
+from litdata.constants import _FSSPEC_AVAILABLE, _HF_HUB_AVAILABLE, _INDEX_FILENAME, _TQDM_AVAILABLE
 from litdata.streaming.resolver import Dir, _resolve_dir
 
 
@@ -254,9 +250,9 @@ class HFParquetDir(ParquetDir):
     def task(self, _file: str) -> None:
         assert isinstance(_file, str)
         assert self.cache_path is not None
-
         if _file.endswith(".parquet"):
-            local_path = os.path.join(self.cache_path, _file)
+            file_name = os.path.basename(_file)
+            local_path = os.path.join(self.cache_path, file_name)
             os.makedirs(os.path.dirname(local_path), exist_ok=True)
             temp_path = local_path + ".tmp"  # Avoid partial writes
             # if an existing temp file is present, means its corrupted
@@ -264,10 +260,21 @@ class HFParquetDir(ParquetDir):
                 os.remove(temp_path)
 
             with self.fs.open(_file, "rb") as cloud_file, open(temp_path, "wb") as local_file:
+                if _TQDM_AVAILABLE:
+                    from tqdm.auto import tqdm as _tqdm
+
+                    file_size = self.fs.info(_file)["size"]
+                    desc = f"Downloading {file_name}"
+                    pbar = _tqdm(desc=desc, total=file_size, unit="B", unit_scale=True)
+
                 for chunk in iter(lambda: cloud_file.read(4096), b""):  # Read in 4KB chunks
                     local_file.write(chunk)
+
+                    if _TQDM_AVAILABLE:
+                        pbar.update(len(chunk))
+
             os.rename(temp_path, local_path)  # Atomic move after successful write
-            self.process_queue.put_nowait((_file, local_path))
+            self.process_queue.put_nowait((file_name, local_path))
 
     def write_index(self, chunks_info: List[Dict[str, Any]], config: Dict[str, Any]) -> None:
         assert self.cache_path is not None

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -264,8 +264,7 @@ class HFParquetDir(ParquetDir):
                     from tqdm.auto import tqdm as _tqdm
 
                     file_size = self.fs.info(_file)["size"]
-                    desc = f"Downloading {file_name}"
-                    pbar = _tqdm(desc=desc, total=file_size, unit="B", unit_scale=True)
+                    pbar = _tqdm(desc=f"Downloading {file_name}", total=file_size, unit="B", unit_scale=True)
 
                 for chunk in iter(lambda: cloud_file.read(4096), b""):  # Read in 4KB chunks
                     local_file.write(chunk)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,6 +181,9 @@ def huggingface_hub_mock(monkeypatch, write_pq_data, tmp_path):
     hf_fs_mock = Mock()
     hf_fs_mock.ls = Mock(side_effect=lambda *args, **kwargs: os.listdir(os.path.join(tmp_path, "pq-dataset")))
     hf_fs_mock.open = Mock(side_effect=mock_open)
+    hf_fs_mock.info = Mock(
+        side_effect=lambda filename: {"size": os.path.getsize(os.path.join(tmp_path, "pq-dataset", filename))}
+    )
     huggingface_hub.HfFileSystem = Mock(return_value=hf_fs_mock)
 
     return huggingface_hub

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -3,8 +3,6 @@ import os
 import shutil
 from time import sleep
 
-import pytest
-
 from litdata.streaming import reader
 from litdata.streaming.cache import Cache
 from litdata.streaming.config import ChunkedIndex
@@ -134,9 +132,9 @@ def test_get_folder_size(tmpdir, caplog):
     assert len(caplog.messages) == 1
 
     # Assert that a warning was logged
-    assert any(f"Skipping {file_name}: Not a valid chunk file." in record.message for record in caplog.records), (
-        "Expected warning about an invalid chunk file was not logged"
-    )
+    assert any(
+        f"Skipping {file_name}: Not a valid chunk file." in record.message for record in caplog.records
+    ), "Expected warning about an invalid chunk file was not logged"
 
 
 def test_prepare_chunks_thread_eviction(tmpdir, monkeypatch):

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -1,12 +1,15 @@
+import logging
 import os
 import shutil
 from time import sleep
+
+import pytest
 
 from litdata.streaming import reader
 from litdata.streaming.cache import Cache
 from litdata.streaming.config import ChunkedIndex
 from litdata.streaming.item_loader import PyTreeLoader
-from litdata.streaming.reader import _END_TOKEN, PrepareChunksThread
+from litdata.streaming.reader import _END_TOKEN, PrepareChunksThread, _get_folder_size
 from litdata.streaming.resolver import Dir
 from litdata.utilities.env import _DistributedEnv
 from tests.streaming.utils import filter_lock_files, get_lock_files
@@ -95,6 +98,45 @@ def test_reader_chunk_removal_compressed(tmpdir):
         assert cache[index] == i
 
     assert len(filter_lock_files(os.listdir(cache_dir))) in [2, 3]
+
+
+def test_get_folder_size(tmpdir, caplog):
+    cache_dir = os.path.join(tmpdir, "cache_dir")
+    cache = Cache(cache_dir, chunk_size=10)
+    for i in range(100):
+        cache[i] = i
+
+    cache.done()
+    cache.merge()
+
+    config = cache._reader._try_load_config()
+
+    with caplog.at_level(logging.WARNING):
+        cache_size = _get_folder_size(cache_dir, config)
+
+    actual_cache_size = 0
+    for file_name in filter_lock_files(os.listdir(cache_dir)):
+        if file_name in config.filename_to_size_map:
+            actual_cache_size += os.path.getsize(os.path.join(cache_dir, file_name))
+
+    assert cache_size == actual_cache_size
+    assert len(caplog.messages) == 0
+
+    # add a txt to the cache dir
+    file_name = "sample.txt"
+    with open(os.path.join(cache_dir, file_name), "w") as f:
+        f.write("sample")
+
+    with caplog.at_level(logging.WARNING):
+        cache_size = _get_folder_size(cache_dir, config)
+
+    assert cache_size == actual_cache_size
+    assert len(caplog.messages) == 1
+
+    # Assert that a warning was logged
+    assert any(f"Skipping {file_name}: Not a valid chunk file." in record.message for record in caplog.records), (
+        "Expected warning about an invalid chunk file was not logged"
+    )
 
 
 def test_prepare_chunks_thread_eviction(tmpdir, monkeypatch):


### PR DESCRIPTION
## What does this PR do?
Adds progress tracking for HF file downloads and  also updates the local cache file path

**Changes:**  
- Added `tqdm` progress tracking for file downloads from huggingface.  
    > For larger files, downloads take longer, and without a progress indicator, it's difficult to know if the process is still running or stalled.
![image](https://github.com/user-attachments/assets/5fb5eacb-48f9-4a3d-b751-e38599cd66e4)

- Simplified local cache path by removing the nested folder structure and storing files directly in the cache folder.
   > This reduces unnecessary subdirectories and makes file management more straightforward. 
![image](https://github.com/user-attachments/assets/cf3f4021-4f21-4ac1-b2f8-4a4643095155)

- Test case for `test_get_folder_size`

Also addresses: #482 ( folder size part)

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
