### PR TITLE
Fix parquet cache

### DIFF
--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -107,8 +107,6 @@ class StreamingDataset(IterableDataset):
             if index_path is None:
                 # No index_path was provided. Attempt to load it from cache or generate it dynamically on the fly.
                 index_path = index_hf_dataset(input_dir.url)
-                cache_dir.path = index_path
-                input_dir.path = index_path
 
             if item_loader is not None and not isinstance(item_loader, ParquetLoader):
                 raise ValueError(

--- a/tests/streaming/test_parquet.py
+++ b/tests/streaming/test_parquet.py
@@ -230,8 +230,8 @@ def test_cache_dir_option(monkeypatch, huggingface_hub_fs_mock, default):
     index_cache_dir = default_cache_dir(hf_url)
     with tempfile.TemporaryDirectory() as tmpdir:
         ds = StreamingDataset(hf_url, cache_dir=None if default else tmpdir)
-        assert ds.cache_dir.path == (None if default else tmpdir)
-        assert ds.input_dir.path.startswith(_DEFAULT_CACHE_DIR if default else tmpdir)
+        assert ds.cache_dir.path == (None if default else os.path.realpath(tmpdir))
+        assert ds.input_dir.path.startswith(_DEFAULT_CACHE_DIR if default else os.path.realpath(tmpdir))
         # check index file is sole file in chunk cache dir
         assert len(os.listdir(ds.input_dir.path)) == 1
         assert os.path.exists(os.path.join(ds.input_dir.path, _INDEX_FILENAME))
@@ -242,6 +242,6 @@ def test_cache_dir_option(monkeypatch, huggingface_hub_fs_mock, default):
         for _ in ds:
             pass
         # check chunk cache dir was filled
-        assert len(os.listdir(ds.input_dir.path)) == 11  # 5 chunks, 5 lock files and 1 index file
+        assert len([f for f in os.listdir(ds.input_dir.path) if f.endswith(".parquet")]) == 5  # 5 chunks
         # check index cache dir was not filled
         assert len(os.listdir(index_cache_dir)) == 1

--- a/tests/streaming/test_parquet.py
+++ b/tests/streaming/test_parquet.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import os
 import sys
+import tempfile
 from contextlib import nullcontext
 from fnmatch import fnmatch
 from types import ModuleType
@@ -9,7 +10,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from litdata.constants import _INDEX_FILENAME
+from litdata.constants import _DEFAULT_CACHE_DIR, _INDEX_FILENAME
 from litdata.streaming.dataset import StreamingDataset
 from litdata.streaming.item_loader import ParquetLoader, PyTreeLoader
 from litdata.streaming.writer import index_parquet_dataset
@@ -218,3 +219,29 @@ def test_input_dir_wildcard(monkeypatch, huggingface_hub_fs_mock, hf_url, length
         pattern = os.path.basename(hf_url)
         assert all(fnmatch(fn, pattern) for fn in ds.subsampled_files)
         assert len(ds) == length  # 5 datasets for 5 loops
+
+
+@pytest.mark.usefixtures("clean_pq_index_cache")
+@patch("litdata.utilities.parquet._HF_HUB_AVAILABLE", True)
+@patch("litdata.streaming.downloader._HF_HUB_AVAILABLE", True)
+@pytest.mark.parametrize("default", [False, True])
+def test_cache_dir_option(monkeypatch, huggingface_hub_fs_mock, default):
+    hf_url = "hf://datasets/some_org/some_repo/some_path"
+    index_cache_dir = default_cache_dir(hf_url)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ds = StreamingDataset(hf_url, cache_dir=None if default else tmpdir)
+        assert ds.cache_dir.path == (None if default else tmpdir)
+        assert ds.input_dir.path.startswith(_DEFAULT_CACHE_DIR if default else tmpdir)
+        # check index file is sole file in chunk cache dir
+        assert len(os.listdir(ds.input_dir.path)) == 1
+        assert os.path.exists(os.path.join(ds.input_dir.path, _INDEX_FILENAME))
+        # check index file is sole file in index cache dir
+        assert len(os.listdir(index_cache_dir)) == 1
+        assert os.path.exists(os.path.join(index_cache_dir, _INDEX_FILENAME))
+        # iterate over dataset to fill cache
+        for _ in ds:
+            pass
+        # check chunk cache dir was filled
+        assert len(os.listdir(ds.input_dir.path)) == 11  # 5 chunks, 5 lock files and 1 index file
+        # check index cache dir was not filled
+        assert len(os.listdir(index_cache_dir)) == 1


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #544.

This fix removes two lines of code in `StreamingDataset.__init__` which were executed only for Hugging Face datasets: 
- The first line was causing the `cache_dir` option to be ignored.
- The second line was causing the `_try_create_cache_dir` call in `subsample_streaming_dataset` to be skipped, and `input_dir.path = index_path` to be used as the cache dir.

The Parquet files are now cached in `~/.lightning/chunks/` by default, like the LitData-optimized chunks. They used to be cached in `~/.cache/litdata-cache-index-pq/` next to the index file. The index file is now still cached in `~/.cache/litdata-cache-index-pq/`. The index file is also cached in `~/.lightning/chunks/` or the user-provided cache dir.

Added a test.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
