### PR TITLE
fix: remove warnings for Streaming Dataset with hf dataset and shuffle enabled

### DIFF
--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -112,12 +112,6 @@ class StreamingDataset(IterableDataset):
                     "Please provide a valid ParquetLoader instance."
                 )
 
-            if item_loader is not None and item_loader._low_memory and shuffle:
-                raise ValueError(
-                    "You have enabled shuffling when using low memory with ParquetLoader. "
-                    "This configuration may lead to performance issues during the training process. "
-                    "Consider disabling shuffling or using a ParquetLoader without low memory mode."
-                )
             item_loader = item_loader or ParquetLoader()
 
         self.input_dir = input_dir

--- a/tests/streaming/test_parquet.py
+++ b/tests/streaming/test_parquet.py
@@ -204,7 +204,3 @@ def test_stream_hf_parquet_dataset(monkeypatch, huggingface_hub_fs_mock, pq_data
         assert _ds[0] == pq_data["name"][idx]
         assert _ds[1] == pq_data["weight"][idx]
         assert _ds[2] == pq_data["height"][idx]
-
-    # Test case 5: Streaming with ParquetLoader and low_memory=True and shuffle=True
-    with pytest.raises(ValueError, match="You have enabled shuffling when using low memory with ParquetLoader."):
-        StreamingDataset(hf_url, item_loader=ParquetLoader(low_memory=True), shuffle=True)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?
Removes warnings for Streaming Dataset with hf dataset and shuffle enabled which was added in #505

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
