### PR TITLE
fix: Mark flaky tests to rerun on failure

### DIFF
--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -765,6 +765,7 @@ def test_dataset_for_text_tokens_distributed_num_workers(tmpdir):
 def optimize_fn(item):
     return torch.arange(item[0], item[0] + 20).to(torch.int)
 
+
 @pytest.mark.flaky(reruns=3)
 def test_dataset_for_text_tokens_distributed_num_workers_end_to_end(tmpdir, monkeypatch):
     monkeypatch.setattr(functions, "_get_input_dir", lambda x: str(tmpdir))
@@ -1388,6 +1389,7 @@ def test_dataset_distributed_drop_last(tmpdir, monkeypatch, compression):
         " if your system depends on distributed collectives."
     )
     assert expected_warn_msg == warn_msg
+
 
 @pytest.mark.flaky(reruns=3)
 def test_subsample_streaming_dataset_with_token_loader(tmpdir, monkeypatch):


### PR DESCRIPTION
## What does this PR do ?
Mark specific tests as flaky to allow them to rerun automatically upon failure, improving test reliability.

Partially covers: #437

Functions falling under this: 
- `tests/streaming/test_dataset.py::test_subsample_streaming_dataset_with_token_loader`
- `tests/streaming/test_dataset.py::test_dataset_for_text_tokens_distributed_num_workers_end_to_end`