### PR TITLE
Warn user if `max_cache_size` is less than 25GB in StreamingDataset

### DIFF
--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -451,7 +451,7 @@ def _get_folder_size(path: str, config: ChunksConfig) -> int:
         if filename in config.filename_to_size_map:
             with contextlib.suppress(FileNotFoundError):
                 size += config.filename_to_size_map[filename]
-        elif not filename.endswith((".cnt", ".lock", ".json", ".zstd.bin")):
+        elif not filename.endswith((".cnt", ".lock", ".json", ".zstd.bin", ".tmp")):
             # ignore .cnt, .lock, .json and .zstd files for warning
             logger.warning(
                 f"Skipping {filename}: Not a valid chunk file. It will be excluded from cache size calculation."

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -13,6 +13,7 @@
 
 import json
 import os
+import logging
 import random
 import shutil
 import sys
@@ -117,6 +118,39 @@ def test_streaming_dataset_max_pre_download(tmpdir):
     for i in range(60):
         assert dataset[i] == i
     assert dataset.cache._reader._max_pre_download == 10
+
+
+@pytest.mark.timeout(30)
+def test_streaming_dataset_max_cache_dir(tmpdir, caplog):
+    seed_everything(42)
+
+    cache = Cache(str(tmpdir), chunk_size=10)
+    for i in range(60):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    dataset = StreamingDataset(input_dir=str(tmpdir))
+    assert len(dataset) == 60
+    for i in range(60):
+        assert dataset[i] == i
+
+    with caplog.at_level(logging.WARNING):
+        StreamingDataset(input_dir=str(tmpdir), max_cache_size="25GB")
+        StreamingDataset(input_dir=str(tmpdir), max_cache_size="30GB")
+        StreamingDataset(input_dir=str(tmpdir), max_cache_size="50GB")
+        StreamingDataset(input_dir=str(tmpdir), max_cache_size="100GB")
+    assert len(caplog.messages) == 0
+
+    with caplog.at_level(logging.WARNING):
+        StreamingDataset(input_dir=str(tmpdir), max_cache_size="500MB")
+        StreamingDataset(input_dir=str(tmpdir), max_cache_size="1GB")
+        StreamingDataset(input_dir=str(tmpdir), max_cache_size="10GB")
+        StreamingDataset(input_dir=str(tmpdir), max_cache_size="20GB")
+    assert len(caplog.messages) == 4
+    assert all("The provided `max_cache_size` is less than 25GB." in record.message for record in caplog.records), (
+        "Expected warning about the `max_cache_size` being less than 25GB was not logged"
+    )
 
 
 @pytest.mark.parametrize("drop_last", [False, True])

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -148,9 +148,9 @@ def test_streaming_dataset_max_cache_dir(tmpdir, caplog):
         StreamingDataset(input_dir=str(tmpdir), max_cache_size="10GB")
         StreamingDataset(input_dir=str(tmpdir), max_cache_size="20GB")
     assert len(caplog.messages) == 4
-    assert all(
-        "The provided `max_cache_size` is less than 25GB." in record.message for record in caplog.records
-    ), "Expected warning about the `max_cache_size` being less than 25GB was not logged"
+    assert all("The provided `max_cache_size` is less than 25GB." in record.message for record in caplog.records), (
+        "Expected warning about the `max_cache_size` being less than 25GB was not logged"
+    )
 
 
 @pytest.mark.parametrize("drop_last", [False, True])
@@ -1200,7 +1200,7 @@ def test_dataset_distributed_drop_last(tmpdir, monkeypatch, compression):
     dataset = StreamingDataset(str(tmpdir), drop_last=False)
     assert not dataset.drop_last
 
-    warn_msg = logger_mock.warn._mock_mock_calls[0].args[0]
+    warn_msg = logger_mock.warning._mock_mock_calls[0].args[0]
     expected_warn_msg = (
         "You're operating within a distributed environment and have disabled the `drop_last` option."
         " Please note that this configuration may lead to training interruptions"

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -148,9 +148,9 @@ def test_streaming_dataset_max_cache_dir(tmpdir, caplog):
         StreamingDataset(input_dir=str(tmpdir), max_cache_size="10GB")
         StreamingDataset(input_dir=str(tmpdir), max_cache_size="20GB")
     assert len(caplog.messages) == 4
-    assert all("The provided `max_cache_size` is less than 25GB." in record.message for record in caplog.records), (
-        "Expected warning about the `max_cache_size` being less than 25GB was not logged"
-    )
+    assert all(
+        "The provided `max_cache_size` is less than 25GB." in record.message for record in caplog.records
+    ), "Expected warning about the `max_cache_size` being less than 25GB was not logged"
 
 
 @pytest.mark.parametrize("drop_last", [False, True])

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 import json
-import os
 import logging
+import os
 import random
 import shutil
 import sys
@@ -148,9 +148,9 @@ def test_streaming_dataset_max_cache_dir(tmpdir, caplog):
         StreamingDataset(input_dir=str(tmpdir), max_cache_size="10GB")
         StreamingDataset(input_dir=str(tmpdir), max_cache_size="20GB")
     assert len(caplog.messages) == 4
-    assert all("The provided `max_cache_size` is less than 25GB." in record.message for record in caplog.records), (
-        "Expected warning about the `max_cache_size` being less than 25GB was not logged"
-    )
+    assert all(
+        "The provided `max_cache_size` is less than 25GB." in record.message for record in caplog.records
+    ), "Expected warning about the `max_cache_size` being less than 25GB was not logged"
 
 
 @pytest.mark.parametrize("drop_last", [False, True])


### PR DESCRIPTION
## What does this PR do?
- Warn user about performance implications if max cache size is less than 25GB
- update deprecated `warn` method to `warning`
- Add `.tmp` to ignore files for cache size calculation

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
