### PR TITLE
fix: Move cache warning under debug

### DIFF
--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -512,10 +512,11 @@ def _get_folder_size(path: str, config: ChunksConfig) -> int:
 
             # warn about unrecognized files
             else:
-                logger.warning(
-                    f"Ignoring '{filename}': "
-                    "This file doesn't appear to be a valid chunk file and has been excluded from the size calculation."
-                )
+                if _DEBUG:
+                    logger.warning(
+                        f"Ignoring '{filename}': This file doesn't appear to be a valid chunk file"
+                        " and has been excluded from the cache size calculation."
+                    )
 
     return size
 

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -2,6 +2,7 @@ import logging
 import os
 import shutil
 from time import sleep
+from unittest import mock
 
 from litdata.streaming import reader
 from litdata.streaming.cache import Cache
@@ -103,7 +104,7 @@ def test_reader_chunk_removal_compressed(tmpdir):
 
     assert len(filter_lock_files(os.listdir(cache_dir))) in [1, 2, 3]
 
-
+@mock.patch("litdata.streaming.downloader._DEBUG", True)
 def test_get_folder_size(tmpdir, caplog):
     cache_dir = os.path.join(tmpdir, "cache_dir")
     cache = Cache(cache_dir, chunk_size=10)

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -105,7 +105,7 @@ def test_reader_chunk_removal_compressed(tmpdir):
     assert len(filter_lock_files(os.listdir(cache_dir))) in [1, 2, 3]
 
 
-@mock.patch("litdata.streaming.downloader._DEBUG", True)
+@mock.patch("litdata.streaming.reader._DEBUG", True)
 def test_get_folder_size(tmpdir, caplog):
     cache_dir = os.path.join(tmpdir, "cache_dir")
     cache = Cache(cache_dir, chunk_size=10)

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -104,6 +104,7 @@ def test_reader_chunk_removal_compressed(tmpdir):
 
     assert len(filter_lock_files(os.listdir(cache_dir))) in [1, 2, 3]
 
+
 @mock.patch("litdata.streaming.downloader._DEBUG", True)
 def test_get_folder_size(tmpdir, caplog):
     cache_dir = os.path.join(tmpdir, "cache_dir")


### PR DESCRIPTION
Move the cache warning to only trigger in debug mode. 
The warning is very verbose and can become annoying at times.
<details><summary>Example</summary>

```python

Ignoring '002_00000_part27.parquet1819120251': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '002_00000_part27.parquet1819120251': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '003_00000_part20.parquet1898613907': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '003_00000_part20.parquet1898613907': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '012_00000_part4.parquet3634788641': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '012_00000_part4.parquet3634788641': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '002_00000_part27.parquet1819120251': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '003_00000_part20.parquet1898613907': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '012_00000_part4.parquet3634788641': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '002_00000_part27.parquet1819120251': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '003_00000_part20.parquet1898613907': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '012_00000_part4.parquet3634788641': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '004_00000_part7.parquet3774976435': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '002_00000_part11.parquet933250909': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '002_00000_part27.parquet1819120251': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '003_00000_part20.parquet1898613907': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
Ignoring '001_00000_part18.parquet713488054': This file doesn't appear to be a valid chunk file and has been excluded from the size calculation.
.....
```
</details> 

