### PR TITLE
fix: optimize with StreamingDataloader(parquet data) for >=5 workers

### DIFF
--- a/src/litdata/processing/data_processor.py
+++ b/src/litdata/processing/data_processor.py
@@ -832,6 +832,11 @@ class BaseWorker:
                 if self.use_checkpoint:
                     checkpoint_filepath = self.cache.save_checkpoint()
                     self._try_upload(checkpoint_filepath)
+        except StopIteration:
+            # If a StopIteration occurs, the iterator is exhausted.
+            # This is expected behavior for the StreamingDataLoader iterator.
+            # We catch it to ensure smooth operation.
+            pass
         except Exception as e:
             raise RuntimeError(f"Failed processing {item=}; {index=}") from e
 

--- a/src/litdata/processing/data_processor.py
+++ b/src/litdata/processing/data_processor.py
@@ -856,7 +856,7 @@ class BaseWorker:
                 if isinstance(chunk_filepath, str) and os.path.exists(chunk_filepath):
                     self.to_upload_queues[i % self.num_uploaders].put(chunk_filepath)
 
-        if self.use_checkpoint and not getattr(self.data_recipe, "is_generator", False):
+        if self.use_checkpoint and not self.data_recipe.is_generator:
             checkpoint_filepath = self.cache.save_checkpoint()
             self._try_upload(checkpoint_filepath)
 

--- a/src/litdata/processing/readers.py
+++ b/src/litdata/processing/readers.py
@@ -143,16 +143,11 @@ class StreamingDataLoaderReader(BaseReader):
         """Read the next item from the dataloader."""
         if self.dataloader_iter is None:
             self.dataloader_iter = iter(self.dataloader)
-        try:
-            # Data is distributed across workers, similar to DDP.
-            # Although the iterator is created within this worker process,
-            # distribution is already managed by the StreamingDataLoader and StreamingDataset.
-            return next(self.dataloader_iter)
-        except StopIteration:
-            # If a StopIteration occurs, the iterator is exhausted.
-            # This is expected behavior for the StreamingDataLoader iterator.
-            # We catch it to ensure smooth operation.
-            return None
+
+        # Data is distributed across workers through iterator, similar to DDP.
+        # Although the iterator is created within this worker process,
+        # distribution is already managed by the StreamingDataLoader and StreamingDataset.
+        return next(self.dataloader_iter)
 
     def remap_items(self, dataloader: StreamingDataLoader, _: int) -> List[Any]:
         """Remap the items from the dataloader. But here, we don't do anything.

--- a/src/litdata/processing/readers.py
+++ b/src/litdata/processing/readers.py
@@ -150,7 +150,7 @@ class StreamingDataLoaderReader(BaseReader):
             return next(self.dataloader_iter)
         except StopIteration:
             # If a StopIteration occurs, the iterator is exhausted.
-            # This is expected behavior for the StreamingDataLoader.
+            # This is expected behavior for the StreamingDataLoader iterator.
             # We catch it to ensure smooth operation.
             return None
 

--- a/src/litdata/processing/readers.py
+++ b/src/litdata/processing/readers.py
@@ -144,13 +144,24 @@ class StreamingDataLoaderReader(BaseReader):
         if self.dataloader_iter is None:
             self.dataloader_iter = iter(self.dataloader)
 
-        # Data is distributed across workers through iterator, similar to DDP.
-        # Although the iterator is created within this worker process,
-        # distribution is already managed by the StreamingDataLoader and StreamingDataset.
-        return next(self.dataloader_iter)
+        try:
+            # Data is distributed across workers through iterator, similar to DDP.
+            # Although the iterator is created within this worker process,
+            # distribution is already managed by the StreamingDataLoader and StreamingDataset.
+            return next(self.dataloader_iter)
+        except StopIteration:
+            # This can happen when some workers finish their data slice before others.
+            # In multiprocessing scenarios with StreamingDataLoader, this is expected behavior.
+            # We return None to signal that this worker has no more data to process.
+            return None
 
-    def remap_items(self, dataloader: StreamingDataLoader, _: int) -> List[Any]:
-        """Remap the items from the dataloader. But here, we don't do anything.
-        No splitting or batching is done here. As streaming dataloader is already optimized for this.
+    def remap_items(self, items: Any, num_workers: int) -> List[Any]:
+        """For StreamingDataLoader, we need to be smarter about item distribution.
+        We create enough virtual items so that each worker can process until its
+        portion of the dataloader is exhausted.
         """
-        return list(range(len(dataloader)))
+        # The items parameter is the StreamingDataLoader in this case
+        total_items = len(items)
+        # Create more virtual items than actual items to ensure all workers
+        # get enough chances to process their portion of the dataloader
+        return list(range(total_items * 2))

--- a/src/litdata/processing/readers.py
+++ b/src/litdata/processing/readers.py
@@ -144,15 +144,15 @@ class StreamingDataLoaderReader(BaseReader):
         if self.dataloader_iter is None:
             self.dataloader_iter = iter(self.dataloader)
         # try:
-            # Data is distributed across workers, similar to DDP.
-            # Although the iterator is created within this worker process,
-            # distribution is already managed by the StreamingDataLoader and StreamingDataset.
+        # Data is distributed across workers, similar to DDP.
+        # Although the iterator is created within this worker process,
+        # distribution is already managed by the StreamingDataLoader and StreamingDataset.
         return next(self.dataloader_iter)
         # except StopIteration:
-            # If a StopIteration occurs, the iterator is exhausted.
-            # This is expected behavior for the StreamingDataLoader iterator.
-            # We catch it to ensure smooth operation.
-            # return None
+        # If a StopIteration occurs, the iterator is exhausted.
+        # This is expected behavior for the StreamingDataLoader iterator.
+        # We catch it to ensure smooth operation.
+        # return None
 
     def remap_items(self, dataloader: StreamingDataLoader, _: int) -> List[Any]:
         """Remap the items from the dataloader. But here, we don't do anything.

--- a/src/litdata/processing/readers.py
+++ b/src/litdata/processing/readers.py
@@ -143,7 +143,16 @@ class StreamingDataLoaderReader(BaseReader):
         """Read the next item from the dataloader."""
         if self.dataloader_iter is None:
             self.dataloader_iter = iter(self.dataloader)
-        return next(self.dataloader_iter)
+        try:
+            # Data is distributed across workers, similar to DDP.
+            # Although the iterator is created within this worker process,
+            # distribution is already managed by the StreamingDataLoader and StreamingDataset.
+            return next(self.dataloader_iter)
+        except StopIteration:
+            # If a StopIteration occurs, the iterator is exhausted.
+            # This is expected behavior for the StreamingDataLoader.
+            # We catch it to ensure smooth operation.
+            return None
 
     def remap_items(self, dataloader: StreamingDataLoader, _: int) -> List[Any]:
         """Remap the items from the dataloader. But here, we don't do anything.

--- a/src/litdata/processing/readers.py
+++ b/src/litdata/processing/readers.py
@@ -143,16 +143,16 @@ class StreamingDataLoaderReader(BaseReader):
         """Read the next item from the dataloader."""
         if self.dataloader_iter is None:
             self.dataloader_iter = iter(self.dataloader)
-        # try:
-        # Data is distributed across workers, similar to DDP.
-        # Although the iterator is created within this worker process,
-        # distribution is already managed by the StreamingDataLoader and StreamingDataset.
-        return next(self.dataloader_iter)
-        # except StopIteration:
-        # If a StopIteration occurs, the iterator is exhausted.
-        # This is expected behavior for the StreamingDataLoader iterator.
-        # We catch it to ensure smooth operation.
-        # return None
+        try:
+            # Data is distributed across workers, similar to DDP.
+            # Although the iterator is created within this worker process,
+            # distribution is already managed by the StreamingDataLoader and StreamingDataset.
+            return next(self.dataloader_iter)
+        except StopIteration:
+            # If a StopIteration occurs, the iterator is exhausted.
+            # This is expected behavior for the StreamingDataLoader iterator.
+            # We catch it to ensure smooth operation.
+            return None
 
     def remap_items(self, dataloader: StreamingDataLoader, _: int) -> List[Any]:
         """Remap the items from the dataloader. But here, we don't do anything.

--- a/src/litdata/processing/readers.py
+++ b/src/litdata/processing/readers.py
@@ -143,16 +143,16 @@ class StreamingDataLoaderReader(BaseReader):
         """Read the next item from the dataloader."""
         if self.dataloader_iter is None:
             self.dataloader_iter = iter(self.dataloader)
-        try:
+        # try:
             # Data is distributed across workers, similar to DDP.
             # Although the iterator is created within this worker process,
             # distribution is already managed by the StreamingDataLoader and StreamingDataset.
-            return next(self.dataloader_iter)
-        except StopIteration:
+        return next(self.dataloader_iter)
+        # except StopIteration:
             # If a StopIteration occurs, the iterator is exhausted.
             # This is expected behavior for the StreamingDataLoader iterator.
             # We catch it to ensure smooth operation.
-            return None
+            # return None
 
     def remap_items(self, dataloader: StreamingDataLoader, _: int) -> List[Any]:
         """Remap the items from the dataloader. But here, we don't do anything.

--- a/tests/processing/test_functions.py
+++ b/tests/processing/test_functions.py
@@ -756,6 +756,7 @@ def optimize_fn(data):
     answer = data["answer"][0]
     return {"index": index, "question": question, "answer": answer}
 
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Not tested on windows")
 @pytest.mark.parametrize("num_workers", [5, 6, 8])
 def test_optimize_with_streaming_dataloader_on_parquet_data(tmpdir, num_workers):

--- a/tests/processing/test_functions.py
+++ b/tests/processing/test_functions.py
@@ -756,7 +756,7 @@ def optimize_fn(data):
     answer = data["answer"][0]
     return {"index": index, "question": question, "answer": answer}
 
-
+@pytest.mark.skipif(sys.platform == "win32", reason="Not tested on windows")
 @pytest.mark.parametrize("num_workers", [5, 6, 8])
 def test_optimize_with_streaming_dataloader_on_parquet_data(tmpdir, num_workers):
     """Test optimization with StreamingDataLoader on parquet data with multiple workers.

--- a/tests/processing/test_functions.py
+++ b/tests/processing/test_functions.py
@@ -755,7 +755,7 @@ def optimize_fn(data):
     return {"question": question, "answer": answer}
 
 
-@pytest.mark.parametrize("num_workers", [5, 6])
+@pytest.mark.parametrize("num_workers", [5, 6, 8])
 def test_optimize_with_streaming_dataloader_on_parquet_data(tmpdir, num_workers):
     # Prepare parquet dataset
     parquet_dir = os.path.join(tmpdir, "parquet")

--- a/tests/processing/test_functions.py
+++ b/tests/processing/test_functions.py
@@ -759,9 +759,9 @@ def test_optimize_with_streaming_dataloader_on_parquet_data(tmpdir, num_workers)
     os.makedirs(parquet_dir, exist_ok=True)
     import polars as pl
 
-    num_of_items = 500
-    questions = ["What is the capital of France?"] * num_of_items
-    answers = ["The capital of France is Paris."] * num_of_items
+    num_items = 500
+    questions = ["What is the capital of France?"] * num_items
+    answers = ["The capital of France is Paris."] * num_items
 
     df = pl.DataFrame({"question": questions, "answer": answers})
     df.write_parquet(os.path.join(parquet_dir, "sample.parquet"))
@@ -785,4 +785,4 @@ def test_optimize_with_streaming_dataloader_on_parquet_data(tmpdir, num_workers)
 
     # verify len of optimized dataset
     ds = StreamingDataset(output_dir)
-    assert len(ds) == num_of_items
+    assert len(ds) == num_items


### PR DESCRIPTION
## What does this PR do?
Fixes #599
Also resolves #482

Fixes data loss when using `optimize()` with `StreamingDataLoader` on parquet data with 5+ workers.

> The solution is admittedly a bit hacky but effective: we increase the total virtual items and let workers process their iterators until they're naturally exhausted, rather than depending on rigid index.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
