### PR TITLE
Add register function for downloader

### DIFF
--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from litdata.constants import _INDEX_FILENAME
 from litdata.streaming.compression import _COMPRESSORS, Compressor
-from litdata.streaming.downloader import get_downloader_cls
+from litdata.streaming.downloader import get_downloader
 from litdata.streaming.item_loader import BaseItemLoader, Interval, PyTreeLoader, TokensLoader
 from litdata.streaming.sampler import ChunkedIndex
 from litdata.streaming.serializers import Serializer
@@ -80,7 +80,7 @@ class ChunksConfig:
         self._downloader = None
 
         if remote_dir:
-            self._downloader = get_downloader_cls(remote_dir, cache_dir, self._chunks, self._storage_options)
+            self._downloader = get_downloader(remote_dir, cache_dir, self._chunks, self._storage_options)
 
         self._compressor_name = self._config["compression"]
         self._compressor: Optional[Compressor] = None
@@ -274,7 +274,7 @@ class ChunksConfig:
                         f"This should not have happened. No index.json file found in cache: {cache_index_filepath}"
                     )
             else:
-                downloader = get_downloader_cls(remote_dir, cache_dir, [], storage_options)
+                downloader = get_downloader(remote_dir, cache_dir, [], storage_options)
                 downloader.download_file(os.path.join(remote_dir, _INDEX_FILENAME), cache_index_filepath)
 
         if not os.path.exists(cache_index_filepath):

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -23,7 +23,6 @@ from litdata import __version__
 from litdata.constants import _INDEX_FILENAME
 from litdata.helpers import _check_version_and_prompt_upgrade
 from litdata.streaming import Cache
-from litdata.streaming.downloader import get_downloader_cls  # noqa: F401
 from litdata.streaming.item_loader import BaseItemLoader, ParquetLoader
 from litdata.streaming.resolver import Dir, _resolve_dir
 from litdata.streaming.sampler import ChunkedIndex

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -249,6 +249,16 @@ _DOWNLOADERS: dict[str, type[Downloader]] = {
 
 
 def register_downloader(prefix: str, downloader_cls: type[Downloader], overwrite=False) -> None:
+    """Register a new downloader class with a specific prefix.
+
+    Args:
+        prefix (str): The prefix associated with the downloader.
+        downloader_cls (type[Downloader]): The downloader class to register.
+        overwrite (bool, optional): Whether to overwrite an existing downloader with the same prefix. Defaults to False.
+
+    Raises:
+        ValueError: If a downloader with the given prefix is already registered and overwrite is False.
+    """
     if prefix in _DOWNLOADERS and not overwrite:
         raise ValueError(f"Downloader with prefix {prefix} already registered.")
 
@@ -256,12 +266,28 @@ def register_downloader(prefix: str, downloader_cls: type[Downloader], overwrite
 
 
 def unregister_downloader(prefix: str) -> None:
+    """Unregister a downloader class associated with a specific prefix.
+
+    Args:
+        prefix (str): The prefix associated with the downloader to unregister.
+    """
     del _DOWNLOADERS[prefix]
 
 
 def get_downloader(
     remote_dir: str, cache_dir: str, chunks: List[Dict[str, Any]], storage_options: Optional[Dict] = {}
 ) -> Downloader:
+    """Get the appropriate downloader instance based on the remote directory prefix.
+
+    Args:
+        remote_dir (str): The remote directory URL.
+        cache_dir (str): The local cache directory.
+        chunks (List[Dict[str, Any]]): List of chunks to managed by the downloader.
+        storage_options (Optional[Dict], optional): Additional storage options. Defaults to {}.
+
+    Returns:
+        Downloader: An instance of the appropriate downloader class.
+    """
     for k, cls in _DOWNLOADERS.items():
         if str(remote_dir).startswith(k):
             return cls(remote_dir, cache_dir, chunks, storage_options)

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -255,6 +255,10 @@ def register_downloader(prefix: str, downloader_cls: type[Downloader], overwrite
     _DOWNLOADERS[prefix] = downloader_cls
 
 
+def unregister_downloader(prefix: str) -> None:
+    del _DOWNLOADERS[prefix]
+
+
 def get_downloader(
     remote_dir: str, cache_dir: str, chunks: List[Dict[str, Any]], storage_options: Optional[Dict] = {}
 ) -> Downloader:

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -248,7 +248,7 @@ _DOWNLOADERS: Dict[str, Type[Downloader]] = {
 }
 
 
-def register_downloader(prefix: str, downloader_cls: Type[Downloader], overwrite=False) -> None:
+def register_downloader(prefix: str, downloader_cls: Type[Downloader], overwrite: bool = False) -> None:
     """Register a new downloader class with a specific prefix.
 
     Args:

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -17,7 +17,7 @@ import shutil
 import subprocess
 from abc import ABC
 from contextlib import suppress
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 from urllib import parse
 
 from filelock import FileLock, Timeout
@@ -239,7 +239,7 @@ class LocalDownloaderWithCache(LocalDownloader):
         super().download_file(remote_filepath, local_filepath)
 
 
-_DOWNLOADERS: dict[str, type[Downloader]] = {
+_DOWNLOADERS: Dict[str, Type[Downloader]] = {
     "s3://": S3Downloader,
     "gs://": GCPDownloader,
     "azure://": AzureDownloader,
@@ -248,7 +248,7 @@ _DOWNLOADERS: dict[str, type[Downloader]] = {
 }
 
 
-def register_downloader(prefix: str, downloader_cls: type[Downloader], overwrite=False) -> None:
+def register_downloader(prefix: str, downloader_cls: Type[Downloader], overwrite=False) -> None:
     """Register a new downloader class with a specific prefix.
 
     Args:

--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 
 from litdata.constants import _DEFAULT_CACHE_DIR, _DEFAULT_LIGHTNING_CACHE_DIR, _INDEX_FILENAME
-from litdata.streaming.downloader import get_downloader_cls
+from litdata.streaming.downloader import get_downloader
 from litdata.streaming.item_loader import BaseItemLoader, TokensLoader
 from litdata.streaming.resolver import Dir, _resolve_dir
 from litdata.utilities.subsample import shuffle_lists_together, subsample_filenames_and_roi
@@ -59,7 +59,7 @@ def subsample_streaming_dataset(
         if index_path is not None:
             copy_index_to_cache_index_filepath(index_path, cache_index_filepath)
         else:
-            downloader = get_downloader_cls(input_dir.url, input_dir.path, [], storage_options)
+            downloader = get_downloader(input_dir.url, input_dir.path, [], storage_options)
             downloader.download_file(os.path.join(input_dir.url, _INDEX_FILENAME), cache_index_filepath)
 
     if not os.path.exists(input_dir.path):
@@ -150,7 +150,7 @@ def _read_updated_at(
             if index_path is not None:
                 copy_index_to_cache_index_filepath(index_path, temp_index_filepath)
             else:
-                downloader = get_downloader_cls(input_dir.url, tmp_directory, [], storage_options)
+                downloader = get_downloader(input_dir.url, tmp_directory, [], storage_options)
                 downloader.download_file(os.path.join(input_dir.url, _INDEX_FILENAME), temp_index_filepath)
             index_json_content = load_index_file(tmp_directory)
 

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -810,7 +810,7 @@ def test_s3_streaming_dataset(monkeypatch):
 
     downloader.download_file = fn
 
-    monkeypatch.setattr(dataset_utilities_module, "get_downloader_cls", mock.MagicMock(return_value=downloader))
+    monkeypatch.setattr(dataset_utilities_module, "get_downloader", mock.MagicMock(return_value=downloader))
 
     dataset = StreamingDataset(input_dir="s3://pl-flash-data/optimized_tiny_imagenet")
     assert dataset.input_dir.url == "s3://pl-flash-data/optimized_tiny_imagenet"
@@ -1057,7 +1057,7 @@ def test_dataset_valid_state(tmpdir, monkeypatch):
     downloader.download_file = fn
 
     monkeypatch.setattr(resolver_module, "_resolve_datasets", mock_resolve_dataset)
-    monkeypatch.setattr(dataset_utilities_module, "get_downloader_cls", mock.MagicMock(return_value=downloader))
+    monkeypatch.setattr(dataset_utilities_module, "get_downloader", mock.MagicMock(return_value=downloader))
 
     data_dir = os.path.join(tmpdir, "data")
     cache_dir = os.path.join(tmpdir, "cache_dir")


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

1. Add a method `register_downloader` to allow registering a new DOWNLOADER. If `overwrite=False`, it will raise error when a prefix is set twice.
2. Remove `LocalDownloader` from `_DOWNLOADERS` since "" will match any prefix. Practically made it the fallback of everything. Because `dict` is ordered, so it will stop the forloop in `get_downloader` before it can get to any newly registered downloader.
3. Add `unregiester_downloader` to unregister a downloader (for cleanup?)
4. Rename `get_downloader_cls` to `get_downloader` because the method return a downloader object not `type[Downloader]`.

Fixes https://github.com/Lightning-AI/litdata/issues/495

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
