### PR TITLE
upd: Optimize test (`test_dataset_for_text_tokens_with_large_num_chunks`) to reduce time consumption

### DIFF
--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -589,13 +589,12 @@ def test_dataset_for_text_tokens(tmpdir):
 @pytest.mark.skipif(sys.platform == "win32", reason="windows isn't supported")
 def test_dataset_for_text_tokens_with_large_num_chunks(tmpdir):
     import resource
-
-    resource.setrlimit(resource.RLIMIT_NOFILE, (1024, 1024))
+    resource.setrlimit(resource.RLIMIT_NOFILE, (512, 512))
 
     block_size = 1024
     cache = Cache(input_dir=str(tmpdir), chunk_bytes="10KB", item_loader=TokensLoader(block_size))
 
-    for i in range(10000):
+    for i in range(1500):
         text_ids = torch.randint(0, 10001, (torch.randint(100, 1001, (1,)).item(),)).numpy()
         cache._add_item(i, text_ids)
 
@@ -603,7 +602,6 @@ def test_dataset_for_text_tokens_with_large_num_chunks(tmpdir):
     cache.merge()
 
     dataset = StreamingDataset(input_dir=str(tmpdir), item_loader=TokensLoader(block_size), shuffle=True)
-
     for _ in dataset:
         pass
 

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -589,6 +589,7 @@ def test_dataset_for_text_tokens(tmpdir):
 @pytest.mark.skipif(sys.platform == "win32", reason="windows isn't supported")
 def test_dataset_for_text_tokens_with_large_num_chunks(tmpdir):
     import resource
+
     resource.setrlimit(resource.RLIMIT_NOFILE, (512, 512))
 
     block_size = 1024


### PR DESCRIPTION
## What does this PR do ?

Adjust resource limits and decrease the number of chunk iterations in the `tests/streaming/test_dataset.py::test_dataset_for_text_tokens_with_large_num_chunks` test to improve test execution time.


Partial work on https://github.com/Lightning-AI/litData/issues/612

**Before**
```python
# ubuntu
195.33s call     tests/streaming/test_dataset.py::test_dataset_for_text_tokens_with_large_num_chunks

#macos
345.54s call     tests/streaming/test_dataset.py::test_dataset_for_text_tokens_with_large_num_chunks
```

**After**
```python
# ubuntu
31.33s call     tests/streaming/test_dataset.py::test_dataset_for_text_tokens_with_large_num_chunks

#macos
56.55s call     tests/streaming/test_dataset.py::test_dataset_for_text_tokens_with_large_num_chunks
```