### PR TITLE
pin:snowballstemmer dependency

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,5 +11,6 @@ sphinx-paramlinks >=0.5.1
 sphinx-togglebutton >=0.2
 sphinx-copybutton >=0.3
 # jinja2 >=3.0.0,<3.2.0
+snowballstemmer<3
 
 pt-lightning-sphinx-theme @ https://github.com/Lightning-AI/lightning_sphinx_theme/archive/master.zip


### PR DESCRIPTION
## What does this PR do ?
Pins `snowballstemmer<3` as versions `>=3` include some [breaking changes](https://github.com/sphinx-doc/sphinx/issues/13533).