### PR TITLE
feat(ci): switch to `astral-sh/setup-uv` for Python setup and use `uv pip` for package installation

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -28,7 +28,7 @@ jobs:
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     timeout-minutes: 60
     env:
-      TORCH_URL: "https://download.pytorch.org/whl/cpu/torch_stable.html"
+      TORCH_URL: "https://download.pytorch.org/whl/cpu"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Install package & dependencies
         run: |
-          uv pip --version
           uv pip install -U lightning-sdk
           uv pip install torch torchvision torchaudio --index-url $TORCH_URL
           uv pip install -e ".[extras]" -r requirements/test.txt -U -q --find-links $TORCH_URL

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -1,4 +1,4 @@
-name: CI testing
+name: CI Testing
 
 # see: https://help.github.com/en/actions/reference/events-that-trigger-workflows
 on: # Trigger the workflow on push or pull request, but only for the main branch

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           uv pip install -U lightning-sdk
           uv pip install torch torchvision torchaudio --index-url $TORCH_URL
-          uv pip install -e ".[extras]" -r requirements/test.txt -U -q --find-links $TORCH_URL
+          uv pip install -e ".[extras]" -r requirements/test.txt -U -q
           uv pip list
 
       - name: Tests

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -32,18 +32,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Install uv and setup python
+        uses: astral-sh/setup-uv@v6
         with:
+          activate-environment: true
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
+          enable-cache: true
 
       - name: Install package & dependencies
         run: |
-          pip --version
-          pip install -U lightning-sdk
-          pip install -e ".[extras]" -r requirements/test.txt -U -q --find-links $TORCH_URL
-          pip list
+          uv pip --version
+          uv pip install -U lightning-sdk
+          uv pip install torch torchvision torchaudio --index-url $TORCH_URL
+          uv pip install -e ".[extras]" -r requirements/test.txt -U -q --find-links $TORCH_URL
+          uv pip list
 
       - name: Tests
         working-directory: tests

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -42,8 +42,7 @@ jobs:
       - name: Install package & dependencies
         run: |
           uv pip install -U lightning-sdk
-          uv pip install torch torchvision torchaudio --index-url $TORCH_URL
-          uv pip install -e ".[extras]" -r requirements/test.txt -U -q
+          uv pip install -e ".[extras]" -r requirements/test.txt -U -q --index-url $TORCH_URL
           uv pip list
 
       - name: Tests

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install uv and setup python
+      - name: Install uv and setup python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v6
         with:
           activate-environment: true

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -28,7 +28,7 @@ jobs:
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     timeout-minutes: 60
     env:
-      TORCH_URL: "https://download.pytorch.org/whl/cpu"
+      UV_TORCH_BACKEND: "cpu"
 
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
       - name: Install package & dependencies
         run: |
           uv pip install -U lightning-sdk
-          uv pip install -e ".[extras]" -r requirements/test.txt -U -q --index-url $TORCH_URL
+          uv pip install -e ".[extras]" -r requirements/test.txt -U -q
           uv pip list
 
       - name: Tests

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,15 @@ setup: install-dependencies install-pre-commit
 	@echo "All set! Ready to go!"
 
 test: clean
-	pip install -q -r requirements.txt
-	pip install -q -r requirements/test.txt
+	uv pip install -q -r requirements.txt
+	uv pip install -q -r requirements/test.txt
 
 	# use this to run tests
 	python -m coverage run --source litdata -m pytest src -v --flake8
 	python -m coverage report
 
 docs: clean
-	pip install . --quiet -r requirements/docs.txt
+	uv pip install . --quiet -r requirements/docs.txt
 	python -m sphinx -b html -W --keep-going docs/source docs/build
 
 clean:
@@ -34,13 +34,13 @@ clean:
 	rm -rf ./dist
 
 install-dependencies:
-	pip install -r requirements.txt
-	pip install -r requirements/test.txt
-	pip install -r requirements/docs.txt
-	pip install -r requirements/extras.txt
-	pip install -e .
+	uv pip install -r requirements.txt
+	uv pip install -r requirements/test.txt
+	uv pip install -r requirements/docs.txt
+	uv pip install -r requirements/extras.txt
+	uv pip install -e .
 
 
 install-pre-commit:
-	pip install pre-commit
+	uv pip install pre-commit
 	pre-commit install


### PR DESCRIPTION
## What does this PR do?

This PR updates the CI testing setup to use `uv` for faster installation. - (1/n)
> Note: This PR does **not** yet include updates to the `pyproject.toml`.

> Inspired from https://github.com/Lightning-AI/LitServe/pull/563

Installation time reduced (~ 2-5 m) as follows:

| OS | Python Version | Before | After (with `uv`) |
|--------|--------|----------------|----------------|
| ubuntu | 3.11 | install - 2m 45s<br>test - 37m 8s | install - 9s<br>test - 34m 59s |
| ubuntu | 3.12 | install - 2m 43s<br>test - 48m 16s | install - 11s<br>test - 46m 3s |
| mac-os | 3.10 | install - 1m 19s<br>test - 32m 49s | install - 12s<br>test - 35m 26s |
| mac-os | 3.11 | install - 1m 52s<br>test - 35m 26s | install - 10s<br>test - 34m 3s |
| windows | 3.11 | install - 5m 15s<br>test - 21m 56s | install - 20s<br>test - 21m 45s |
| windows | 3.12 | install - 5m 14s<br>test - 27m 24s | install - 19s<br>test - 26m 8s |

> Ref Runs: [before](https://github.com/Lightning-AI/litData/actions/runs/16412222787/job/46369733166) & [after](https://github.com/Lightning-AI/litData/actions/runs/16326035961/job/46116305207)




## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
