### PR TITLE
fix: Consolidate Cache Handling + Fix DDP Multi-Indexing for huggingface datasets

### DIFF
--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -106,7 +106,7 @@ class StreamingDataset(IterableDataset):
         if input_dir.url is not None and input_dir.url.startswith("hf://"):
             if index_path is None:
                 # No index_path was provided. Attempt to load it from cache or generate it dynamically on the fly.
-                index_path = index_hf_dataset(input_dir.url)
+                index_path = index_hf_dataset(input_dir.url, cache_dir.path)
 
             if item_loader is not None and not isinstance(item_loader, ParquetLoader):
                 raise ValueError(

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -107,7 +107,6 @@ class StreamingDataset(IterableDataset):
             if index_path is None:
                 # No index_path was provided. Attempt to load it from cache or generate it dynamically on the fly.
                 index_path = index_hf_dataset(input_dir.url, cache_dir.path)
-
             if item_loader is not None and not isinstance(item_loader, ParquetLoader):
                 raise ValueError(
                     "Invalid item_loader for hf://datasets. "

--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -187,6 +187,18 @@ def _clear_cache_dir_if_updated(input_dir_hash_filepath: str, updated_at_hash: s
             shutil.rmtree(input_dir_hash_filepath)
 
 
+def generate_md5_hash(value: str) -> str:
+    """Generate an MD5 hash for the given string value.
+
+    Args:
+        value (str): The input string to hash.
+
+    Returns:
+        str: The hexadecimal MD5 hash of the input string.
+    """
+    return hashlib.md5(value.encode()).hexdigest()  # noqa: S324
+
+
 def _try_create_cache_dir(
     input_dir: Optional[str],
     cache_dir: Optional[str] = None,
@@ -199,9 +211,9 @@ def _try_create_cache_dir(
 
     # Fallback to a hash of the input_dir if updated_at is "0"
     if updated_at == "0" and input_dir is not None:
-        updated_at = hashlib.md5(input_dir.encode()).hexdigest()  # noqa: S324
+        updated_at = generate_md5_hash(input_dir)
 
-    dir_url_hash = hashlib.md5((resolved_input_dir.url or "").encode()).hexdigest()  # noqa: S324
+    dir_url_hash = generate_md5_hash(resolved_input_dir.url or "")
 
     # Determine cache root based on environment
     is_lightning_cloud = "LIGHTNING_CLUSTER_ID" in os.environ and "LIGHTNING_CLOUD_PROJECT_ID" in os.environ

--- a/src/litdata/utilities/hf_dataset.py
+++ b/src/litdata/utilities/hf_dataset.py
@@ -10,7 +10,7 @@ from filelock import FileLock, Timeout
 
 from litdata.constants import _INDEX_FILENAME
 from litdata.streaming.writer import index_parquet_dataset
-from litdata.utilities.dataset_utilities import _try_create_cache_dir, generate_md5_hash
+from litdata.utilities.dataset_utilities import _try_create_cache_dir, generate_md5_hash, get_default_cache_dir
 
 
 def index_hf_dataset(dataset_url: str, cache_dir: Optional[str] = None) -> str:
@@ -66,8 +66,8 @@ def _get_existing_cache(dataset_url: str, cache_dir: Optional[str]) -> Optional[
     Returns:
         Optional[str]: The path to the existing cache directory if found, otherwise None.
     """
-    if not cache_dir:
-        return None
+    # Determine the cache directory, preferring user-provided cache_dir if given
+    cache_dir = cache_dir if cache_dir is not None else get_default_cache_dir()
 
     url_hash = generate_md5_hash(dataset_url)
     hashed_cache_path = os.path.join(cache_dir, url_hash)

--- a/src/litdata/utilities/hf_dataset.py
+++ b/src/litdata/utilities/hf_dataset.py
@@ -1,34 +1,55 @@
 """Contains utility functions for indexing and streaming HF datasets."""
 
 import os
-
+import tempfile
+import shutil
 from litdata.constants import _INDEX_FILENAME
 from litdata.streaming.writer import index_parquet_dataset
-from litdata.utilities.parquet import default_cache_dir
+from litdata.utilities.dataset_utilities import _try_create_cache_dir, generate_md5_hash
 
 
-def index_hf_dataset(hf_url: str) -> str:
+def index_hf_dataset(hf_url: str, cache_dir: str = None) -> str:
     """Index a Hugging Face dataset and return the cache directory path.
 
     Args:
-        hf_url (str): The URL of the Hugging Face dataset.
+        hf_url (str): The URL of the Hugging Face dataset (must start with 'hf://').
+        cache_dir (str, optional): The directory where the cache and index will be stored. Defaults to None.
 
     Returns:
         str: The path to the cache directory containing the index.
+
+    Raises:
+        ValueError: If the provided URL does not start with 'hf://'.
     """
     if not hf_url.startswith("hf://"):
         raise ValueError(
             f"Invalid Hugging Face dataset URL: {hf_url}. "
             "The URL should start with 'hf://'. Please check the URL and try again."
         )
+    # If cache_dir is provided, check if the index already exists and return early if so
+    if cache_dir:
+        url_hash = generate_md5_hash(hf_url)
+        cache_dir = os.path.join(cache_dir, url_hash)
+        if os.path.exists(cache_dir):
+            dirs = os.listdir(cache_dir)
+            final_cache_dir = os.path.join(cache_dir, dirs[0] if dirs else "")
+            if os.path.exists(os.path.join(final_cache_dir, _INDEX_FILENAME)):
+                print(f"Index already exists at {final_cache_dir}.")
+                return final_cache_dir
+            else:
+                print("Index not found in cache")
+        else:
+            print("cache not exist, creating a new one.", cache_dir)
 
-    cache_dir = default_cache_dir(hf_url)
-    cache_index_path = os.path.join(cache_dir, _INDEX_FILENAME)
+    # Otherwise, create a new index file
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_index_path = os.path.join(temp_dir, _INDEX_FILENAME)
+        index_parquet_dataset(hf_url, temp_dir, num_workers=os.cpu_count() or 4)
 
-    if os.path.exists(cache_index_path):
-        print(f"Found existing HF {_INDEX_FILENAME} file for {hf_url} at {cache_index_path}.")
-    else:
+        # Prepare the cache directory and move the index file there
+        final_cache_dir = _try_create_cache_dir(hf_url, cache_dir, index_path=temp_index_path)
+        cache_index_path = os.path.join(final_cache_dir, _INDEX_FILENAME)
         print(f"Indexing HF dataset from {hf_url} into {cache_index_path}.")
-        index_parquet_dataset(hf_url, cache_dir, num_workers=os.cpu_count() or 4)
-
-    return cache_dir
+        shutil.copyfile(temp_index_path, cache_index_path)
+        print(f"Index created at {cache_index_path}.")
+        return final_cache_dir

--- a/src/litdata/utilities/hf_dataset.py
+++ b/src/litdata/utilities/hf_dataset.py
@@ -34,7 +34,7 @@ def index_hf_dataset(dataset_url: str, cache_dir: Optional[str] = None) -> str:
 
     # Acquire a file lock to guarantee exclusive access,
     # ensuring that multiple processes do not create the index simultaneously.
-    with suppress(Timeout), FileLock(os.path.join(tempfile.gettempdir(), "hf_index.lock"), timeout=5):
+    with suppress(Timeout), FileLock(os.path.join(tempfile.gettempdir(), "hf_index.lock"), timeout=20):
         # Check for existing index in the cache
         cache_directory = _get_existing_cache(dataset_url, cache_dir)
         if cache_directory:

--- a/src/litdata/utilities/hf_dataset.py
+++ b/src/litdata/utilities/hf_dataset.py
@@ -48,11 +48,12 @@ def index_hf_dataset(dataset_url: str, cache_dir: Optional[str] = None) -> str:
 
             # Prepare the cache directory and move the index file there
             cache_dir = _try_create_cache_dir(dataset_url, cache_dir, index_path=temp_index_path)
+            assert cache_dir is not None
             cache_index_path = os.path.join(cache_dir, _INDEX_FILENAME)
             shutil.copyfile(temp_index_path, cache_index_path)
             print(f"Index created at {cache_index_path}.")
 
-    return cache_dir
+    return cache_dir  # type: ignore
 
 
 def _get_existing_cache(dataset_url: str, cache_dir: Optional[str]) -> Optional[str]:

--- a/src/litdata/utilities/hf_dataset.py
+++ b/src/litdata/utilities/hf_dataset.py
@@ -3,53 +3,80 @@
 import os
 import shutil
 import tempfile
+from contextlib import suppress
+from typing import Optional
+
+from filelock import FileLock, Timeout
 
 from litdata.constants import _INDEX_FILENAME
 from litdata.streaming.writer import index_parquet_dataset
 from litdata.utilities.dataset_utilities import _try_create_cache_dir, generate_md5_hash
 
 
-def index_hf_dataset(hf_url: str, cache_dir: str = None) -> str:
-    """Index a Hugging Face dataset and return the cache directory path.
+def index_hf_dataset(dataset_url: str, cache_dir: Optional[str] = None) -> str:
+    """Indexes a Hugging Face dataset and returns the path to the cache directory.
 
     Args:
-        hf_url (str): The URL of the Hugging Face dataset (must start with 'hf://').
-        cache_dir (str, optional): The directory where the cache and index will be stored. Defaults to None.
+        dataset_url (str): The URL of the Hugging Face dataset, starting with 'hf://'.
+        cache_dir (Optional[str]): The directory for storing the cache and index. If None, a default location is used.
 
     Returns:
-        str: The path to the cache directory containing the index.
+        str: The path to the cache directory containing the index file.
 
     Raises:
-        ValueError: If the provided URL does not start with 'hf://'.
+        ValueError: If the dataset URL does not start with 'hf://'.
     """
-    if not hf_url.startswith("hf://"):
+    if not dataset_url.startswith("hf://"):
         raise ValueError(
-            f"Invalid Hugging Face dataset URL: {hf_url}. "
-            "The URL should start with 'hf://'. Please check the URL and try again."
+            f"Invalid Hugging Face dataset URL: {dataset_url}. "
+            "URLs must start with 'hf://'. Please check the URL and try again."
         )
-    # If cache_dir is provided, check if the index already exists and return early if so
-    if cache_dir:
-        url_hash = generate_md5_hash(hf_url)
-        cache_dir = os.path.join(cache_dir, url_hash)
-        if os.path.exists(cache_dir):
-            dirs = os.listdir(cache_dir)
-            final_cache_dir = os.path.join(cache_dir, dirs[0] if dirs else "")
-            if os.path.exists(os.path.join(final_cache_dir, _INDEX_FILENAME)):
-                print(f"Index already exists at {final_cache_dir}.")
-                return final_cache_dir
-            print("Index not found in cache")
-        else:
-            print("cache not exist, creating a new one.", cache_dir)
 
-    # Otherwise, create a new index file
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_index_path = os.path.join(temp_dir, _INDEX_FILENAME)
-        index_parquet_dataset(hf_url, temp_dir, num_workers=os.cpu_count() or 4)
+    # Acquire a file lock to guarantee exclusive access,
+    # ensuring that multiple processes do not create the index simultaneously.
+    with suppress(Timeout), FileLock(os.path.join(tempfile.gettempdir(), "hf_index.lock"), timeout=5):
+        # Check for existing index in the cache
+        cache_directory = _get_existing_cache(dataset_url, cache_dir)
+        if cache_directory:
+            print(f"Using existing index at {cache_directory}.")
+            return cache_directory
 
-        # Prepare the cache directory and move the index file there
-        final_cache_dir = _try_create_cache_dir(hf_url, cache_dir, index_path=temp_index_path)
-        cache_index_path = os.path.join(final_cache_dir, _INDEX_FILENAME)
-        print(f"Indexing HF dataset from {hf_url} into {cache_index_path}.")
-        shutil.copyfile(temp_index_path, cache_index_path)
-        print(f"Index created at {cache_index_path}.")
-        return final_cache_dir
+        # Otherwise, create a new index file
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_index_path = os.path.join(temp_dir, _INDEX_FILENAME)
+            index_parquet_dataset(dataset_url, temp_dir, num_workers=os.cpu_count() or 4)
+
+            # Prepare the cache directory and move the index file there
+            cache_dir = _try_create_cache_dir(dataset_url, cache_dir, index_path=temp_index_path)
+            cache_index_path = os.path.join(cache_dir, _INDEX_FILENAME)
+            shutil.copyfile(temp_index_path, cache_index_path)
+            print(f"Index created at {cache_index_path}.")
+
+    return cache_dir
+
+
+def _get_existing_cache(dataset_url: str, cache_dir: Optional[str]) -> Optional[str]:
+    """Checks if a cache directory with an index file exists for the given dataset URL.
+
+    Args:
+        dataset_url (str): The URL of the Hugging Face dataset.
+        cache_dir (Optional[str]): The root directory for the cache.
+
+    Returns:
+        Optional[str]: The path to the existing cache directory if found, otherwise None.
+    """
+    if not cache_dir:
+        return None
+
+    url_hash = generate_md5_hash(dataset_url)
+    hashed_cache_path = os.path.join(cache_dir, url_hash)
+
+    if not os.path.exists(hashed_cache_path):
+        return None
+
+    for subdir in os.listdir(hashed_cache_path):
+        potential_cache_dir = os.path.join(hashed_cache_path, subdir)
+        if os.path.exists(os.path.join(potential_cache_dir, _INDEX_FILENAME)):
+            return potential_cache_dir
+
+    return None

--- a/src/litdata/utilities/hf_dataset.py
+++ b/src/litdata/utilities/hf_dataset.py
@@ -1,8 +1,9 @@
 """Contains utility functions for indexing and streaming HF datasets."""
 
 import os
-import tempfile
 import shutil
+import tempfile
+
 from litdata.constants import _INDEX_FILENAME
 from litdata.streaming.writer import index_parquet_dataset
 from litdata.utilities.dataset_utilities import _try_create_cache_dir, generate_md5_hash
@@ -36,8 +37,7 @@ def index_hf_dataset(hf_url: str, cache_dir: str = None) -> str:
             if os.path.exists(os.path.join(final_cache_dir, _INDEX_FILENAME)):
                 print(f"Index already exists at {final_cache_dir}.")
                 return final_cache_dir
-            else:
-                print("Index not found in cache")
+            print("Index not found in cache")
         else:
             print("cache not exist, creating a new one.", cache_dir)
 

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -60,8 +60,6 @@ class ParquetDir(ABC):
             data = {"chunks": chunks_info, "config": config, "updated_at": str(time())}
             json.dump(data, f, sort_keys=True)
 
-        print(f"Index file successfully written to: {index_file_path}")
-
 
 class LocalParquetDir(ParquetDir):
     def __init__(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from litdata import CombinedStreamingDataset, StreamingDataset
 from litdata.constants import _POLARS_AVAILABLE
 from litdata.streaming.cache import Cache
 from litdata.streaming.reader import PrepareChunksThread
+from litdata.utilities.dataset_utilities import get_default_cache_dir
 
 
 @pytest.fixture(autouse=True)
@@ -168,7 +169,7 @@ def write_pq_data(pq_data, tmp_path):
 @pytest.fixture
 def clean_pq_index_cache():
     """Ensures the PQ index cache is cleared before and after the test."""
-    cache_path = os.path.join(os.path.expanduser("~"), ".cache", "litdata-cache-index-pq")
+    cache_path = os.path.join(get_default_cache_dir())
 
     # Cleanup before the test
     if os.path.exists(cache_path):


### PR DESCRIPTION
## What does this PR do?
### 🛠️ Changes in this PR

1. **Consolidate Cache Directories**
   - Removed `.cache/litdata-cache-index-pq`.
   - Now, all chunks and index files are stored under `DEFAULT_CACHE_DIR` (or user-passed `cache_dir`).
   - Users can still separately manage indexes if needed by manually calling `index_hf_dataset` and passing the `cache_dir`.

2. **Fix DDP Multi-Indexing**
   - Only **one process per node** now handles indexing.
   - Fixes race conditions, cache conflicts, and random DDP failures during streaming.

3. **Minor Refactoring and Tests**
   - Small code cleanups and updates to related tests to match the new updates.

## Related issues:

Fixes #562
Fixes [multi cache dir issue](https://github.com/Lightning-AI/litData/issues/544#issuecomment-2816022581)


## PR review:
 Anyone in the community is welcome to review!  


## Did you have fun?

> Absolutely! 🚀  
It’s exciting improving LitData for smoother distributed and streaming workflows!

## 📋 Extra Note:
After this PR, the `.cache/litdata-cache-index-pq` directory becomes obsolete.  
Users upgrading should manually delete it if needed to free up space.