### PR TITLE
Update `JPEGSerializer` (deserialize) to return as a tensor and also make `torchvision` required dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 torch
+torchvision
 lightning-utilities
 filelock
 numpy

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,4 +1,3 @@
-torchvision
 pillow
 viztracer
 pyarrow

--- a/src/litdata/streaming/serializers.py
+++ b/src/litdata/streaming/serializers.py
@@ -126,7 +126,7 @@ class JPEGSerializer(Serializer):
 
         raise TypeError(f"The provided item should be of type `JpegImageFile`. Found {item}.")
 
-    def deserialize(self, data: bytes) -> torch.Tensor:  # type: ignore
+    def deserialize(self, data: bytes) -> torch.Tensor:
         from torchvision.io import decode_jpeg
         from torchvision.transforms.functional import pil_to_tensor
 

--- a/src/litdata/streaming/serializers.py
+++ b/src/litdata/streaming/serializers.py
@@ -126,7 +126,7 @@ class JPEGSerializer(Serializer):
 
         raise TypeError(f"The provided item should be of type `JpegImageFile`. Found {item}.")
 
-    def deserialize(self, data: bytes) -> torch.Tensor:
+    def deserialize(self, data: bytes) -> torch.Tensor:  # type: ignore
         from torchvision.io import decode_jpeg
 
         array = torch.frombuffer(data, dtype=torch.uint8)

--- a/src/litdata/streaming/serializers.py
+++ b/src/litdata/streaming/serializers.py
@@ -19,7 +19,7 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict
 from contextlib import suppress
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 import tifffile
@@ -28,10 +28,7 @@ from lightning_utilities.core.imports import RequirementCache
 
 from litdata.constants import _NUMPY_DTYPES_MAPPING, _TORCH_DTYPES_MAPPING
 
-if TYPE_CHECKING:
-    from PIL.JpegImagePlugin import JpegImageFile
 _PIL_AVAILABLE = RequirementCache("PIL")
-_TORCH_VISION_AVAILABLE = RequirementCache("torchvision")
 _AV_AVAILABLE = RequirementCache("av")
 
 
@@ -129,20 +126,13 @@ class JPEGSerializer(Serializer):
 
         raise TypeError(f"The provided item should be of type `JpegImageFile`. Found {item}.")
 
-    def deserialize(self, data: bytes) -> Union["JpegImageFile", torch.Tensor]:
-        if _TORCH_VISION_AVAILABLE:
-            from torchvision.io import decode_jpeg
-            from torchvision.transforms.functional import pil_to_tensor
+    def deserialize(self, data: bytes) -> torch.Tensor:
+        from torchvision.io import decode_jpeg
 
-            array = torch.frombuffer(data, dtype=torch.uint8)
-            # Note: Some datasets like Imagenet contains some PNG images with JPEG extension, so we fallback to PIL
-            with suppress(RuntimeError):
-                return decode_jpeg(array)
-
-        img = PILSerializer.deserialize(data)
-        if _TORCH_VISION_AVAILABLE:
-            img = pil_to_tensor(img)
-        return img
+        array = torch.frombuffer(data, dtype=torch.uint8)
+        # Note: Some datasets like Imagenet contains some PNG images with JPEG extension, so we fallback to PIL
+        with suppress(RuntimeError):
+            return decode_jpeg(array)
 
     def can_serialize(self, item: Any) -> bool:
         if not _PIL_AVAILABLE:
@@ -327,9 +317,6 @@ class VideoSerializer(Serializer):
             return f.read(), f"video:{file_extension}"
 
     def deserialize(self, data: bytes) -> Any:
-        if not _TORCH_VISION_AVAILABLE:
-            raise ModuleNotFoundError("torchvision is required. Run `pip install torchvision`")
-
         if not _AV_AVAILABLE:
             raise ModuleNotFoundError("av is required. Run `pip install av`")
 

--- a/tests/streaming/test_cache.py
+++ b/tests/streaming/test_cache.py
@@ -39,7 +39,6 @@ def seed_everything(random_seed):
 
 
 _PIL_AVAILABLE = RequirementCache("PIL")
-_TORCH_VISION_AVAILABLE = RequirementCache("torchvision")
 _LIGHTNING_AVAILABLE = RequirementCache("lightning")
 
 
@@ -139,9 +138,7 @@ def _cache_for_image_dataset(num_workers, tmpdir, fabric=None):
         pass
 
 
-@pytest.mark.skipif(
-    condition=not _PIL_AVAILABLE or not _TORCH_VISION_AVAILABLE, reason="Requires: ['pil', 'torchvision']"
-)
+@pytest.mark.skipif(condition=not _PIL_AVAILABLE, reason="Requires: 'pil'")
 @pytest.mark.parametrize("num_workers", [0])
 def test_cache_for_image_dataset(num_workers, tmpdir):
     cache_dir = os.path.join(tmpdir, "cache")
@@ -155,8 +152,8 @@ def _fabric_cache_for_image_dataset(fabric, num_workers, tmpdir):
 
 
 @pytest.mark.skipif(
-    condition=not _PIL_AVAILABLE or not _TORCH_VISION_AVAILABLE or sys.platform == "win32" or not _LIGHTNING_AVAILABLE,
-    reason="Requires: ['pil', 'torchvision']",
+    condition=not _PIL_AVAILABLE or sys.platform == "win32" or not _LIGHTNING_AVAILABLE,
+    reason="Requires: 'pil'",
 )
 @pytest.mark.parametrize("num_workers", [2])
 def test_cache_for_image_dataset_distributed(num_workers, tmpdir):

--- a/tests/streaming/test_serializer.py
+++ b/tests/streaming/test_serializer.py
@@ -29,7 +29,6 @@ from litdata.streaming.serializers import (
     _NUMPY_DTYPES_MAPPING,
     _SERIALIZERS,
     _TORCH_DTYPES_MAPPING,
-    _TORCH_VISION_AVAILABLE,
     BooleanSerializer,
     IntegerSerializer,
     JPEGSerializer,
@@ -215,9 +214,7 @@ def test_assert_no_header_numpy_serializer():
     np.testing.assert_equal(t, new_t)
 
 
-@pytest.mark.skipif(
-    condition=not _TORCH_VISION_AVAILABLE or not _AV_AVAILABLE, reason="Requires: ['torchvision', 'av']"
-)
+@pytest.mark.skipif(condition=not _AV_AVAILABLE, reason="Requires: 'av'")
 def test_wav_deserialization(tmpdir):
     from torch.hub import download_url_to_file
 


### PR DESCRIPTION
## What does this PR do?
This pr updates `JPEGSerializer` (deserialize) to return as a tensor and also make `torchvision` as a required dependency.

Also, fixes #540.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
