### PR TITLE
ci: Add Python 3.11 to CI testing matrix

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04", "macos-14", "windows-2022"]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     timeout-minutes: 35


### PR DESCRIPTION
Expand the CI testing matrix to include Python 3.11, ensuring compatibility.