### PR TITLE
Update `_get_folder_size`: Reduce Logs noise and switch to `os.scandir`

### DIFF
--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -441,21 +441,50 @@ class BinaryReader:
 
 
 def _get_folder_size(path: str, config: ChunksConfig) -> int:
-    """Collect the size of each files within a folder.
+    """Calculate the total size of files in a directory based on specific rules.
 
-    This method is robust to file deletion races
+    This method is robust to file deletion races.
+
+    Args:
+        path (str): Directory path to scan.
+        config (ChunksConfig): Configuration object containing filename_to_size_map.
+
+    Returns:
+        int: Total size of valid files in bytes.
 
     """
     size = 0
-    for filename in os.listdir(path):
-        if filename in config.filename_to_size_map:
-            with contextlib.suppress(FileNotFoundError):
+    ignored_extensions = (".cnt", ".lock", ".json", ".zstd.bin")
+
+    # os.scan_dir is more efficient than os.listdir
+    with os.scandir(path) as dir_entries:
+        for entry in dir_entries:
+            # skip directories and symlinks
+            if not entry.is_file(follow_symlinks=False):
+                continue
+
+            filename = entry.name
+
+            # use size from config if available
+            if filename in config.filename_to_size_map:
                 size += config.filename_to_size_map[filename]
-        elif not filename.endswith((".cnt", ".lock", ".json", ".zstd.bin", ".tmp")):
-            # ignore .cnt, .lock, .json and .zstd files for warning
-            logger.warning(
-                f"Skipping {filename}: Not a valid chunk file. It will be excluded from cache size calculation."
-            )
+
+            # silently ignore specified extensions
+            elif filename.endswith(ignored_extensions):
+                continue
+
+            # handle temporary files containing '.bin'
+            elif ".bin" in filename:
+                with contextlib.suppress(FileNotFoundError):
+                    size += entry.stat(follow_symlinks=False).st_size
+
+            # warn about unrecognized files
+            else:
+                logger.warning(
+                    f"Ignoring '{filename}': "
+                    "This file doesn't appear to be a valid chunk file and has been excluded from the size calculation."
+                )
+
     return size
 
 

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -120,10 +120,13 @@ def test_get_folder_size(tmpdir, caplog):
     assert cache_size == actual_cache_size
     assert len(caplog.messages) == 0
 
-    # add a txt to the cache dir
-    file_name = "sample.txt"
-    with open(os.path.join(cache_dir, file_name), "w") as f:
-        f.write("sample")
+    # add some extra files to the cache directory
+    file_names = ["sample.txt", "sample.bin", "sample.bin.tmp", "sample.bin.ABCD", "sample.binEFGH"]
+    for file_name in file_names:
+        with open(os.path.join(cache_dir, file_name), "w") as f:
+            f.write("sample")
+        if file_name != "sample.txt":
+            actual_cache_size += os.path.getsize(os.path.join(cache_dir, file_name))
 
     with caplog.at_level(logging.WARNING):
         cache_size = _get_folder_size(cache_dir, config)
@@ -133,7 +136,7 @@ def test_get_folder_size(tmpdir, caplog):
 
     # Assert that a warning was logged
     assert any(
-        f"Ignoring '{file_name}': This file doesn't appear to be a valid chunk file" in record.message
+        "Ignoring 'sample.txt': This file doesn't appear to be a valid chunk file" in record.message
         for record in caplog.records
     ), "Expected warning about an invalid chunk file was not logged"
 

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -133,7 +133,8 @@ def test_get_folder_size(tmpdir, caplog):
 
     # Assert that a warning was logged
     assert any(
-        f"Skipping {file_name}: Not a valid chunk file." in record.message for record in caplog.records
+        f"Ignoring '{file_name}': This file doesn't appear to be a valid chunk file" in record.message
+        for record in caplog.records
     ), "Expected warning about an invalid chunk file was not logged"
 
 


### PR DESCRIPTION
## What does this PR do?
Improves `_get_folder_size` by:
- Switching to `os.scandir` for better performance.
- Including temporary `.bin` files in size calc without logging.
- Reducing log noise by skipping temp file warnings.

Fixes #492.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
