### PR TITLE
Fix: unsigned s5cmd requests and also add option to disable s5cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Additionally, you can inject client connection settings for [S3](https://boto3.a
 ```python
 from litdata import StreamingDataset
 
+# boto3 compatible storage options for a custom S3-compatible endpoint
 storage_options = {
     "endpoint_url": "your_endpoint_url",
     "aws_access_key_id": "your_access_key_id",
@@ -223,7 +224,20 @@ storage_options = {
 }
 
 dataset = StreamingDataset('s3://my-bucket/my-data', storage_options=storage_options)
+
+# s5cmd compatible storage options for a custom S3-compatible endpoint
+# Note: If s5cmd is installed, it will be used by default for S3 operations. If you prefer not to use s5cmd, you can disable it by setting the environment variable: `DISABLE_S5CMD=1`
+storage_options = {
+    "AWS_ACCESS_KEY_ID": "your_access_key_id",
+    "AWS_SECRET_ACCESS_KEY": "your_secret_access_key",
+    "S3_ENDPOINT_URL": "your_endpoint_url",  # Required only for custom endpoints
+}
+
+
+dataset = StreamingDataset('s3://my-bucket/my-data', storage_options=storage_options)
 ```
+
+Alternative: Using `s5cmd` for S3 Operations
 
 
 Also, you can specify a custom cache directory when initializing your dataset. This is useful when you want to store the cache in a specific location.
@@ -366,18 +380,36 @@ for batch in val_dataloader:
 
 &nbsp;
 
-The StreamingDataset supports reading optimized datasets from common cloud providers. 
+The `StreamingDataset` provides support for reading optimized datasets from common cloud storage providers like AWS S3, Google Cloud Storage (GCS), and Azure Blob Storage. Below are examples of how to use StreamingDataset with each cloud provider.
 
 ```python
 import os
 import litdata as ld
 
-# Read data from AWS S3
+# Read data from AWS S3 using s5cmd
+# Note: If s5cmd is installed, it will be used by default for S3 operations. If you prefer not to use s5cmd, you can disable it by setting the environment variable: `DISABLE_S5CMD=1`
 aws_storage_options={
     "AWS_ACCESS_KEY_ID": os.environ['AWS_ACCESS_KEY_ID'],
     "AWS_SECRET_ACCESS_KEY": os.environ['AWS_SECRET_ACCESS_KEY'],
+    "S3_ENDPOINT_URL": os.environ['AWS_ENDPOINT_URL'],  # Required only for custom endpoints
 }
 dataset = ld.StreamingDataset("s3://my-bucket/my-data", storage_options=aws_storage_options)
+
+# Read Data from AWS S3 with Unsigned Request using s5cmd
+aws_storage_options={
+  "AWS_NO_SIGN_REQUEST": "Yes" # Required for unsigned requests
+  "S3_ENDPOINT_URL": os.environ['AWS_ENDPOINT_URL'],  # Required only for custom endpoints
+}
+dataset = ld.StreamingDataset("s3://my-bucket/my-data", storage_options=aws_storage_options)
+
+# Read data from AWS S3 using boto3
+os.environ["DISABLE_S5CMD"] = "1"
+aws_storage_options={
+    "aws_access_key_id": os.environ['AWS_ACCESS_KEY_ID'],
+    "aws_secret_access_key": os.environ['AWS_SECRET_ACCESS_KEY'],
+}
+dataset = ld.StreamingDataset("s3://my-bucket/my-data", storage_options=aws_storage_options)
+
 
 # Read data from GCS
 gcp_storage_options={

--- a/src/litdata/constants.py
+++ b/src/litdata/constants.py
@@ -44,6 +44,7 @@ _DEBUG = bool(int(os.getenv("DEBUG", "0")))
 
 _MAX_WAIT_TIME = int(os.getenv("MAX_WAIT_TIME", "120"))
 _FORCE_DOWNLOAD_TIME = int(os.getenv("FORCE_DOWNLOAD_TIME", "30"))
+_S5CMD = bool(int(os.getenv("S5CMD", "1")))
 
 # DON'T CHANGE ORDER
 _TORCH_DTYPES_MAPPING = {

--- a/src/litdata/constants.py
+++ b/src/litdata/constants.py
@@ -44,7 +44,7 @@ _DEBUG = bool(int(os.getenv("DEBUG", "0")))
 
 _MAX_WAIT_TIME = int(os.getenv("MAX_WAIT_TIME", "120"))
 _FORCE_DOWNLOAD_TIME = int(os.getenv("FORCE_DOWNLOAD_TIME", "30"))
-_S5CMD = bool(int(os.getenv("S5CMD", "1")))
+_DISABLE_S5CMD = bool(int(os.getenv("DISABLE_S5CMD", "0")))
 
 # DON'T CHANGE ORDER
 _TORCH_DTYPES_MAPPING = {

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -114,7 +114,7 @@ class S3Downloader(Downloader):
                 return_code = proc.wait()
 
                 if return_code != 0:
-                    stderr_output = proc.stderr.read().decode().strip()
+                    stderr_output = proc.stderr.read().decode().strip() if proc.stderr else ""
                     error_message = (
                         f"Failed to execute command `{cmd}` (exit code: {return_code}). "
                         "This might be due to an incorrect file path, insufficient permissions, or network issues. "

--- a/tests/streaming/test_downloader.py
+++ b/tests/streaming/test_downloader.py
@@ -85,7 +85,7 @@ def test_s3_downloader_with_s5cmd_no_storage_options(popen_mock, system_mock, tm
 
 @patch("os.system")
 @patch("subprocess.Popen")
-@mock.patch("litdata.streaming.downloader._S5CMD", False)
+@mock.patch("litdata.streaming.downloader._DISABLE_S5CMD", True)
 @mock.patch("boto3.client")
 def test_s3_downloader_s5cmd_available_but_disabled(boto3_client_mock, popen_mock, system_mock, tmpdir):
     system_mock.return_value = 0  # Simulates s5cmd being available
@@ -178,6 +178,61 @@ def test_s3_downloader_with_s5cmd_with_storage_options_unsigned(popen_mock, syst
         env=expected_env,
     )
     process_mock.wait.assert_called_once()
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.skipif(shutil.which("s5cmd") is None, reason="s5cmd is not available")
+def test_s3_downloader_with_s5cmd_with_storage_options_unsigned_pl(tmpdir):
+    # Set up the test environment
+    remote_filepath = "s3://pl-flash-data/optimized_tiny_imagenet/index.json"
+    local_filepath = os.path.join(tmpdir, "index.json")
+
+    storage_options = {"AWS_NO_SIGN_REQUEST": "Yes"}
+    # Initialize the S3Downloader
+    downloader = S3Downloader("s3://pl-flash-data", str(tmpdir), [], storage_options)
+
+    # Download the file
+    downloader.download_file(remote_filepath, local_filepath)
+
+    # Verify the download
+    assert os.path.exists(local_filepath), "The index.json file was not downloaded successfully."
+
+    # verify the contents of the file
+    with open(local_filepath) as f:
+        content = f.read()
+        assert content.startswith("{"), "The downloaded file does not appear to be a valid JSON file."
+
+
+@patch("os.system")
+@patch("subprocess.Popen")
+def test_s3_downloader_s5cmd_error_handling(popen_mock, system_mock, tmpdir):
+    system_mock.return_value = 0  # Simulates s5cmd being available
+    process_mock = MagicMock()
+    process_mock.wait.return_value = 1  # Simulate a non-zero return code
+    process_mock.stderr.read.return_value = b"Simulated error message"
+    popen_mock.return_value = process_mock
+
+    # Initialize the S3Downloader without storage options
+    downloader = S3Downloader("s3://random_bucket", str(tmpdir), [])
+
+    # Action: Call the download_file method and expect a RuntimeError
+    remote_filepath = "s3://random_bucket/sample_file.txt"
+    local_filepath = os.path.join(tmpdir, "sample_file.txt")
+
+    with pytest.raises(RuntimeError, match="Failed to execute command"):
+        downloader.download_file(remote_filepath, local_filepath)
+
+    # Assertion: Verify subprocess.Popen was called with the correct arguments
+    popen_mock.assert_called_once_with(
+        f"s5cmd cp {remote_filepath} {local_filepath}",
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=None,
+    )
+
+    # Assertion: Verify the error message includes the simulated stderr output
+    process_mock.stderr.read.assert_called_once()
 
 
 @mock.patch("litdata.streaming.downloader._GOOGLE_STORAGE_AVAILABLE", True)

--- a/tests/streaming/test_downloader.py
+++ b/tests/streaming/test_downloader.py
@@ -52,6 +52,7 @@ def test_get_downloader(tmpdir):
 def test_s3_downloader_fast(tmpdir, monkeypatch):
     monkeypatch.setattr(os, "system", MagicMock(return_value=0))
     popen_mock = MagicMock()
+    popen_mock.wait.return_value = 0  # Simulate a successful download
     monkeypatch.setattr(subprocess, "Popen", MagicMock(return_value=popen_mock))
     downloader = S3Downloader(tmpdir, tmpdir, [])
     downloader.download_file("s3://random_bucket/a.txt", os.path.join(tmpdir, "a.txt"))
@@ -63,6 +64,7 @@ def test_s3_downloader_fast(tmpdir, monkeypatch):
 def test_s3_downloader_with_s5cmd_no_storage_options(popen_mock, system_mock, tmpdir):
     system_mock.return_value = 0  # Simulates s5cmd being available
     process_mock = MagicMock()
+    process_mock.wait.return_value = 0  # Simulate a successful download
     popen_mock.return_value = process_mock
 
     # Initialize the S3Downloader without storage options
@@ -78,6 +80,7 @@ def test_s3_downloader_with_s5cmd_no_storage_options(popen_mock, system_mock, tm
         f"s5cmd cp {remote_filepath} {local_filepath}",
         shell=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         env=None,
     )
     process_mock.wait.assert_called_once()
@@ -123,6 +126,7 @@ def test_s3_downloader_s5cmd_available_but_disabled(boto3_client_mock, popen_moc
 def test_s3_downloader_with_s5cmd_with_storage_options(popen_mock, system_mock, tmpdir):
     system_mock.return_value = 0  # Simulates s5cmd being available
     process_mock = MagicMock()
+    process_mock.wait.return_value = 0  # Simulate a successful download
     popen_mock.return_value = process_mock
 
     storage_options = {"AWS_ACCESS_KEY_ID": "dummy_key", "AWS_SECRET_ACCESS_KEY": "dummy_secret"}
@@ -144,6 +148,7 @@ def test_s3_downloader_with_s5cmd_with_storage_options(popen_mock, system_mock, 
         f"s5cmd cp {remote_filepath} {local_filepath}",
         shell=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         env=expected_env,
     )
     process_mock.wait.assert_called_once()
@@ -154,6 +159,7 @@ def test_s3_downloader_with_s5cmd_with_storage_options(popen_mock, system_mock, 
 def test_s3_downloader_with_s5cmd_with_storage_options_unsigned(popen_mock, system_mock, tmpdir):
     system_mock.return_value = 0  # Simulates s5cmd being available
     process_mock = MagicMock()
+    process_mock.wait.return_value = 0  # Simulate a successful download
     popen_mock.return_value = process_mock
 
     storage_options = {"AWS_NO_SIGN_REQUEST": "Yes"}
@@ -175,6 +181,7 @@ def test_s3_downloader_with_s5cmd_with_storage_options_unsigned(popen_mock, syst
         f"s5cmd --no-sign-request cp {remote_filepath} {local_filepath}",
         shell=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         env=expected_env,
     )
     process_mock.wait.assert_called_once()

--- a/tests/streaming/test_downloader.py
+++ b/tests/streaming/test_downloader.py
@@ -1,5 +1,6 @@
 # ruff: noqa: S604
 import os
+import sys
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -187,8 +188,9 @@ def test_s3_downloader_with_s5cmd_with_storage_options_unsigned(popen_mock, syst
     process_mock.wait.assert_called_once()
 
 
-@pytest.mark.timeout(10)
-@pytest.mark.skipif(shutil.which("s5cmd") is None, reason="s5cmd is not available")
+@pytest.mark.skipif(
+    shutil.which("s5cmd") is None or sys.platform == "win32", reason="s5cmd is not available or running on Windows"
+)
 def test_s3_downloader_with_s5cmd_with_storage_options_unsigned_pl(tmpdir):
     # Set up the test environment
     remote_filepath = "s3://pl-flash-data/optimized_tiny_imagenet/index.json"


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

- [x] Enables support for unsigned requests with `s5cmd` to pass as storage options
  ```
   storage_options = {
    "AWS_NO_SIGN_REQUEST": "Yes",
    "S3_ENDPOINT_URL": "endpoint-url",
    }
    ```
- [x] Adds an option to disable `s5cmd`
- [x] Add test cases 
- [x] Update README

Fixes #511.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
