### PR TITLE
 Revert '#506 Add s5cmd' – as boto3 Outperforms s5cmd in Latest Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,7 +1152,7 @@ Speed to stream Imagenet 1.2M from AWS S3:
 
 | Framework | Images / sec  1st Epoch (float32)  | Images / sec   2nd Epoch (float32) | Images / sec 1st Epoch (torch16) | Images / sec 2nd Epoch (torch16) |
 |---|---|---|---|---|
-| LitData | **5800** | **6589**  | **6282**  | **7221**  |
+| LitData | **5839** | **6692**  | **6282**  | **7221**  |
 | Web Dataset  | 3134 | 3924 | 3343 | 4424 |
 | Mosaic ML  | 2898 | 5099 | 2809 | 5158 |
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ numpy
 boto3
 requests
 tifffile
-s5cmd

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,5 +8,6 @@ pytest-rerunfailures ==14.0
 pytest-random-order ==1.1.1
 pandas
 lightning
+transformers <4.50.0
 zstd
 numpy < 2.0


### PR DESCRIPTION
**Title:** Revert Lightning-AI/litdata#506 – boto3 Outperforms s5cmd in Latest Benchmarks  

**Description:**  
As per our latest benchmark tests on ImageNet for `litdata`, we found that `boto3` significantly outperforms `s5cmd` in streaming efficiency. The previous assumption that `s5cmd` would be faster does not hold for our use case.  

### **Benchmark Results from @tchaton**  
```python
███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5005/5005 [03:39<00:00, 22.83it/s]
For /teamspace/studios/this_studio/stream.py on 0, streamed over 1,281,167 samples in 219.40s → **5,839 images/sec**  

███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5005/5005 [03:11<00:00, 26.14it/s]
For /teamspace/studios/this_studio/stream.py on 1, streamed over 1,281,167 samples in 191.44s → **6,692 images/sec**  
```
### **Performance Summary (First Epoch)**  
- **s5cmd**: ~5,380 images/sec  
- **boto3**: ~5,840 images/sec  

Given these results, this PR **reverts** #506 to restore `boto3` as the default, ensuring optimal performance for large-scale dataset streaming.  
