### PR TITLE
Update bug report template with Lightning Studio sharing instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,14 +23,17 @@ Steps to reproduce the behavior...
 # Ideally attach a minimal code sample to reproduce the decried issue.
 # Minimal means having the shortest code but still preserving the bug.
 ```
+
 </details>
 
 Alternatively, you can share a fully reproducible [Lightning Studio](https://lightning.ai/studios) environment:
->  A simple guide on how to create such a studio can be found [here](https://www.youtube.com/watch?v=YcW-2Zt_bFg&ab_channel=LightningAI).
-1. Create a [Studio](https://lightning.ai/studios).    
-2. Reproduce the issue in the Studio.    
+
+> A simple guide on how to create such a studio can be found [here](https://www.youtube.com/watch?v=YcW-2Zt_bFg&ab_channel=LightningAI).
+
+1. Create a [Studio](https://lightning.ai/studios).
+2. Reproduce the issue in the Studio.
 3. [Publish the Studio](https://lightning.ai/docs/overview/studios/publishing#how-to-publish).
-4. Paste the Studio link here.    
+4. Paste the Studio link here.
 
 ### Expected behavior
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,8 +23,14 @@ Steps to reproduce the behavior...
 # Ideally attach a minimal code sample to reproduce the decried issue.
 # Minimal means having the shortest code but still preserving the bug.
 ```
-
 </details>
+
+Alternatively, you can share a fully reproducible [Lightning Studio](https://lightning.ai/studios) environment:
+>  A simple guide on how to create such a studio can be found [here](https://www.youtube.com/watch?v=YcW-2Zt_bFg&ab_channel=LightningAI).
+1. Create a [Studio](https://lightning.ai/studios).    
+2. Reproduce the issue in the Studio.    
+3. [Publish the Studio](https://lightning.ai/docs/overview/studios/publishing#how-to-publish).
+4. Paste the Studio link here.    
 
 ### Expected behavior
 


### PR DESCRIPTION
## What does this PR do ?
Update the bug report template by adding instructions for sharing a reproducible Lightning Studio environment, facilitating easier issue reproduction and resolution.