### PR TITLE
Feat: add support to pass transform kwargs in StreamingDataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,7 +935,7 @@ if __name__ == "__main__":
 
 Transform datasets on-the-fly while streaming them, allowing for efficient data processing without the need to store intermediate results.
 
-- You can use the `transform` argument in `StreamingDataset` to apply a transformation function to each sample as it is streamed.
+- You can use the `transform` argument in `StreamingDataset` to apply a `transformation function` or a list of `transformation function` to each sample as it is streamed.
 
 ```python
 # Define a simple transform function
@@ -982,6 +982,74 @@ class StreamingDatasetWithTransform(StreamingDataset):
 
 dataset = StreamingDatasetWithTransform(data_dir, cache_dir=str(cache_dir), shuffle=shuffle)
 ```
+
+#### Passing keyword arguments to your transform function(s)
+
+You can now pass custom keyword arguments to your transform function(s) using the `transform_kwargs` argument in `StreamingDataset`.
+
+This allows for more flexible and dynamic preprocessing, especially useful `when transforms depend on external configuration, state, or shared dataset attributes`.
+
+```python
+def transform_fn_1(x, **kwargs):
+    """Apply a custom transform using additional arguments."""
+    some_val = kwargs["key1"]
+    index = kwargs["index"]  # Automatically included
+    return transform_logic_1(index, some_val, x)
+
+def transform_fn_2(x, **kwargs):
+    """Apply a second transform using shared config."""
+    some_val = kwargs["key2"]
+    return transform_logic_2(some_val, x)
+
+dataset = StreamingDataset(
+    data_dir,
+    cache_dir=str(cache_dir),
+    shuffle=shuffle,
+    transform=[transform_fn_1, transform_fn_2],
+    transform_kwargs={"key1": "value1", "key2": "value2"}
+)
+```
+
+> ℹ️ **Note:** `transform_kwargs` will always include the `index` key automatically.
+
+##### 💡 Why this is useful
+
+Traditionally, transform functions are self-contained. But in real-world pipelines, transforms often depend on shared context like:
+
+* Dataset-specific configurations (`img_size`, `augmentation`, `task_type`)
+* Class methods (e.g., parsing logic, tokenizers, decoders)
+* External tools (like label mappers or precomputed metadata)
+
+Instead of wrapping these in closures or using global variables, you can now **pass them cleanly via `transform_kwargs`**.
+
+##### 📦 Real-world use case: Integrating Ultralytics datasets
+
+Ultralytics datasets have their own logic for parsing labels and transforming images. You can wrap that logic inside a `StreamingDataset` by:
+
+1. Subclassing `StreamingDataset`
+2. Extracting needed attributes from a preconfigured Ultralytics dataset
+3. Passing them to transform functions using `transform_kwargs`
+
+#### Example
+
+```python
+class StreamingUltralyticsDataset(StreamingDataset):
+    def __init__(self, yolo_dataset, *args, **kwargs):
+        self.yolo_dataset = yolo_dataset  # Ultralytics dataset instance
+
+        super().__init__(
+            *args,
+            transform=[ultralytics.parse_labels, ultralytics.postprocess],
+            transform_kwargs={
+                "names": yolo_dataset.names,
+                "is_coco": yolo_dataset.is_coco_format,
+                "imgsz": yolo_dataset.imgsz,
+            },
+            **kwargs
+        )
+```
+
+> 🔁 Each transform receives all `transform_kwargs` (including `index`), making it easy to pass dynamic state without breaking encapsulation.
 
 </details>
 

--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -1,11 +1,12 @@
 import hashlib
+import inspect
 import json
 import math
 import os
 import shutil
 import tempfile
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -341,3 +342,9 @@ def copy_index_to_cache_index_filepath(index_path: str, cache_index_filepath: st
         raise FileNotFoundError(f"Index file not found: {index_path}")
     # Copy the file to cache_index_filepath
     shutil.copy(index_path, cache_index_filepath)
+
+
+def fn_accepts_kwargs(_fn: Callable) -> bool:
+    """Check if a function accepts keyword arguments."""
+    signature = inspect.signature(_fn)
+    return any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values())

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -1696,6 +1696,59 @@ def test_dataset_transform(tmpdir, shuffle):
 
 
 @pytest.mark.parametrize("shuffle", [True, False])
+def test_dataset_multiple_transform(tmpdir, shuffle):
+    """Test if the dataset transform is applied correctly."""
+    # Create a simple dataset
+    # Create directories for cache and data
+    cache_dir = os.path.join(tmpdir, "cache_dir")
+    data_dir = os.path.join(tmpdir, "data_dir")
+    os.makedirs(cache_dir)
+    os.makedirs(data_dir)
+
+    # Create a dataset with 100 items, 20 items per chunk
+    cache = Cache(str(data_dir), chunk_size=20)
+    for i in range(100):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    # Define two simple transform function
+    def transform_fn_1(x):
+        """A simple transform function that doubles the input."""
+        return x * 2
+
+    def transform_fn_2(x, **kwargs):
+        """A simple transform function that adds one to the input."""
+        extra_num = kwargs.get("extra_num", 0)
+        return x + extra_num
+
+    dataset = StreamingDataset(
+        data_dir,
+        cache_dir=str(cache_dir),
+        shuffle=shuffle,
+        transform=[transform_fn_1, transform_fn_2],
+        transform_kwargs={"extra_num": 100},
+    )
+    dataset_length = len(dataset)
+    assert dataset_length == 100
+
+    # ACT
+    # Stream through the entire dataset and store the results
+    complete_data = []
+    for data in dataset:
+        assert data is not None
+        complete_data.append(data)
+
+    if shuffle:
+        complete_data.sort()
+
+    # ASSERT
+    # Verify that the transform is applied correctly
+    for i, item in enumerate(complete_data):
+        assert item == i * 2 + 100, f"Expected {i * 2 + 100}, got {item}"
+
+
+@pytest.mark.parametrize("shuffle", [True, False])
 def test_dataset_transform_inheritance(tmpdir, shuffle):
     """Test if the dataset transform is applied correctly."""
     # Create a simple dataset

--- a/tests/utilities/test_dataset_utilities.py
+++ b/tests/utilities/test_dataset_utilities.py
@@ -11,6 +11,7 @@ from litdata.utilities.dataset_utilities import (
     _should_replace_path,
     _try_create_cache_dir,
     adapt_mds_shards_to_chunks,
+    fn_accepts_kwargs,
     generate_roi,
     get_default_cache_dir,
     load_index_file,
@@ -109,3 +110,20 @@ def test_get_default_cache_dir():
         importlib.reload(litdata.constants)
         importlib.reload(litdata.utilities.dataset_utilities)
         assert litdata.utilities.dataset_utilities.get_default_cache_dir() == "/custom/cache/dir"
+
+
+def test_fn_accepts_kwargs():
+    """Check if a function accepts keyword arguments."""
+
+    def func_with_kwargs(a, b=1, *args, **kwargs):
+        return a + b
+
+    def func_without_kwargs(a, b=1):
+        return a + b
+
+    assert fn_accepts_kwargs(func_with_kwargs)
+    assert not fn_accepts_kwargs(func_without_kwargs)
+
+    # Test with a lambda function
+    lambda_func = lambda x, y=2: x + y
+    assert not fn_accepts_kwargs(lambda_func)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This PR introduces support for passing keyword arguments (`transform_kwargs`) to transform functions defined in the `StreamingDataset`. This allows users to inject shared configuration, context, or state into their transformation logic without relying on closures, subclassing, or global variables.

### 🧩 Why is this useful?

In many real-world pipelines, transform functions need access to external information like:

* Dataset-specific configurations (`img_size`, `mode`, `names`)
* Parsing methods from dataset classes (e.g., Ultralytics-style label parsers)
* Shared tools or processing logic (e.g., tokenizers, label maps)

This PR enables users to supply those via a clean, declarative API using the `transform_kwargs` argument.

---

### ✅ Key Features

* `transform_kwargs` is a new optional argument to `StreamingDataset`
* Automatically injected into every transform function (or list of functions) via `**kwargs`
* Includes `index` by default for per-sample awareness
* Supports both standalone functions and method-based transforms

---

### 💡 Real-world use case

This feature was motivated by integrating Ultralytics datasets into a streaming pipeline. These datasets contain methods and attributes needed for parsing and postprocessing, such as:

* `.names`, `.is_coco_format`, `.imgsz`
* `custom_label_parser`, `postprocess`

With `transform_kwargs`, we can directly pass these into transform functions, enabling modular and reusable streaming transforms without needing to subclass `StreamingDataset`.

---

### 🧪 Example

```python
def transform_fn(x, **kwargs):
    names = kwargs["names"]
    index = kwargs["index"]
    return parse_and_transform(index, names, x)

dataset = StreamingDataset(
    data_dir,
    cache_dir=str(cache_dir),
    transform=transform_fn,
    transform_kwargs={"names": yolo_dataset.names}
)
```

> `index` is automatically injected even if not specified in `transform_kwargs`.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
