### PR TITLE
Fixes the logic for `is_last_index`.  

### DIFF
--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -417,7 +417,7 @@ class StreamingDataset(IterableDataset):
                 chunk_index=self.worker_chunks[self.chunk_index - 1],
                 # We provide the chunks indexes only one the first
                 chunk_indexes=None if self.has_triggered_download else self.worker_chunks[self.chunk_index - 1 :],
-                is_last_index=(self.chunk_index - 1) == len(self.worker_intervals) and len(self.current_indexes) == 1,
+                is_last_index=(self.chunk_index) == len(self.worker_intervals) and len(self.current_indexes) == 0,
             )
         )
 


### PR DESCRIPTION
## What does this PR do?  

Fixes the logic for `is_last_index`.  

```diff
- is_last_index = (self.chunk_index - 1) == len(self.worker_intervals) and len(self.current_indexes) == 1  
+ is_last_index = self.chunk_index == len(self.worker_intervals) and len(self.current_indexes) == 0  
```
### Why?  
- The previous check mistakenly used `- 1`, making it always false.  
> This could be done by checking either the index or length.
- `self.current_indexes` is already empty when checked.  

## PR review  

Open for community review after tests pass. Unreviewed PRs without prior discussion may not be merged.  

## Did you have fun?  

Hope you enjoyed coding this! 🙃
> Yes, I did. 😊