### PR TITLE
Fix/last chunk deletion

### DIFF
--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -170,9 +170,11 @@ class PrepareChunksThread(Thread):
             self._to_delete_queue, timeout=_LONG_DEFAULT_TIMEOUT if reached_pre_download else _DEFAULT_TIMEOUT
         )
 
-        if chunk_index is not None:
-            # Store the current chunk index
-            self._chunks_index_to_be_deleted.append(chunk_index)
+        if chunk_index is None:
+            return
+
+        # Store the current chunk index
+        self._chunks_index_to_be_deleted.append(chunk_index)
 
         # Get the current cache size and decide whether we need to start cleanup. Otherwise, keep track of it
         while self._max_cache_size and self._chunks_index_to_be_deleted and self._can_delete_chunk():

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -185,7 +185,8 @@ class PrepareChunksThread(Thread):
 
     def _can_delete_chunk(self) -> bool:
         if self._delete_chunks_when_processed:
-            return self._pre_download_counter >= self._max_pre_download - 1
+            # TODO: check why it is >= self.max_pre_download - 1
+            return self._pre_download_counter >= 0
         return (
             self._max_cache_size is not None
             and _get_folder_size(self._config._cache_dir, self._config) >= self._max_cache_size

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -422,6 +422,8 @@ class BinaryReader:
             self._prepare_thread._decrement_local_lock(index.chunk_index)
             self._prepare_thread.delete([index.chunk_index])
             self._prepare_thread.stop()
+            if self._max_cache_size and self._prepare_thread.is_alive():
+                self._prepare_thread.join()
             self._prepare_thread = None
             self._item_loader.close(self._last_chunk_index)
             self._last_chunk_index = None

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -197,7 +197,7 @@ class PrepareChunksThread(Thread):
         self._item_loader.pre_load_chunk(chunk_index, chunk_filepath)
 
     def _force_download(self) -> None:
-        chunk_index = _get_from_queue(self._force_download_queue, _DEFAULT_TIMEOUT)
+        chunk_index = _get_from_queue(self._force_download_queue)
         if chunk_index is not None:
             if _DEBUG:
                 chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -418,6 +418,7 @@ class BinaryReader:
         if index.is_last_index and self._prepare_thread:
             # inform the thread it is time to stop
             self._prepare_thread._decrement_local_lock(index.chunk_index)
+            self._prepare_thread.delete([index.chunk_index])
             self._prepare_thread.stop()
             self._prepare_thread = None
             self._item_loader.close(self._last_chunk_index)

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -223,6 +223,8 @@ class PrepareChunksThread(Thread):
             if self._pre_download_counter < self._max_pre_download:
                 chunk_index = _get_from_queue(self._to_download_queue)
                 if chunk_index == _END_TOKEN:
+                    if self._max_cache_size:
+                        self._maybe_delete_chunks()
                     self._has_exited = True
                     return
 

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -197,7 +197,7 @@ class PrepareChunksThread(Thread):
         self._item_loader.pre_load_chunk(chunk_index, chunk_filepath)
 
     def _force_download(self) -> None:
-        chunk_index = _get_from_queue(self._force_download_queue)
+        chunk_index = _get_from_queue(self._force_download_queue, _DEFAULT_TIMEOUT)
         if chunk_index is not None:
             if _DEBUG:
                 chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -171,8 +171,6 @@ class PrepareChunksThread(Thread):
         )
 
         if chunk_index is not None:
-            self._pre_download_counter -= 1
-
             # Store the current chunk index
             self._chunks_index_to_be_deleted.append(chunk_index)
 
@@ -180,13 +178,13 @@ class PrepareChunksThread(Thread):
         while self._max_cache_size and self._chunks_index_to_be_deleted and self._can_delete_chunk():
             # Delete the oldest chunk
             self._apply_delete(self._chunks_index_to_be_deleted.pop(0))
-
+        # Decrement the pre-download counter
+        self._pre_download_counter -= 1
         return
 
     def _can_delete_chunk(self) -> bool:
         if self._delete_chunks_when_processed:
-            # TODO: check why it is >= self.max_pre_download - 1
-            return self._pre_download_counter >= 0
+            return self._pre_download_counter >= self._max_pre_download - 1
         return (
             self._max_cache_size is not None
             and _get_folder_size(self._config._cache_dir, self._config) >= self._max_cache_size

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -1540,9 +1540,9 @@ def test_dataset_as_iterator_and_non_iterator(tmpdir, local, shuffle):
         assert data is not None
         if local and i < dataset_length - 1:
             # In iterator mode with local or remote data, _chunks_queued_for_download should be enabled
-            assert dataset.cache._reader._chunks_queued_for_download is True, (
-                "_chunks_queued_for_download should be enabled during iteration"
-            )
+            assert (
+                dataset.cache._reader._chunks_queued_for_download is True
+            ), "_chunks_queued_for_download should be enabled during iteration"
         else:
             assert dataset.cache._reader._chunks_queued_for_download is False, (
                 "_chunks_queued_for_download should be disabled when used as local dir without `local:` prefix"

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -1603,7 +1603,6 @@ def test_cache_get_clear_after_dataset_stream(tmpdir, shuffle):
     chunks = [f for f in cache_contents if ".bin" in f]
 
     assert len(chunks) == 0, (
-        f"Cache directory should be empty after streaming through the dataset.\n"
-        f"Shuffle: {shuffle}\n"
+        f"All of the chunks should have been cleared from the cache directory after streaming."
         f"Found {len(chunks)} chunk files: {chunks}"
     )

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -1561,6 +1561,7 @@ def test_dataset_as_iterator_and_non_iterator(tmpdir, local, shuffle):
     assert dataset.cache._reader._chunks_queued_for_download is False
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Not tested on windows")
 @pytest.mark.parametrize("shuffle", [True, False])
 def test_cache_get_clear_after_dataset_stream(tmpdir, shuffle):
     """Test that the cache directory is cleaned up after streaming through the dataset.

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -320,7 +320,7 @@ def test_streaming_dataset_distributed_full_shuffle_odd(drop_last, tmpdir, compr
         ),
     ],
 )
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(60)
 def test_streaming_dataset_distributed_full_shuffle_even(drop_last, tmpdir, compression):
     seed_everything(42)
 

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -56,7 +56,7 @@ def test_reader_chunk_removal(tmpdir):
         index = ChunkedIndex(*cache._get_chunk_index_from_index(i), is_last_index=i == 24)
         assert cache[index] == i
 
-    assert len(filter_lock_files(os.listdir(cache_dir))) in [2, 3]
+    assert len(filter_lock_files(os.listdir(cache_dir))) in [1, 2, 3]
 
 
 def test_reader_chunk_removal_compressed(tmpdir):
@@ -101,7 +101,7 @@ def test_reader_chunk_removal_compressed(tmpdir):
         index = ChunkedIndex(*cache._get_chunk_index_from_index(i), is_last_index=i == 24)
         assert cache[index] == i
 
-    assert len(filter_lock_files(os.listdir(cache_dir))) in [2, 3]
+    assert len(filter_lock_files(os.listdir(cache_dir))) in [1, 2, 3]
 
 
 def test_get_folder_size(tmpdir, caplog):


### PR DESCRIPTION
## What does this PR do?  
Fixes #533.  

This PR fixes the deletion issue for the last chunk within in a worker process, when in `deletion` mode and updates the order in which the `_pre_download_counter` is decremented.  
<details>
<summary> <b>Details on _pre_download_counter </b></summary>

Previously, `_pre_download_counter` was decremented before `_can_delete_chunk()` was evaluated. However, `_can_delete_chunk()` depends on `_pre_download_counter`, leading to incorrect behavior.  

For example, if there is only one chunk and `_pre_download_counter` value is incremented to `1` after download, the counter should allow its deletion later. But because `_pre_download_counter` was already decremented back to `0` before the check, `_can_delete_chunk()` would always return `False`.  

Consider a case where `_max_pre_download = 2`:  
```python
self._pre_download_counter >= self._max_pre_download - 1
```
If `_pre_download_counter` is 0, this evaluates as `0 >= 1`, which is `False`, preventing the chunk from being deleted.  

By adjusting the order of operations, we ensure that `_can_delete_chunk()` gets evaluated with the correct counter value, allowing proper last chunk deletion.  
</details>

Also, part of #512.
> This PR only addresses the deletion of the last remaining chunk. There are still underlying issues with lock count decrements, which seem to appear when the number of ddp processes exceeds 5 (not 100% sure, but observed in a few tests). This prevents the deletion of a lot of chunks.

Experiment results [here](https://github.com/Lightning-AI/litData/pull/536#issuecomment-2782586876)

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
