### PR TITLE
🕒 Add Test Duration Reporting to Pytest in CI

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -42,7 +42,7 @@ jobs:
           pip list
 
       - name: Tests
-        run: coverage run --source litdata -m pytest tests -v
+        run: coverage run --source litdata -m pytest tests -v --durations=100
 
       - name: Statistics
         run: |


### PR DESCRIPTION
## What does this PR do?
Adds `--durations=100` to `pytest` in the CI workflow to track the slowest tests — useful for performance insights.

**Inspired by:** [LitServe#526](https://github.com/Lightning-AI/LitServe/pull/526)

To be useful for #612 
