### PR TITLE
Add file filtering support to `StreamingDataset` for Parquet datasets

### DIFF
--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -60,6 +60,7 @@ class StreamingDataset(IterableDataset):
         max_pre_download: int = 2,
         index_path: Optional[str] = None,
         force_override_state_dict: bool = False,
+        fnmatch_pattern: str = None,
     ) -> None:
         """The streaming dataset can be used once your data have been optimised using the DatasetOptimiser class.
 
@@ -84,7 +85,7 @@ class StreamingDataset(IterableDataset):
                 If `index_path` is a directory, the function will look for `index.json` within it.
                 If `index_path` is a full file path, it will use that directly.
             force_override_state_dict: Boolean flag for allowing local arguments to override a loaded state dict.
-
+            fnmatch_pattern: Filename pattern to filter files in `input_dir`.
         """
         _check_version_and_prompt_upgrade(__version__)
 
@@ -119,7 +120,15 @@ class StreamingDataset(IterableDataset):
         self.subsampled_files: List[str] = []
         self.region_of_interest: List[Tuple[int, int]] = []
         self.subsampled_files, self.region_of_interest = subsample_streaming_dataset(
-            self.input_dir, self.cache_dir, item_loader, subsample, shuffle, seed, storage_options, index_path
+            self.input_dir,
+            self.cache_dir,
+            item_loader,
+            subsample,
+            shuffle,
+            seed,
+            storage_options,
+            index_path,
+            fnmatch_pattern,
         )
 
         self.item_loader = item_loader

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -60,12 +60,12 @@ class StreamingDataset(IterableDataset):
         max_pre_download: int = 2,
         index_path: Optional[str] = None,
         force_override_state_dict: bool = False,
-        fnmatch_pattern: str = None,
     ) -> None:
         """The streaming dataset can be used once your data have been optimised using the DatasetOptimiser class.
 
         Args:
-            input_dir: Path to the folder where the input data is stored.
+            input_dir: Path to the folder where the input data is stored. Supports paths ending with `.parquet`
+                with wildcards in the basename to stream specific Parquet files.
             cache_dir: Path to the folder where the cache data is stored. If not provided, the cache will be stored
                 in the default cache directory.
             item_loader: The logic to load an item from a chunk.
@@ -85,7 +85,6 @@ class StreamingDataset(IterableDataset):
                 If `index_path` is a directory, the function will look for `index.json` within it.
                 If `index_path` is a full file path, it will use that directly.
             force_override_state_dict: Boolean flag for allowing local arguments to override a loaded state dict.
-            fnmatch_pattern: Filename pattern to filter files in `input_dir`.
         """
         _check_version_and_prompt_upgrade(__version__)
 
@@ -95,6 +94,10 @@ class StreamingDataset(IterableDataset):
 
         if not isinstance(subsample, float) or subsample <= 0.0:
             raise ValueError("subsample must be a float with value greater than 0.")
+
+        fnmatch_pattern = None
+        if isinstance(input_dir, str) and input_dir.endswith(".parquet"):
+            input_dir, fnmatch_pattern = os.path.split(input_dir)
 
         input_dir = _resolve_dir(input_dir)
         cache_dir = _resolve_dir(cache_dir)

--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -24,6 +24,7 @@ def subsample_streaming_dataset(
     seed: int = 42,
     storage_options: Optional[Dict] = {},
     index_path: Optional[str] = None,
+    fnmatch_pattern: str = None,
 ) -> Tuple[List[str], List[Tuple[int, int]]]:
     """Subsample streaming dataset.
 
@@ -74,6 +75,11 @@ def subsample_streaming_dataset(
             f"The provided dataset `{input_dir.path}` doesn't contain any {_INDEX_FILENAME} file."
             "\n HINT: Did you successfully optimize a dataset to the provided `input_dir`?"
         )
+
+    if fnmatch_pattern is not None:
+        from fnmatch import fnmatch
+
+        original_chunks = [chunk for chunk in original_chunks if fnmatch(chunk["filename"], fnmatch_pattern)]
 
     assert len(original_chunks) > 0, f"No chunks found in the `{input_dir}/index.json` file"
 

--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -24,7 +24,7 @@ def subsample_streaming_dataset(
     seed: int = 42,
     storage_options: Optional[Dict] = {},
     index_path: Optional[str] = None,
-    fnmatch_pattern: str = None,
+    fnmatch_pattern: Optional[str] = None,
 ) -> Tuple[List[str], List[Tuple[int, int]]]:
     """Subsample streaming dataset.
 

--- a/tests/streaming/test_parquet.py
+++ b/tests/streaming/test_parquet.py
@@ -210,7 +210,7 @@ def test_stream_hf_parquet_dataset(monkeypatch, huggingface_hub_fs_mock, pq_data
         ("hf://datasets/some_org/some_repo/some_path/tmp-[012].parquet", 15, nullcontext()),
         ("hf://datasets/some_org/some_repo/some_path/tmp-0.parquet", 5, nullcontext()),
         ("hf://datasets/some_org/some_repo/some_path/foo.parquet", 0, pytest.raises(AssertionError, match="No chunks")),
-    ]
+    ],
 )
 def test_input_dir_wildcard(monkeypatch, huggingface_hub_fs_mock, hf_url, length, context):
     with context:


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #539.

We agreed to go for filename and wildcard support directly in `input_dir` instead of an explicit `fnmatch_pattern`-like option. A heuristic is thus needed to detect whether `input_dir` specifies a filename or not. I have decided to simply check whether `input_dir` ends with `".parquet"`. The file filtering is then implemented in `subsample_streaming_dataset`.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
