### PR TITLE
fix: suppress FileNotFoundError when acquiring file lock for count file

### DIFF
--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -54,7 +54,7 @@ class Downloader(ABC):
     def _increment_local_lock(self, chunkpath: str) -> None:
         logger.debug(_get_log_msg({"name": f"increment_local_lock_for_{chunkpath}", "ph": "B"}))
         countpath = chunkpath + ".cnt"
-        with suppress(Timeout), FileLock(countpath + ".lock", timeout=1):
+        with suppress(Timeout, FileNotFoundError), FileLock(countpath + ".lock", timeout=1):
             try:
                 with open(countpath) as count_f:
                     curr_count = int(count_f.read().strip())

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import logging
 import os
 import warnings
@@ -117,10 +116,10 @@ class PrepareChunksThread(Thread):
                     curr_count = 1
             curr_count -= 1
             if curr_count <= 0:
-                with contextlib.suppress(FileNotFoundError, PermissionError):
+                with suppress(FileNotFoundError, PermissionError):
                     os.remove(countpath)
 
-                with contextlib.suppress(FileNotFoundError, PermissionError):
+                with suppress(FileNotFoundError, PermissionError):
                     os.remove(countpath + ".lock")
             else:
                 with open(countpath, "w+") as count_f:
@@ -511,7 +510,7 @@ def _get_folder_size(path: str, config: ChunksConfig) -> int:
 
             # handle temporary files containing '.bin'
             elif ".bin" in filename:
-                with contextlib.suppress(FileNotFoundError):
+                with suppress(FileNotFoundError):
                     size += entry.stat(follow_symlinks=False).st_size
 
             # warn about unrecognized files


### PR DESCRIPTION
## What does this PR do ?
Fixes #566.

This PR suppresses errors caused by missing lock files when attempting to increment a lock. These files may have been removed due to interprocess cleanup, and the suppression prevents unnecessary error messages in such cases.
