### PR TITLE
 fix: Add error handling for empty Parquet files while indexing and corresponding tests

### DIFF
--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -39,7 +39,7 @@ class ParquetDir(ABC):
             raise RuntimeError(
                 f"No Parquet files were found at '{self.dir.url or self.dir.path}'. "
                 "Please verify that the provided path is correct and that it contains at least one .parquet file. "
-                "If your files are located in a subdirectory, please specify the correct path."
+                "If the files are located in a subdirectory, please specify the correct path."
             )
 
         with ThreadPoolExecutor(max_workers=self.num_workers) as executor:

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -35,6 +35,13 @@ class ParquetDir(ABC):
         Yields:
             Generator[Tuple[str, int], None, None]: A generator yielding tuples of file name, file path, and order.
         """
+        if not self.files:
+            raise RuntimeError(
+                f"No Parquet files were found at '{self.dir.url or self.dir.path}'. "
+                "Please verify that the provided path is correct and that it contains at least one .parquet file. "
+                "If your files are located in a subdirectory, please specify the correct path."
+            )
+
         with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
             futures = {executor.submit(self.task, _file): (order, _file) for order, _file in enumerate(self.files)}
             for future in futures:


### PR DESCRIPTION
## What does this PR do ?
This PR adds error handling to the `ParquetDir` iterator to raise a clear exception when no Parquet files are found in the specified directory. Additionally, it includes tests to verify this behavior.

This change prevents unnecessary execution of the indexing process and avoids generating an empty `index.json` file when no data is available, and provides a clear error message to help the user identify and resolve the issue.

Resolves #600 