### PR TITLE
Fix: redundant chunk index download request in BinaryReader , when dataset in iter mode

### DIFF
--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -372,7 +372,7 @@ class BinaryReader:
                     self._chunks_queued_for_download = True
 
             # Only request individual chunk download if:
-            # 1. We haven't already queued a bulk download via chunk_indexes
+            # 1. We haven't already queued all chunks for the download
             # 2. We're processing a new chunk (different from the last one)
             if not self._chunks_queued_for_download and index.chunk_index != self._last_chunk_index:
                 assert self._prepare_thread

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -369,11 +369,6 @@ class BinaryReader:
                 if index.chunk_indexes:
                     self._prepare_thread.download(index.chunk_indexes)
 
-            # If the chunk_index is new, request for it to be downloaded.
-            if index.chunk_index != self._last_chunk_index:
-                assert self._prepare_thread
-                self._prepare_thread.download([index.chunk_index])
-
             if self._last_chunk_index is None:
                 self._last_chunk_index = index.chunk_index
 

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -421,6 +421,8 @@ class BinaryReader:
             self._prepare_thread.stop()
             self._prepare_thread = None
             self._item_loader.close(self._last_chunk_index)
+            self._last_chunk_index = None
+            self._chunks_queued_for_download = False
 
         return item
 

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -1540,12 +1540,14 @@ def test_dataset_as_iterator_and_non_iterator(tmpdir, local, shuffle):
         assert data is not None
         if local and i < dataset_length - 1:
             # In iterator mode with local or remote data, _chunks_queued_for_download should be enabled
-            assert dataset.cache._reader._chunks_queued_for_download is True, \
-                "_chunks_queued_for_download should be enabled during iteration"
+            assert (
+                dataset.cache._reader._chunks_queued_for_download is True
+            ), "_chunks_queued_for_download should be enabled during iteration"
         else:
-            assert dataset.cache._reader._chunks_queued_for_download is False, \
-                "_chunks_queued_for_download should be disbaled when used as local dir withput `local:` prefix" \
+            assert dataset.cache._reader._chunks_queued_for_download is False, (
+                "_chunks_queued_for_download should be disbaled when used as local dir withput `local:` prefix"
                 " or when iteration is done"
+            )
     # After iteration, _chunks_queued_for_download should be reset
     assert dataset.cache._reader._chunks_queued_for_download is False
 

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -1545,7 +1545,7 @@ def test_dataset_as_iterator_and_non_iterator(tmpdir, local, shuffle):
             ), "_chunks_queued_for_download should be enabled during iteration"
         else:
             assert dataset.cache._reader._chunks_queued_for_download is False, (
-                "_chunks_queued_for_download should be disbaled when used as local dir withput `local:` prefix"
+                "_chunks_queued_for_download should be disabled when used as local dir without `local:` prefix"
                 " or when iteration is done"
             )
     # After iteration, _chunks_queued_for_download should be reset

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -1505,3 +1505,55 @@ def test_is_last_index_for_chunked_index_with_dataset(tmpdir, shuffle):
     assert len(indexes) == 1, "Expected exactly one index with is_last_index=True"
     assert indexes[0].is_last_index, "Expected is_last_index=True for the last item"
     assert indexes[0].chunk_index == worker_chunks[-1], "Expected to match the last chunk"
+
+
+@pytest.mark.parametrize("local", [True, False])
+@pytest.mark.parametrize("shuffle", [True, False])
+def test_dataset_as_iterator_and_non_iterator(tmpdir, local, shuffle):
+    """Test that _chunks_queued_for_download flag is correctly set and reset in reader.
+
+    This test verifies that:
+    1. When iterating, _chunks_queued_for_download is enabled during iteration but reset when done
+    2. When accessing by index, _chunks_queued_for_download is never enabled
+    """
+    # Create directories
+    cache_dir = os.path.join(tmpdir, "cache_dir")
+    data_dir = os.path.join(tmpdir, "data_dir")
+    os.makedirs(cache_dir)
+    os.makedirs(data_dir)
+
+    # Create a dataset with 50 items, 10 items per chunk
+    cache = Cache(str(data_dir), chunk_size=10)
+    for i in range(50):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    # Create dataset with appropriate configuration
+    input_dir = f"local:{data_dir}" if local else str(data_dir)
+    dataset = StreamingDataset(input_dir, cache_dir=str(cache_dir) if local else None, shuffle=shuffle)
+    dataset_length = len(dataset)
+    assert dataset_length == 50
+
+    # ACT & ASSERT - Test iterator mode
+    for i, data in enumerate(dataset):
+        assert data is not None
+        if local and i < dataset_length - 1:
+            # In iterator mode with local or remote data, _chunks_queued_for_download should be enabled
+            assert dataset.cache._reader._chunks_queued_for_download is True, \
+                "_chunks_queued_for_download should be enabled during iteration"
+        else:
+            assert dataset.cache._reader._chunks_queued_for_download is False, \
+                "_chunks_queued_for_download should be disbaled when used as local dir withput `local:` prefix" \
+                " or when iteration is done"
+    # After iteration, _chunks_queued_for_download should be reset
+    assert dataset.cache._reader._chunks_queued_for_download is False
+
+    # ACT & ASSERT - Test indexed access mode
+    for i in range(dataset_length):
+        data = dataset[i]
+        assert data is not None
+        # In indexed access mode, _chunks_queued_for_download should never be enabled
+        assert dataset.cache._reader._chunks_queued_for_download is False
+
+    assert dataset.cache._reader._chunks_queued_for_download is False


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #534.

This PR fixes the redundant chunk download issue by preventing individual chunk download requests when a download for multiple chunk indexes has already been queued while the dataset is in iterator mode.

> Further details by copilot [here](https://github.com/Lightning-AI/litdata/pull/535#pullrequestreview-2727337108)

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
