### PR TITLE
Feat: Update indexing of parquet dataset and also add streaming support to huggingface datasets

### DIFF
--- a/src/litdata/constants.py
+++ b/src/litdata/constants.py
@@ -38,6 +38,7 @@ _AZURE_STORAGE_AVAILABLE = RequirementCache("azure.storage.blob")
 _TQDM_AVAILABLE = RequirementCache("tqdm")
 _LIGHTNING_SDK_AVAILABLE = RequirementCache("lightning_sdk")
 _HF_HUB_AVAILABLE = RequirementCache("huggingface_hub")
+_PYARROW_AVAILABLE = RequirementCache("pyarrow")
 _POLARS_AVAILABLE = RequirementCache("polars>1.0.0")
 _DEBUG = bool(int(os.getenv("DEBUG", "0")))
 

--- a/src/litdata/processing/readers.py
+++ b/src/litdata/processing/readers.py
@@ -16,12 +16,9 @@ import os
 from abc import ABC, abstractmethod
 from typing import Any, List
 
-from lightning_utilities.core.imports import RequirementCache
-
+from litdata.constants import _PYARROW_AVAILABLE
 from litdata.streaming.dataloader import StreamingDataLoader
 from litdata.utilities.format import _get_tqdm_iterator_if_available
-
-_PYARROW_AVAILABLE = RequirementCache("pyarrow")
 
 
 class BaseReader(ABC):

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -111,6 +111,13 @@ class StreamingDataset(IterableDataset):
                     "The item_loader must be an instance of ParquetLoader. "
                     "Please provide a valid ParquetLoader instance."
                 )
+
+            if item_loader is not None and item_loader._low_memory and shuffle:
+                raise ValueError(
+                    "You have enabled shuffling when using low memory with ParquetLoader. "
+                    "This configuration may lead to performance issues during the training process. "
+                    "Consider disabling shuffling or using a ParquetLoader without low memory mode."
+                )
             item_loader = item_loader or ParquetLoader()
 
         self.input_dir = input_dir

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -100,11 +100,18 @@ class StreamingDataset(IterableDataset):
 
         if input_dir.url is not None and input_dir.url.startswith("hf://"):
             if index_path is None:
-                # no index path provide, load from cache, or try indexing on the go.
+                # No index_path was provided. Attempt to load it from cache or generate it dynamically on the fly.
                 index_path = index_hf_dataset(input_dir.url)
                 cache_dir.path = index_path
                 input_dir.path = index_path
-            item_loader = ParquetLoader()
+
+            if item_loader is not None and not isinstance(item_loader, ParquetLoader):
+                raise ValueError(
+                    "Invalid item_loader for hf://datasets. "
+                    "The item_loader must be an instance of ParquetLoader. "
+                    "Please provide a valid ParquetLoader instance."
+                )
+            item_loader = item_loader or ParquetLoader()
 
         self.input_dir = input_dir
         self.cache_dir = cache_dir
@@ -548,9 +555,7 @@ class StreamingDataset(IterableDataset):
                     "The provided `item_loader` state doesn't match the current one. "
                     f"Found `{self.item_loader.state_dict()}` instead of `{state['item_loader']}`."
                 )
-            logger.warning(
-                f"Overriding state item_loader {state['item_loader']} " f"to {self.item_loader.state_dict()}."
-            )
+            logger.warning(f"Overriding state item_loader {state['item_loader']} to {self.item_loader.state_dict()}.")
             state["item_loader"] = self.item_loader.state_dict()
 
         if state["drop_last"] != self.drop_last:

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -252,7 +252,7 @@ class HFDownloader(Downloader):
             )
             if downloaded_path != local_filepath and os.path.exists(downloaded_path):
                 temp_file_path = local_filepath + ".tmp"
-                shutil.copy2(downloaded_path, temp_file_path)
+                shutil.copyfile(downloaded_path, temp_file_path)
                 os.rename(temp_file_path, local_filepath)
 
 

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -249,9 +249,6 @@ class HFDownloader(Downloader):
             )
 
         super().__init__(remote_dir, cache_dir, chunks, storage_options)
-        from huggingface_hub import HfFileSystem
-
-        self.fs = HfFileSystem()
 
     def download_file(self, remote_filepath: str, local_filepath: str) -> None:
         """Download a file from the Hugging Face Hub.

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -15,6 +15,7 @@ import contextlib
 import os
 import shutil
 import subprocess
+import tempfile
 from abc import ABC
 from contextlib import suppress
 from typing import Any, Dict, List, Optional, Type
@@ -57,9 +58,9 @@ class Downloader(ABC):
         local_chunkpath = os.path.join(self._cache_dir, chunk_filename)
         remote_chunkpath = os.path.join(self._remote_dir, chunk_filename)
 
-        self.download_file(remote_chunkpath, local_chunkpath, chunk_filename)
+        self.download_file(remote_chunkpath, local_chunkpath)
 
-    def download_file(self, remote_chunkpath: str, local_chunkpath: str, remote_chunk_filename: str = "") -> None:
+    def download_file(self, remote_chunkpath: str, local_chunkpath: str) -> None:
         pass
 
 
@@ -73,7 +74,7 @@ class S3Downloader(Downloader):
         if not self._s5cmd_available:
             self._client = S3Client(storage_options=self._storage_options)
 
-    def download_file(self, remote_filepath: str, local_filepath: str, remote_chunk_filename: str = "") -> None:
+    def download_file(self, remote_filepath: str, local_filepath: str) -> None:
         obj = parse.urlparse(remote_filepath)
 
         if obj.scheme != "s3":
@@ -128,7 +129,7 @@ class GCPDownloader(Downloader):
 
         super().__init__(remote_dir, cache_dir, chunks, storage_options)
 
-    def download_file(self, remote_filepath: str, local_filepath: str, remote_chunk_filename: str = "") -> None:
+    def download_file(self, remote_filepath: str, local_filepath: str) -> None:
         from google.cloud import storage
 
         obj = parse.urlparse(remote_filepath)
@@ -163,7 +164,7 @@ class AzureDownloader(Downloader):
 
         super().__init__(remote_dir, cache_dir, chunks, storage_options)
 
-    def download_file(self, remote_filepath: str, local_filepath: str, remote_chunk_filename: str = "") -> None:
+    def download_file(self, remote_filepath: str, local_filepath: str) -> None:
         from azure.storage.blob import BlobServiceClient
 
         obj = parse.urlparse(remote_filepath)
@@ -190,7 +191,7 @@ class AzureDownloader(Downloader):
 
 
 class LocalDownloader(Downloader):
-    def download_file(self, remote_filepath: str, local_filepath: str, remote_chunk_filename: str = "") -> None:
+    def download_file(self, remote_filepath: str, local_filepath: str) -> None:
         if not os.path.exists(remote_filepath):
             raise FileNotFoundError(f"The provided remote_path doesn't exist: {remote_filepath}")
 
@@ -222,28 +223,41 @@ class HFDownloader(Downloader):
 
         self.fs = HfFileSystem()
 
-    def download_file(self, remote_filepath: str, local_filepath: str, remote_chunk_filename: str = "") -> None:
-        # for HF dataset downloading, we don't need remote_filepath, but remote_chunk_filename
-        with suppress(Timeout), FileLock(local_filepath + ".lock", timeout=0):
-            temp_path = local_filepath + ".tmp"  # Avoid partial writes
-            try:
-                with self.fs.open(remote_chunk_filename, "rb") as cloud_file, open(temp_path, "wb") as local_file:
-                    for chunk in iter(lambda: cloud_file.read(4096), b""):  # Stream in 4KB chunks local_file.
-                        local_file.write(chunk)
+    def download_file(self, remote_filepath: str, local_filepath: str) -> None:
+        """Download a file from the Hugging Face Hub.
+        The remote_filepath should be in the format `hf://<repo_type>/<repo_org>/<repo_name>/path`. For more
+        information, see
+        https://huggingface.co/docs/huggingface_hub/en/guides/hf_file_system#integrations.
+        """
+        from huggingface_hub import hf_hub_download
 
-                os.rename(temp_path, local_filepath)  # Atomic move after successful write
+        obj = parse.urlparse(remote_filepath)
 
-            except Exception as e:
-                print(f"Error processing {remote_chunk_filename}: {e}")
+        if obj.scheme != "hf":
+            raise ValueError(f"Expected obj.scheme to be `hf`, instead, got {obj.scheme} for remote={remote_filepath}")
 
-            finally:
-                # Ensure cleanup of temp file if an error occurs
-                if os.path.exists(temp_path):
-                    os.remove(temp_path)
+        if os.path.exists(local_filepath):
+            return
+
+        with suppress(Timeout), FileLock(local_filepath + ".lock", timeout=0), tempfile.TemporaryDirectory() as tmpdir:
+            _, _, _, repo_org, repo_name, path = remote_filepath.split("/", 5)
+            repo_id = f"{repo_org}/{repo_name}"
+
+            downloaded_path = hf_hub_download(
+                repo_id,
+                path,
+                cache_dir=tmpdir,
+                repo_type="dataset",
+                **self._storage_options,
+            )
+            if downloaded_path != local_filepath and os.path.exists(downloaded_path):
+                temp_file_path = local_filepath + ".tmp"
+                shutil.copy2(downloaded_path, temp_file_path)
+                os.rename(temp_file_path, local_filepath)
 
 
 class LocalDownloaderWithCache(LocalDownloader):
-    def download_file(self, remote_filepath: str, local_filepath: str, remote_chunk_filename: str = "") -> None:
+    def download_file(self, remote_filepath: str, local_filepath: str) -> None:
         remote_filepath = remote_filepath.replace("local:", "")
         super().download_file(remote_filepath, local_filepath)
 

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -569,7 +569,7 @@ class ParquetLoader(BaseItemLoader):
         """Logic to load the chunk in background to gain some time."""
         import polars as pl
 
-        if chunk_filepath not in self._df:
+        if chunk_filepath not in self._df and os.path.exists(chunk_filepath):
             self._df[chunk_filepath] = pl.scan_parquet(chunk_filepath).collect()
 
     def load_item_from_chunk(

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -615,35 +615,68 @@ class ParquetLoader(BaseItemLoader):
         # relative index of the desired row within the chunk.
         relative_index = index - begin
         if self._low_memory:
-            return self.get_low_memory_df(chunk_index, chunk_filepath, relative_index)
+            return self._get_item_with_low_memory(chunk_index, chunk_filepath, relative_index)
 
-        return self.get_df(chunk_index, chunk_filepath, index).row(relative_index)
+        return self._get_item(chunk_index, chunk_filepath, relative_index)
 
-    def get_low_memory_df(self, chunk_index: int, chunk_filepath: str, row_index: int) -> Any:
+    def _get_item_with_low_memory(self, chunk_index: int, chunk_filepath: str, row_index: int) -> Any:
+        """Retrieve a dataframe row from a parquet chunk in low memory mode.
+
+        This method reads only the necessary row group from the parquet file using PyArrow and Polars,
+        which helps in reducing memory usage.
+
+        Args:
+            chunk_index (int): The index of the chunk to be accessed.
+            chunk_filepath (str): The file path of the parquet chunk.
+            row_index (int): The relative row index within the loaded chunk.
+
+        Returns:
+            Any: The dataframe row corresponding to the specified index.
+        """
         import polars as pl
         import pyarrow.parquet as pq
 
+        # Load the parquet file if not already loaded and keep the handle in memory
         if chunk_index not in self._df:
             self._df[chunk_index] = pq.ParquetFile(chunk_filepath)
 
+        # Determine the row group and the row index within the row group
         num_rows_in_row_group = self._df[chunk_index].metadata.row_group(0).num_rows
         row_group_index = row_index // num_rows_in_row_group
         row_index_in_row_group = row_index % num_rows_in_row_group
 
+        # Check if the row group is already loaded
         if chunk_index in self._row_groups and row_group_index in self._row_groups[chunk_index]:
-            table = self._row_groups[chunk_index][row_group_index]
+            df = self._row_groups[chunk_index][row_group_index]
         else:
+            # Read the row group and convert it to a Polars dataframe
             row_group = self._df[chunk_index].read_row_group(row_group_index)
-            table = pl.from_arrow(row_group)
-            self._row_groups[chunk_index] = {row_group_index: table}
-        return table.row(row_index_in_row_group)  # type: ignore
+            df = pl.from_arrow(row_group)
+            self._row_groups[chunk_index] = {row_group_index: df}
 
-    def get_df(self, chunk_index: int, chunk_filepath: str, index: int) -> Any:
+        # Return the specific row from the dataframe
+        return df.row(row_index_in_row_group)  # type: ignore
+
+    def _get_item(self, chunk_index: int, chunk_filepath: str, index: int) -> Any:
+        """Retrieve a dataframe row from a parquet chunk by loading the entire chunk into memory.
+
+        Note:
+            This method reads the complete parquet file using Polars. Exercise caution with large files as it
+            may significantly increase memory usage.
+
+        Args:
+            chunk_index (int): The index of the chunk to be accessed.
+            chunk_filepath (str): The file path of the parquet chunk.
+            index (int): The relative row index within the loaded chunk.
+
+        Returns:
+            Any: The dataframe row corresponding to the specified index.
+        """
         import polars as pl
 
         if chunk_index not in self._df:
             self._df[chunk_index] = pl.scan_parquet(chunk_filepath, low_memory=True).collect()
-        return self._df[chunk_index]
+        return self._df[chunk_index].row(index)
 
     def delete(self, chunk_index: int, chunk_filepath: str) -> None:
         """Delete a chunk from the local filesystem."""

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -567,7 +567,10 @@ class ParquetLoader(BaseItemLoader):
 
     def pre_load_chunk(self, chunk_index: int, chunk_filepath: str) -> None:
         """Logic to load the chunk in background to gain some time."""
-        self.get_df(chunk_index, chunk_filepath)
+        import polars as pl
+
+        if chunk_index not in self._df and os.path.exists(chunk_filepath):
+            self._df[chunk_index] = pl.scan_parquet(chunk_filepath, low_memory=True).collect()
 
     def load_item_from_chunk(
         self,
@@ -595,7 +598,7 @@ class ParquetLoader(BaseItemLoader):
     def get_df(self, chunk_index: int, chunk_filepath: str) -> Any:
         import polars as pl
 
-        if chunk_index not in self._df and os.path.exists(chunk_filepath):
+        if chunk_index not in self._df:
             self._df[chunk_index] = pl.scan_parquet(chunk_filepath, low_memory=True).collect()
         return self._df[chunk_index]
 

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -609,5 +609,10 @@ class ParquetLoader(BaseItemLoader):
         if chunk_filepath in self._df:
             del self._df[chunk_filepath]
 
+    def close(self, chunk_index: int) -> None:
+        """Release the memory-mapped file for a specific chunk index."""
+        if chunk_index in self._df:
+            del self._df[chunk_index]
+
     def encode_data(self, data: List[bytes], sizes: List[int], flattened: List[Any]) -> Any:
         pass

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -24,7 +24,7 @@ from filelock import FileLock, Timeout
 
 from litdata.constants import _DEBUG
 from litdata.streaming.config import ChunksConfig, Interval
-from litdata.streaming.item_loader import BaseItemLoader, PyTreeLoader, TokensLoader
+from litdata.streaming.item_loader import BaseItemLoader, ParquetLoader, PyTreeLoader, TokensLoader
 from litdata.streaming.sampler import ChunkedIndex
 from litdata.streaming.serializers import Serializer, _get_serializers
 from litdata.utilities.encryption import Encryption
@@ -401,7 +401,7 @@ class BinaryReader:
 
         if index.chunk_index != self._last_chunk_index:
             # Close the memory-mapped file for the last chunk index
-            if isinstance(self._item_loader, TokensLoader) and self._last_chunk_index is not None:
+            if isinstance(self._item_loader, (TokensLoader, ParquetLoader)) and self._last_chunk_index is not None:
                 self._item_loader.close(self._last_chunk_index)
 
             # track the new chunk index as the latest one

--- a/src/litdata/streaming/writer.py
+++ b/src/litdata/streaming/writer.py
@@ -616,13 +616,21 @@ def index_parquet_dataset(
             dynamic_ncols=True,
             unit="step",
         )
+
+    results = {}
     # iterate the directory and for all files ending in `.parquet` index them
-    for file_name, file_path in pq_dir_class:
-        file_size = os.path.getsize(file_path)
-        pq_polars = pl.scan_parquet(file_path)
-        chunk_dtypes = pq_polars.collect_schema().dtypes()
-        chunk_dtypes = [str(dt) for dt in chunk_dtypes]
-        chunk_size = pq_polars.select(pl.count()).collect().item()
+    for file_name, _file, order in pq_dir_class:
+        if isinstance(_file, str):
+            file_path = _file
+            file_size = os.path.getsize(file_path)
+            pq_polars = pl.scan_parquet(file_path)
+            chunk_dtypes = pq_polars.collect_schema().dtypes()
+            chunk_dtypes = [str(dt) for dt in chunk_dtypes]
+            chunk_size = pq_polars.select(pl.count()).collect().item()
+        else:
+            file_size = _file["chunk_bytes"]
+            chunk_size = _file["chunk_size"]
+            chunk_dtypes = _file["dtypes"]
 
         if len(config["data_format"]) != 0 and config["data_format"] != chunk_dtypes:
             raise Exception(
@@ -636,9 +644,13 @@ def index_parquet_dataset(
             "filename": file_name,
             "dim": None,
         }
-        pq_chunks_info.append(chunk_info)
+        results[order] = chunk_info
         if _TQDM_AVAILABLE:
             pbar.update(1)
 
+    for i in sorted(results.keys()):
+        pq_chunks_info.append(results[i])
+
+    del results
     print(flush=True)  # to prevent truncated printing when using concurrent threads/processes
     pq_dir_class.write_index(pq_chunks_info, config)

--- a/src/litdata/streaming/writer.py
+++ b/src/litdata/streaming/writer.py
@@ -588,8 +588,6 @@ def index_parquet_dataset(
     if not _POLARS_AVAILABLE:
         raise ModuleNotFoundError("Please, run: `pip install polars`")
 
-    import polars as pl
-
     pq_chunks_info = []
     config: Dict[str, Any] = {
         "compression": None,

--- a/src/litdata/utilities/hf_dataset.py
+++ b/src/litdata/utilities/hf_dataset.py
@@ -20,7 +20,7 @@ def index_hf_dataset(hf_url: str) -> str:
         print(f"Found HF index.json file in {cache_index_path}.")
     else:
         print("Indexing HF dataset...")
-        index_parquet_dataset(hf_url, cache_dir, remove_after_indexing=False)
+        index_parquet_dataset(hf_url, cache_dir, remove_after_indexing=False, num_workers=os.cpu_count())
 
     print("=" * 50)
 

--- a/src/litdata/utilities/hf_dataset.py
+++ b/src/litdata/utilities/hf_dataset.py
@@ -29,6 +29,6 @@ def index_hf_dataset(hf_url: str) -> str:
         print(f"Found existing HF {_INDEX_FILENAME} file for {hf_url} at {cache_index_path}.")
     else:
         print(f"Indexing HF dataset from {hf_url} into {cache_index_path}.")
-        index_parquet_dataset(hf_url, cache_dir)
+        index_parquet_dataset(hf_url, cache_dir, num_workers=os.cpu_count())
 
     return cache_dir

--- a/src/litdata/utilities/hf_dataset.py
+++ b/src/litdata/utilities/hf_dataset.py
@@ -8,20 +8,27 @@ from litdata.utilities.parquet import default_cache_dir
 
 
 def index_hf_dataset(hf_url: str) -> str:
+    """Index a Hugging Face dataset and return the cache directory path.
+
+    Args:
+        hf_url (str): The URL of the Hugging Face dataset.
+
+    Returns:
+        str: The path to the cache directory containing the index.
+    """
     if not hf_url.startswith("hf://"):
-        raise ValueError(f"Invalid Hugging Face dataset URL: {hf_url}. Expected URL to start with 'hf://'.")
+        raise ValueError(
+            f"Invalid Hugging Face dataset URL: {hf_url}. "
+            "The URL should start with 'hf://'. Please check the URL and try again."
+        )
 
     cache_dir = default_cache_dir(hf_url)
-
     cache_index_path = os.path.join(cache_dir, _INDEX_FILENAME)
-    print("=" * 50)
 
     if os.path.exists(cache_index_path):
-        print(f"Found HF index.json file in {cache_index_path}.")
+        print(f"Found existing HF {_INDEX_FILENAME} file for {hf_url} at {cache_index_path}.")
     else:
-        print("Indexing HF dataset...")
-        index_parquet_dataset(hf_url, cache_dir, remove_after_indexing=False, num_workers=os.cpu_count())
-
-    print("=" * 50)
+        print(f"Indexing HF dataset from {hf_url} into {cache_index_path}.")
+        index_parquet_dataset(hf_url, cache_dir)
 
     return cache_dir

--- a/src/litdata/utilities/hf_dataset.py
+++ b/src/litdata/utilities/hf_dataset.py
@@ -29,6 +29,6 @@ def index_hf_dataset(hf_url: str) -> str:
         print(f"Found existing HF {_INDEX_FILENAME} file for {hf_url} at {cache_index_path}.")
     else:
         print(f"Indexing HF dataset from {hf_url} into {cache_index_path}.")
-        index_parquet_dataset(hf_url, cache_dir, num_workers=os.cpu_count())
+        index_parquet_dataset(hf_url, cache_dir, num_workers=os.cpu_count() or 4)
 
     return cache_dir

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -351,8 +351,24 @@ def get_parquet_indexer_cls(
 
 
 def default_cache_dir(url: str) -> str:
-    # Hash the URL using SHA256 and take the first 16 characters for brevity
+    """Generate a default cache directory path based on the given URL.
+
+    The directory is created under the user's home directory at
+    ~/.cache/litdata-cache-index-pq if it does not already exist.
+
+    Args:
+        url (str): The URL to be hashed for generating the cache directory path.
+
+    Returns:
+        str: The path to the generated cache directory.
+    """
+    # Hash the URL using SHA256
     url_hash = hashlib.sha256(url.encode()).hexdigest()
+
+    # Generate the cache directory path
     cache_path = os.path.join(os.path.expanduser("~"), ".cache", "litdata-cache-index-pq", url_hash)
-    os.makedirs(cache_path, exist_ok=True)  # Ensure the directory exists
+
+    # Ensure the directory exists
+    os.makedirs(cache_path, exist_ok=True)
+
     return cache_path

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -71,12 +71,12 @@ class LocalParquetDir(ParquetDir):
         storage_options: Optional[Dict] = {},
         num_workers: int = 4,
     ):
-        super().__init__(dir_path, cache_path, storage_options, num_workers)
         if not _PYARROW_AVAILABLE:
             raise ModuleNotFoundError(
                 "The 'pyarrow' module is required for processing Parquet files. "
                 "Please install it by running: `pip install pyarrow`"
             )
+        super().__init__(dir_path, cache_path, storage_options, num_workers)
 
         for _f in os.listdir(self.dir.path):
             if _f.endswith(".parquet"):
@@ -122,8 +122,6 @@ class CloudParquetDir(ParquetDir):
         storage_options: Optional[Dict] = None,
         num_workers: int = 4,
     ):
-        super().__init__(dir_path, cache_path, storage_options, num_workers)
-
         if not _FSSPEC_AVAILABLE:
             raise ModuleNotFoundError(
                 "Support for Indexing cloud parquet files depends on `fsspec`.", "Please, run: `pip install fsspec`"
@@ -133,6 +131,7 @@ class CloudParquetDir(ParquetDir):
                 "The 'pyarrow' module is required for processing Parquet files. "
                 "Please install it by running: `pip install pyarrow`"
             )
+        super().__init__(dir_path, cache_path, storage_options, num_workers)
 
         assert self.dir.url is not None
 
@@ -226,8 +225,6 @@ class HFParquetDir(ParquetDir):
         storage_options: Optional[Dict] = None,
         num_workers: int = 4,
     ):
-        super().__init__(dir_path, cache_path, storage_options, num_workers)
-
         if not _HF_HUB_AVAILABLE:
             raise ModuleNotFoundError(
                 "Support for Indexing HF depends on `huggingface_hub`.", "Please, run: `pip install huggingface_hub"
@@ -237,6 +234,7 @@ class HFParquetDir(ParquetDir):
                 "The 'pyarrow' module is required for processing Parquet files. "
                 "Please install it by running: `pip install pyarrow`"
             )
+        super().__init__(dir_path, cache_path, storage_options, num_workers)
 
         assert self.dir.url is not None
         assert self.dir.url.startswith("hf")

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -4,30 +4,14 @@ import hashlib
 import io
 import json
 import os
-import sys
-import threading
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import suppress
-from queue import Queue
-from time import sleep, time
+from time import time
 from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 from urllib import parse
 
 from litdata.constants import _FSSPEC_AVAILABLE, _HF_HUB_AVAILABLE, _INDEX_FILENAME, _PYARROW_AVAILABLE
 from litdata.streaming.resolver import Dir, _resolve_dir
-
-
-def delete_thread(rmq: Queue) -> None:
-    while True:
-        file_path = rmq.get()
-        if file_path is None:  # Sentinel value to exit
-            break
-        with suppress(FileNotFoundError):
-            os.remove(file_path)
-
-    # before exiting, just sleep for some time, to complete any pending deletions
-    sleep(0.5)
 
 
 class ParquetDir(ABC):
@@ -36,64 +20,47 @@ class ParquetDir(ABC):
         dir_path: Optional[Union[str, Dir]],
         cache_path: Optional[str] = None,
         storage_options: Optional[Dict] = {},
-        remove_after_indexing: bool = True,
         num_workers: int = 4,
     ):
         self.dir = _resolve_dir(dir_path)
         self.cache_path = cache_path
         self.storage_options = storage_options
-        self.remove_after_indexing = remove_after_indexing
         self.files: List[Any] = []
-        self.process_queue: Queue = Queue()
-        self.delete_queue: Queue = Queue()
         self.num_workers = num_workers
 
-    def __iter__(self) -> Generator[Tuple[str, str], None, None]:
-        # start worker in a separate thread, and then read values from `process_queue`, and yield
+    def __iter__(self) -> Generator[Tuple[str, str, int], None, None]:
+        """Iterate over the Parquet files and yield their metadata.
 
-        self.is_delete_thread_running = self.dir.url is not None and self.remove_after_indexing
-
-        if self.is_delete_thread_running:
-            t = threading.Thread(
-                target=delete_thread,
-                name="delete_thread",
-                args=(self.delete_queue,),
-            )
-            t.start()
-
-        t_worker = threading.Thread(
-            target=self.worker,
-            name="worker_thread",
-            args=(),
-        )
-        t_worker.start()
-
-        # TODO: simplify this
-        while True:
-            file_name, file_path, order = self.process_queue.get()
-            if file_name is None and file_path is None:  # Sentinel value to exit
-                break
-            yield file_name, file_path, order
-            if self.is_delete_thread_running:
-                self.delete_queue.put_nowait(file_path)
-
-        if self.is_delete_thread_running:
-            self.delete_queue.put_nowait(None)  # so that it doesn't hang indefinitely
-            t.join()
-
-        t_worker.join()  # should've completed by now. But, just to be on safe side.
-
-    @abstractmethod
-    def task(self, _file: Any, order: int) -> None: ...
-
-    def worker(self) -> None:
+        Yields:
+            Generator[Tuple[str, int], None, None]: A generator yielding tuples of file name, file path, and order.
+        """
         with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
-            for order, _file in enumerate(self.files):
-                executor.submit(self.task, _file, order)
-        self.process_queue.put_nowait((None, None, None))
+            futures = {executor.submit(self.task, _file): (order, _file) for order, _file in enumerate(self.files)}
+            for future in futures:
+                file_metadata = future.result()
+                order, _ = futures[future]
+                yield file_metadata, order
 
     @abstractmethod
-    def write_index(self, chunks_info: List[Dict[str, Any]], config: Dict[str, Any]) -> None: ...
+    def task(self, _file: Any) -> Dict[str, Any] | None: ...
+
+    @abstractmethod
+    def write_index(self, chunks_info: List[Dict[str, Any]], config: Dict[str, Any]) -> None:
+        """Write the index file to the cache directory.
+
+        Args:
+            chunks_info (List[Dict[str, Any]]): List of dictionaries containing chunk metadata.
+            config (Dict[str, Any]): Configuration dictionary containing metadata.
+        """
+        assert self.cache_path is not None, "Cache path is not set."
+        index_file_path = os.path.join(self.cache_path, _INDEX_FILENAME)
+
+        # write to index.json file
+        with open(index_file_path, "w") as f:
+            data = {"chunks": chunks_info, "config": config, "updated_at": str(time())}
+            json.dump(data, f, sort_keys=True)
+
+        print(f"Index file successfully written to: {index_file_path}")
 
 
 class LocalParquetDir(ParquetDir):
@@ -102,35 +69,49 @@ class LocalParquetDir(ParquetDir):
         dir_path: Optional[Union[str, Dir]],
         cache_path: Optional[str] = None,
         storage_options: Optional[Dict] = {},
-        remove_after_indexing: bool = True,
         num_workers: int = 4,
     ):
-        super().__init__(dir_path, cache_path, storage_options, remove_after_indexing, num_workers)
+        super().__init__(dir_path, cache_path, storage_options, num_workers)
+        if not _PYARROW_AVAILABLE:
+            raise ModuleNotFoundError(
+                "The 'pyarrow' module is required for processing Parquet files. "
+                "Please install it by running: `pip install pyarrow`"
+            )
 
         for _f in os.listdir(self.dir.path):
             if _f.endswith(".parquet"):
                 self.files.append(_f)
 
-    def task(self, _file: str, order: int) -> None:
-        assert isinstance(_file, str)
+    def task(self, _file: str) -> Dict[str, Any] | None:
+        """Extract metadata from a Parquet file on the local filesystem."""
+        import pyarrow.parquet as pq
 
+        assert isinstance(_file, str)
         if _file.endswith(".parquet"):
             assert self.dir.path is not None
             assert self.dir.path != "", "Dir path can't be empty"
 
             file_path = os.path.join(self.dir.path, _file)
-            self.process_queue.put_nowait((_file, file_path, order))
+            parquet_file = pq.ParquetFile(file_path)
+            num_rows = parquet_file.metadata.num_rows
+            data_types = [str(col.type) for col in parquet_file.schema_arrow]
+            file_size = os.path.getsize(file_path)
+            file_name = os.path.basename(file_path)
+
+            return {
+                "file_name": file_name,
+                "num_rows": num_rows,
+                "file_size": file_size,
+                "data_types": data_types,
+            }
+
+        return None
 
     def write_index(self, chunks_info: List[Dict[str, Any]], config: Dict[str, Any]) -> None:
-        # write to index.json file
+        """Write the index file to the cache directory."""
         if self.cache_path is None:
             self.cache_path = self.dir.path
-        assert self.cache_path is not None
-        with open(os.path.join(self.cache_path, _INDEX_FILENAME), "w") as f:
-            data = {"chunks": chunks_info, "config": config, "updated_at": str(time())}
-            json.dump(data, f, sort_keys=True)
-
-        print(f"Index file written to: {os.path.join(self.cache_path, _INDEX_FILENAME)}")
+        super().write_index(chunks_info, config)
 
 
 class CloudParquetDir(ParquetDir):
@@ -139,15 +120,19 @@ class CloudParquetDir(ParquetDir):
         dir_path: Optional[Union[str, Dir]],
         cache_path: Optional[str] = None,
         storage_options: Optional[Dict] = None,
-        remove_after_indexing: bool = True,
         num_workers: int = 4,
     ):
+        super().__init__(dir_path, cache_path, storage_options, num_workers)
+
         if not _FSSPEC_AVAILABLE:
             raise ModuleNotFoundError(
                 "Support for Indexing cloud parquet files depends on `fsspec`.", "Please, run: `pip install fsspec`"
             )
-
-        super().__init__(dir_path, cache_path, storage_options, remove_after_indexing, num_workers)
+        if not _PYARROW_AVAILABLE:
+            raise ModuleNotFoundError(
+                "The 'pyarrow' module is required for processing Parquet files. "
+                "Please install it by running: `pip install pyarrow`"
+            )
 
         assert self.dir.url is not None
 
@@ -171,105 +156,14 @@ class CloudParquetDir(ParquetDir):
             if _f["type"] == "file" and _f["name"].endswith(".parquet"):
                 self.files.append(_f)
 
-    def task(self, _file: Any, order: int) -> None:
-        if _file["type"] == "file" and _file["name"].endswith(".parquet"):
-            file_name = os.path.basename(_file["name"])
-            assert self.cache_path is not None
-            local_path = os.path.join(self.cache_path, file_name)
-            temp_path = local_path + ".tmp"  # Avoid partial writes
-            # if an existing temp file is present, means its corrupted
-            if os.path.exists(temp_path):
-                os.remove(temp_path)
-
-            # Download the file
-            with self.fs.open(_file["name"], "rb") as cloud_file, open(temp_path, "wb") as local_file:
-                for chunk in iter(lambda: cloud_file.read(4096), b""):  # Read in 4KB chunks
-                    local_file.write(chunk)
-
-            os.rename(temp_path, local_path)  # Atomic move after successful write
-            self.process_queue.put_nowait((file_name, local_path, order))
-
-    def write_index(self, chunks_info: List[Dict[str, Any]], config: Dict[str, Any]) -> None:
-        assert self.cache_path is not None
-        assert self.dir.url is not None
-
-        # clear any `.lock` or `.tmp` chunk file if left
-        if self.is_delete_thread_running:
-            for file in os.listdir(self.cache_path):
-                if file != _INDEX_FILENAME:
-                    with suppress(FileNotFoundError):
-                        os.remove(file)
-
-        index_file_path = os.path.join(self.cache_path, _INDEX_FILENAME)
-        cloud_index_path = os.path.join(self.dir.url, _INDEX_FILENAME)
-        # write to index.json file
-        with open(index_file_path, "w") as f:
-            data = {"chunks": chunks_info, "config": config, "updated_at": str(time())}
-            json.dump(data, f, sort_keys=True)
-
-        # upload file to cloud
-        with open(index_file_path, "rb") as local_file, self.fs.open(cloud_index_path, "wb") as cloud_file:
-            for chunk in iter(lambda: local_file.read(4096), b""):  # Read in 4KB chunks
-                cloud_file.write(chunk)
-
-        print(f"Index file written to: {cloud_index_path}")
-        if os.path.exists(index_file_path):
-            os.remove(index_file_path)
-
-
-class HFParquetDir(ParquetDir):
-    def __init__(
-        self,
-        dir_path: Optional[Union[str, Dir]],
-        cache_path: Optional[str] = None,
-        storage_options: Optional[Dict] = None,
-        remove_after_indexing: bool = True,
-        num_workers: int = 4,
-    ):
-        if not _HF_HUB_AVAILABLE:
-            raise ModuleNotFoundError(
-                "Support for Indexing HF depends on `huggingface_hub`.", "Please, run: `pip install huggingface_hub"
-            )
-        if not _PYARROW_AVAILABLE:
-            raise ModuleNotFoundError("Please, run: `pip install pyarrow`")
-
-        super().__init__(dir_path, cache_path, storage_options, remove_after_indexing, num_workers)
-
-        assert self.dir.url is not None
-        assert self.dir.url.startswith("hf")
-
-        if self.cache_path is None:
-            self.cache_path = default_cache_dir(self.dir.url)
-            os.makedirs(self.cache_path, exist_ok=True)  # Ensure the directory exists
-
-        # List all files and directories in the top-level of the specified directory
-        from huggingface_hub import HfFileSystem
-
-        self.fs = HfFileSystem()
-
-        for _f in self.fs.ls(self.dir.url, detail=True):
-            if _f["name"].endswith(".parquet"):
-                self.files.append(_f)
-
-    def task(self, _file: dict, order: int) -> None:
-        """Extract metadata from a Parquet file on Hugging Face Hub without downloading the entire file.
-
-        This method:
-        1. Accesses only the footer section of the Parquet file, which contains schema information
-        2. Parses the schema to extract data types and row count
-        3. Passes the metadata to the processing queue
-
-        Args:
-            _file: Dictionary containing file metadata from HF filesystem
-            order: Order of the file in the list
-        """
+    def task(self, _file: Any) -> Dict[str, Any] | None:
+        """Extract metadata from a Parquet file on the cloud filesystem without downloading the entire file."""
         import pyarrow.parquet as pq
 
         # Validate inputs
         if not isinstance(_file, dict) or "name" not in _file or "size" not in _file:
             raise ValueError(f"Invalid file object: {_file}")
 
-        assert self.cache_path is not None
         assert _file["name"].endswith(".parquet")
 
         file_name = os.path.basename(_file["name"])
@@ -290,47 +184,145 @@ class HFParquetDir(ParquetDir):
 
         # Parse the footer data to extract schema information
         with io.BytesIO(footer_data) as footer_buffer:
-            pq_file = pq.ParquetFile(footer_buffer)
-            dtypes = [str(col.type) for col in pq_file.schema_arrow]
-            num_rows = pq_file.metadata.num_rows
+            parquet_file = pq.ParquetFile(footer_buffer)
+            data_types = [str(col.type) for col in parquet_file.schema_arrow]
+            num_rows = parquet_file.metadata.num_rows
 
-        file_object = {
-            "chunk_size": num_rows,
-            "chunk_bytes": file_size,
-            "dtypes": dtypes,
+        return {
+            "file_name": file_name,
+            "num_rows": num_rows,
+            "file_size": file_size,
+            "data_types": data_types,
         }
 
-        # os.rename(temp_path, local_path)  # Atomic move after successful write
-        self.process_queue.put_nowait((file_name, file_object, order))
-
     def write_index(self, chunks_info: List[Dict[str, Any]], config: Dict[str, Any]) -> None:
+        """Write the index file to the local cache directory and upload it to the cloud."""
         assert self.cache_path is not None
         assert self.dir.url is not None
 
-        # clear any `.lock` or `.tmp` chunk file if left
-        if self.is_delete_thread_running:
-            for file in os.listdir(self.cache_path):
-                if file != _INDEX_FILENAME:
-                    with suppress(FileNotFoundError):
-                        os.remove(file)
-
         index_file_path = os.path.join(self.cache_path, _INDEX_FILENAME)
+        cloud_index_path = os.path.join(self.dir.url, _INDEX_FILENAME)
+
         # write to index.json file
         with open(index_file_path, "w") as f:
             data = {"chunks": chunks_info, "config": config, "updated_at": str(time())}
             json.dump(data, f, sort_keys=True)
 
-        print(f"Index file written to: {index_file_path}")
+        # upload index file to cloud
+        with open(index_file_path, "rb") as local_file, self.fs.open(cloud_index_path, "wb") as cloud_file:
+            for chunk in iter(lambda: local_file.read(4096), b""):  # Read in 4KB chunks
+                cloud_file.write(chunk)
+
+        print(f"Index file successfully written to: {cloud_index_path}")
+        if os.path.exists(index_file_path):
+            os.remove(index_file_path)
+
+
+class HFParquetDir(ParquetDir):
+    def __init__(
+        self,
+        dir_path: Optional[Union[str, Dir]],
+        cache_path: Optional[str] = None,
+        storage_options: Optional[Dict] = None,
+        num_workers: int = 4,
+    ):
+        super().__init__(dir_path, cache_path, storage_options, num_workers)
+
+        if not _HF_HUB_AVAILABLE:
+            raise ModuleNotFoundError(
+                "Support for Indexing HF depends on `huggingface_hub`.", "Please, run: `pip install huggingface_hub"
+            )
+        if not _PYARROW_AVAILABLE:
+            raise ModuleNotFoundError(
+                "The 'pyarrow' module is required for processing Parquet files. "
+                "Please install it by running: `pip install pyarrow`"
+            )
+
+        assert self.dir.url is not None
+        assert self.dir.url.startswith("hf")
+
+        if self.cache_path is None:
+            self.cache_path = default_cache_dir(self.dir.url)
+            os.makedirs(self.cache_path, exist_ok=True)  # Ensure the directory exists
+
+        # List all files and directories in the top-level of the specified directory
+        from huggingface_hub import HfFileSystem
+
+        self.fs = HfFileSystem()
+
+        for _f in self.fs.ls(self.dir.url, detail=True):
+            if _f["name"].endswith(".parquet"):
+                self.files.append(_f)
+
+    def task(self, _file: dict) -> Dict[str, Any] | None:
+        """Extract metadata from a Parquet file on Hugging Face Hub without downloading the entire file."""
+        import pyarrow.parquet as pq
+
+        # Validate inputs
+        if not isinstance(_file, dict) or "name" not in _file or "size" not in _file:
+            raise ValueError(f"Invalid file object: {_file}")
+
+        assert _file["name"].endswith(".parquet")
+
+        file_name = os.path.basename(_file["name"])
+        file_size = _file["size"]
+
+        with self.fs.open(_file["name"], "rb") as f:
+            # Read footer size (last 8 bytes: 4 for footer size + 4 for magic number)
+            f.seek(file_size - 8)
+            footer_size = int.from_bytes(f.read(4), "little")
+
+            # seek to the start of the footer and read the footer data
+            footer_start = file_size - footer_size - 8
+            f.seek(footer_start)
+            footer_data = f.read(file_size - footer_start)
+
+            if len(footer_data) != file_size - footer_start:
+                raise ValueError(f"Failed to read complete footer data from {file_name}")
+
+        # Parse the footer data to extract schema information
+        with io.BytesIO(footer_data) as footer_buffer:
+            parquet_file = pq.ParquetFile(footer_buffer)
+            data_types = [str(col.type) for col in parquet_file.schema_arrow]
+            num_rows = parquet_file.metadata.num_rows
+
+        return {
+            "file_name": file_name,
+            "num_rows": num_rows,
+            "file_size": file_size,
+            "data_types": data_types,
+        }
+
+    def write_index(self, chunks_info: List[Dict[str, Any]], config: Dict[str, Any]) -> None:
+        """Write the index file to the cache directory."""
+        assert self.cache_path is not None
+        assert self.dir.url is not None
+
+        super().write_index(chunks_info, config)
 
 
 def get_parquet_indexer_cls(
     dir_path: str,
     cache_path: Optional[str] = None,
     storage_options: Optional[Dict] = {},
-    remove_after_indexing: bool = True,
     num_workers: int = 4,
 ) -> ParquetDir:
-    args = (dir_path, cache_path, storage_options, remove_after_indexing, num_workers)
+    """Get the appropriate ParquetDir class based on the directory path scheme.
+
+    Args:
+        dir_path (str): Path to the directory containing the Parquet files.
+        cache_path (Optional[str]): Local cache directory for storing temporary files.
+        storage_options (Optional[Dict]): Additional storage options for accessing the Parquet files.
+        remove_after_indexing (bool): Whether to remove files after indexing (default is True).
+        num_workers (int): Number of workers to download metadata of Parquet files and index them.
+
+    Returns:
+        ParquetDir: An instance of the appropriate ParquetDir class.
+
+    Raises:
+        ValueError: If the provided `dir_path` does not have an associated ParquetDir class.
+    """
+    args = (dir_path, cache_path, storage_options, num_workers)
 
     obj = parse.urlparse(dir_path)
 
@@ -341,12 +333,11 @@ def get_parquet_indexer_cls(
     if obj.scheme == "hf":
         return HFParquetDir(*args)
 
-    if sys.platform == "win32":
-        return LocalParquetDir(*args)
-
+    supported_schemes = ["local", "gs", "s3", "hf"]
     raise ValueError(
-        f"The provided `dir_path` {dir_path} doesn't have a ParquetDir class associated.",
-        f"Found scheme => {obj.scheme}",
+        f"The provided `dir_path` '{dir_path}' does not have an associated ParquetDir class. "
+        f"Found scheme: '{obj.scheme}'. Supported schemes are: {', '.join(supported_schemes)}. "
+        "Please provide a valid directory path with one of the supported schemes."
     )
 
 

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -39,10 +39,10 @@ class ParquetDir(ABC):
             for future in futures:
                 file_metadata = future.result()
                 order, _ = futures[future]
-                yield file_metadata, order  # type: ignore
+                yield file_metadata, order
 
     @abstractmethod
-    def task(self, _file: Any) -> Dict[str, Any] | None: ...
+    def task(self, _file: Any) -> Dict[str, Any]: ...
 
     @abstractmethod
     def write_index(self, chunks_info: List[Dict[str, Any]], config: Dict[str, Any]) -> None:
@@ -82,30 +82,28 @@ class LocalParquetDir(ParquetDir):
             if _f.endswith(".parquet"):
                 self.files.append(_f)
 
-    def task(self, _file: str) -> Dict[str, Any] | None:
+    def task(self, _file: str) -> Dict[str, Any]:
         """Extract metadata from a Parquet file on the local filesystem."""
         import pyarrow.parquet as pq
 
         assert isinstance(_file, str)
-        if _file.endswith(".parquet"):
-            assert self.dir.path is not None
-            assert self.dir.path != "", "Dir path can't be empty"
+        assert _file.endswith(".parquet")
+        assert self.dir.path is not None
+        assert self.dir.path != "", "Dir path can't be empty"
 
-            file_path = os.path.join(self.dir.path, _file)
-            parquet_file = pq.ParquetFile(file_path)
-            num_rows = parquet_file.metadata.num_rows
-            data_types = [str(col.type) for col in parquet_file.schema_arrow]
-            file_size = os.path.getsize(file_path)
-            file_name = os.path.basename(file_path)
+        file_path = os.path.join(self.dir.path, _file)
+        parquet_file = pq.ParquetFile(file_path)
+        num_rows = parquet_file.metadata.num_rows
+        data_types = [str(col.type) for col in parquet_file.schema_arrow]
+        file_size = os.path.getsize(file_path)
+        file_name = os.path.basename(file_path)
 
-            return {
-                "file_name": file_name,
-                "num_rows": num_rows,
-                "file_size": file_size,
-                "data_types": data_types,
-            }
-
-        return None
+        return {
+            "file_name": file_name,
+            "num_rows": num_rows,
+            "file_size": file_size,
+            "data_types": data_types,
+        }
 
     def write_index(self, chunks_info: List[Dict[str, Any]], config: Dict[str, Any]) -> None:
         """Write the index file to the cache directory."""
@@ -155,7 +153,7 @@ class CloudParquetDir(ParquetDir):
             if _f["type"] == "file" and _f["name"].endswith(".parquet"):
                 self.files.append(_f)
 
-    def task(self, _file: Any) -> Dict[str, Any] | None:
+    def task(self, _file: Any) -> Dict[str, Any]:
         """Extract metadata from a Parquet file on the cloud filesystem without downloading the entire file."""
         import pyarrow.parquet as pq
 
@@ -252,7 +250,7 @@ class HFParquetDir(ParquetDir):
             if isinstance(_f, dict) and _f["name"].endswith(".parquet"):
                 self.files.append(_f)
 
-    def task(self, _file: dict) -> Dict[str, Any] | None:
+    def task(self, _file: dict) -> Dict[str, Any]:
         """Extract metadata from a Parquet file on Hugging Face Hub without downloading the entire file."""
         import pyarrow.parquet as pq
 

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -28,7 +28,7 @@ class ParquetDir(ABC):
         self.files: List[Any] = []
         self.num_workers = num_workers
 
-    def __iter__(self) -> Generator[Tuple[str, str, int], None, None]:
+    def __iter__(self) -> Generator[Tuple[Dict[str, Any], int], None, None]:
         """Iterate over the Parquet files and yield their metadata.
 
         Yields:
@@ -39,7 +39,7 @@ class ParquetDir(ABC):
             for future in futures:
                 file_metadata = future.result()
                 order, _ = futures[future]
-                yield file_metadata, order
+                yield file_metadata, order  # type: ignore
 
     @abstractmethod
     def task(self, _file: Any) -> Dict[str, Any] | None: ...
@@ -249,7 +249,7 @@ class HFParquetDir(ParquetDir):
         self.fs = HfFileSystem()
 
         for _f in self.fs.ls(self.dir.url, detail=True):
-            if _f["name"].endswith(".parquet"):
+            if isinstance(_f, dict) and _f["name"].endswith(".parquet"):
                 self.files.append(_f)
 
     def task(self, _file: dict) -> Dict[str, Any] | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,7 +207,7 @@ def huggingface_hub_fs_mock(monkeypatch, write_pq_data, tmp_path):
         return open(file_path, mode)
 
     def mock_ls(*args, **kwargs):
-        files = os.listdir(os.path.join(tmp_path, "pq-dataset"))
+        files = sorted(os.listdir(os.path.join(tmp_path, "pq-dataset")))
         return [
             {
                 "type": "file",
@@ -217,10 +217,14 @@ def huggingface_hub_fs_mock(monkeypatch, write_pq_data, tmp_path):
             for file_name in files
         ]
 
+    def mock_hf_hub_download(repo_id, filename, cache_dir, repo_type, **kwargs):
+        return os.path.join(tmp_path, "pq-dataset", os.path.basename(filename))
+
     hf_fs_mock = Mock()
     hf_fs_mock.ls = Mock(side_effect=mock_ls)
     hf_fs_mock.open = Mock(side_effect=mock_open)
     huggingface_hub.HfFileSystem = Mock(return_value=hf_fs_mock)
+    huggingface_hub.hf_hub_download = Mock(side_effect=mock_hf_hub_download)
 
     return huggingface_hub
 

--- a/tests/processing/test_readers.py
+++ b/tests/processing/test_readers.py
@@ -4,7 +4,8 @@ import sys
 import pytest
 
 from litdata import map
-from litdata.processing.readers import _PYARROW_AVAILABLE, BaseReader, ParquetReader
+from litdata.constants import _PYARROW_AVAILABLE
+from litdata.processing.readers import BaseReader, ParquetReader
 
 
 class DummyReader(BaseReader):

--- a/tests/streaming/test_parquet.py
+++ b/tests/streaming/test_parquet.py
@@ -10,6 +10,7 @@ import pytest
 
 from litdata.constants import _INDEX_FILENAME
 from litdata.streaming.dataset import StreamingDataset
+from litdata.streaming.item_loader import PyTreeLoader
 from litdata.streaming.writer import index_parquet_dataset
 from litdata.utilities.hf_dataset import index_hf_dataset
 from litdata.utilities.parquet import (
@@ -168,10 +169,12 @@ def test_get_parquet_indexer_cls(pq_url, cls, expectation, monkeypatch, fsspec_m
 @pytest.mark.usefixtures("clean_pq_index_cache")
 def test_stream_hf_parquet_dataset(huggingface_hub_fs_mock, pq_data):
     hf_url = "hf://datasets/some_org/some_repo/some_path"
+
+    with pytest.raises(ValueError, match="Invalid item_loader for hf://datasets."):
+        StreamingDataset(hf_url, item_loader=PyTreeLoader)
+
     ds = StreamingDataset(hf_url)
-
     assert len(ds) == 25  # 5 datasets for 5 loops
-
     for i, _ds in enumerate(ds):
         idx = i % 5
         assert len(_ds) == 3

--- a/tests/streaming/test_parquet.py
+++ b/tests/streaming/test_parquet.py
@@ -23,7 +23,7 @@ from litdata.utilities.parquet import (
 
 
 #! TODO: Fix test failing on windows
-# @pytest.mark.skipif(condition=sys.platform == "win32", reason="Fails on windows and test gets cancelled")
+@pytest.mark.skipif(condition=sys.platform == "win32", reason="Fails on windows and test gets cancelled")
 @pytest.mark.usefixtures("clean_pq_index_cache")
 @pytest.mark.parametrize(
     ("pq_dir_url"),
@@ -35,12 +35,12 @@ from litdata.utilities.parquet import (
     ],
 )
 @pytest.mark.parametrize(("num_worker"), [None, 1, 2, 4])
+@patch("litdata.utilities.parquet._HF_HUB_AVAILABLE", True)
+@patch("litdata.streaming.downloader._HF_HUB_AVAILABLE", True)
+@patch("litdata.utilities.parquet._FSSPEC_AVAILABLE", True)
 def test_parquet_index_write(
     monkeypatch, tmp_path, pq_data, huggingface_hub_fs_mock, fsspec_pq_mock, pq_dir_url, num_worker
 ):
-    monkeypatch.setattr("litdata.utilities.parquet._HF_HUB_AVAILABLE", True)
-    monkeypatch.setattr("litdata.utilities.parquet._FSSPEC_AVAILABLE", True)
-
     if pq_dir_url is None:
         pq_dir_url = os.path.join(tmp_path, "pq-dataset")
 
@@ -87,11 +87,10 @@ def test_parquet_index_write(
             assert _ds[2] == pq_data["height"][idx]
 
 
+@pytest.mark.skipif(condition=sys.platform == "win32", reason="Fails on windows and test gets cancelled")
 @pytest.mark.usefixtures("clean_pq_index_cache")
-@patch("litdata.utilities.parquet._HF_HUB_AVAILABLE", False)
+@patch("litdata.utilities.parquet._HF_HUB_AVAILABLE", True)
 def test_index_hf_dataset(monkeypatch, tmp_path, huggingface_hub_fs_mock):
-    monkeypatch.setattr("litdata.utilities.parquet._HF_HUB_AVAILABLE", True)
-
     with pytest.raises(ValueError, match="Invalid Hugging Face dataset URL"):
         index_hf_dataset("invalid_url")
 
@@ -167,7 +166,9 @@ def test_get_parquet_indexer_cls(pq_url, cls, expectation, monkeypatch, fsspec_m
 
 
 @pytest.mark.usefixtures("clean_pq_index_cache")
-def test_stream_hf_parquet_dataset(huggingface_hub_fs_mock, pq_data):
+@patch("litdata.utilities.parquet._HF_HUB_AVAILABLE", True)
+@patch("litdata.streaming.downloader._HF_HUB_AVAILABLE", True)
+def test_stream_hf_parquet_dataset(monkeypatch, huggingface_hub_fs_mock, pq_data):
     hf_url = "hf://datasets/some_org/some_repo/some_path"
 
     # Test case 1: Invalid item_loader

--- a/tests/streaming/test_parquet.py
+++ b/tests/streaming/test_parquet.py
@@ -184,8 +184,8 @@ def test_stream_hf_parquet_dataset(huggingface_hub_fs_mock, pq_data):
         assert _ds[1] == pq_data["weight"][idx]
         assert _ds[2] == pq_data["height"][idx]
 
-    # Test case 3: Streaming with ParquetLoader as item_loader
-    ds = StreamingDataset(hf_url, item_loader=ParquetLoader())
+    # Test case 3: Streaming with ParquetLoader as item_loader and low_memory=False
+    ds = StreamingDataset(hf_url, item_loader=ParquetLoader(low_memory=False))
     assert len(ds) == 25
     for i, _ds in enumerate(ds):
         idx = i % 5


### PR DESCRIPTION
## What does this PR do?

This PR introduces the following improvements:

- [x] Updates `HFDownloader` to use `hf_hub_download`, which can be combined with `hf_transfer` for faster downloads.  
- [x] Enhances the parquet dataset indexing process to retrieve metadata and build index without downloading entire files.  
- [x] Adds a low-memory usage option to the Parquet item loader.  
   -  Note: When `low_memory=True`, shuffling has a significant performance impact. It is not recommended to use shuffling with low-memory mode until the next update.
- [x] Updates test cases to reflect these changes.  

Fixes  #502.

### Example usage:
```python
from tqdm import tqdm
from litdata import StreamingDataLoader, StreamingDataset
from litdata.streaming.item_loader import ParquetLoader

# Create a StreamingDataset object
dataset = StreamingDataset(
    input_dir="hf://datasets/open-thoughts/OpenThoughts-114k/data",
    item_loader=ParquetLoader(low_memory=True), # by default it has low_memory=True
)

data_loader = StreamingDataLoader(dataset=dataset, batch_size=8, num_workers=4, shuffle=False, drop_last=True)

for i, batch in enumerate(tqdm(data_loader, desc="Streaming data")):
    pass
```

## Benchmarks  
### Using LitData
These benchmarks were generated using this [script](https://github.com/bhimrazy/litdata-benchmark/blob/main/stream_hf_dataset.py) with the following settings: `batch_size = 256`, `num_workers = 32`, and `machine = A10G`. The results may vary slightly across different runs.  

> For more detailed logs (older), please check [this comment](https://github.com/Lightning-AI/litdata/pull/505#issuecomment-2734439804). 

> **Notes:** 
> 1. Currently, enabling shuffle in low-memory mode degrades performance. However, using `low_memory=True` and `shuffle=False` allows streaming of much larger datasets at better speed.  
> 2. Time in brackets represents the time taken to complete that epoch.  

---

#### Dataset: [OpenThoughts-114k](https://huggingface.co/datasets/open-thoughts/OpenThoughts-114k) (3.55 GB)  

| CASE | Low Memory | Pre-load Chunk | Shuffle | Samples/sec 1st epoch | Samples/sec 2nd epoch | Peak Memory Usage (GB) |
|------------|------------|---------------|------------|------------------------|------------------------|----------------------|
| a    | yes        | no           | no     | **14,329** *(7.95s)*   | **15,948** *(7.14s)*   | ~13 GB               |
| b    | yes      | no           | yes     | **14,093** *(8.08s)*   | **16,026** *(7.11s)*   | ~13 GB               |
| c    | no         | no         | no       | **12,145** *(9.38s)*   | **12,779** *(8.91s)*   | ~23 GB               |
| d    | no          | no         | yes      | **11,696** *(9.74s)*   | **12,747** *(8.93s)*  | ~23 GB               |
| e    | no          | yes         | no      | **11,707** *(9.73s)*   | **10,602** *(10.75s)*  | ~33 GB               |
| f    | no        | yes          | yes     | **11,296** *(10.08s)*  | **10,554** *(10.79s)*  | ~34 GB               |

---

#### Dataset: [fineweb-edu (10BT Sample)](https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu/tree/main/sample/10BT) (~26 GB)  

| CASE | Low Memory | Pre-load Chunk | Shuffle | Samples/sec 1st epoch | Samples/sec 2nd epoch | Peak Memory Usage (GB) |
|------------|------------|---------------|------------|------------------------|------------------------|----------------------|
| a    | yes         |  no          | no      | **36,918** *(261.98s)* | **44,803** *(215.87s)* | ~18 GB               |
| b    | yes         |  no          | yes      | **34,983** *(276.47s)* | **39,966** *(242s)* | ~58 GB               |
| c    | no          | no             | no       | - (crashed)            |                        | ~120 GB              |

------------------------
### Using huggingface datasets streaming
These benchmarks were generated using this [script](https://github.com/bhimrazy/litdata-benchmark/blob/main/stream_hf_iterable_dataset.py) with the following settings: `batch_size = 256`, `num_workers = 32`, and `machine = A10G`. The results may vary slightly across different runs.  
> For `num_workers`, it doesn't not seem to accept a value greater than num_shards.
>Warning: Too many dataloader workers: 32 (max is dataset.num_shards=6). Stopping 26 dataloader workers.

##### Dataset: [OpenThoughts-114k](https://huggingface.co/datasets/open-thoughts/OpenThoughts-114k) (3.55 GB)  
| Shuffle | Samples/sec 1st epoch | Samples/sec 2nd epoch | Peak Memory Usage (GB) |
|---------------|------------------------|------------------------|----------------------|
| no | **14,834** *(7.66s)*   | **15,115** *(7.51s)*   | ~9 GB            |
| yes | **12,173** *(9.33s)*   | **12,288** *(9.23s)*   | ~9 GB            |

#### Dataset: [fineweb-edu (10BT Sample)](https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu/tree/main/sample/10BT) (~26 GB)  
| Shuffle | Samples/sec 1st epoch | Samples/sec 2nd epoch | Peak Memory Usage (GB) |
|---------------|------------------------|------------------------|----------------------|
| no | **44,519** *(217.23s)*  | **44,178** *(218.90s)*   | ~55 GB            |
| yes | **33,147** *(291.74s)*  |  **33,900** *(285.27s)*   | ~55 GB            |


## PR Review  

Community members are welcome to review this PR once tests have passed.  
If your PR was not previously discussed in GitHub issues, there's a high chance it will not be merged.  

## Did you have fun?  
Yes, I did.  😊