### PR TITLE
ref: Move raw dataset code to `litdata/raw`, expose `StreamingRawDataset` at top-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ pip install "litdata[extra]" gcsfs
 
 **Usage Example:**
 ```python
-from litdata.streaming.raw_dataset import StreamingRawDataset
 from torch.utils.data import DataLoader
+from litdata import StreamingRawDataset
 
 dataset = StreamingRawDataset("s3://bucket/files/")
 
@@ -239,18 +239,19 @@ for batch in loader:
 You can also customize how files are grouped by subclassing `StreamingRawDataset` and overriding the `setup` method. This is useful for pairing related files (e.g., image and mask, audio and transcript) or any custom grouping logic.
 
 ```python
-from litdata.streaming.raw_dataset import StreamingRawDataset, FileMetadata
-from torch.utils.data import DataLoader
 from typing import Union
+from torch.utils.data import DataLoader
+from litdata import StreamingRawDataset
+from litdata.raw.indexer import FileMetadata
 
 class SegmentationRawDataset(StreamingRawDataset):
-  def setup(self, files: list[FileMetadata]) -> Union[list[FileMetadata], list[list[FileMetadata]]]:
-      # TODO: Implement your custom grouping logic here.
-      # For example, group files by prefix, extension, or any rule you need.
-      # Return a list of groups, where each group is a list of FileMetadata.
-      # Example:
-      #   return [[image, mask], ...]
-      pass
+    def setup(self, files: list[FileMetadata]) -> Union[list[FileMetadata], list[list[FileMetadata]]]:
+        # TODO: Implement your custom grouping logic here.
+        # For example, group files by prefix, extension, or any rule you need.
+        # Return a list of groups, where each group is a list of FileMetadata.
+        # Example:
+        #   return [[image, mask], ...]
+        pass
 
 # Initialize the custom dataset
 dataset = SegmentationRawDataset("s3://bucket/files/")

--- a/src/litdata/__init__.py
+++ b/src/litdata/__init__.py
@@ -12,10 +12,10 @@
 # limitations under the License.
 import warnings
 
-from lightning_utilities.core.imports import RequirementCache
-
 from litdata.__about__ import *  # noqa: F403
+from litdata.constants import _LIGHTNING_SDK_AVAILABLE
 from litdata.processing.functions import map, merge_datasets, optimize, walk
+from litdata.raw.dataset import StreamingRawDataset
 from litdata.streaming.combined import CombinedStreamingDataset
 from litdata.streaming.dataloader import StreamingDataLoader
 from litdata.streaming.dataset import StreamingDataset
@@ -32,9 +32,9 @@ warnings.filterwarnings(
     category=UserWarning,
 )
 
-
 __all__ = [
     "StreamingDataset",
+    "StreamingRawDataset",
     "CombinedStreamingDataset",
     "StreamingDataLoader",
     "TokensLoader",
@@ -48,7 +48,8 @@ __all__ = [
     "index_hf_dataset",
     "breakpoint",
 ]
-if RequirementCache("lightning_sdk"):
+
+if _LIGHTNING_SDK_AVAILABLE:
     from lightning_sdk import Machine  # noqa: F401
 
-    __all__ + ["Machine"]
+    __all__.append("Machine")

--- a/src/litdata/constants.py
+++ b/src/litdata/constants.py
@@ -45,7 +45,6 @@ _PIL_AVAILABLE = RequirementCache("PIL")
 _TORCH_VISION_AVAILABLE = RequirementCache("torchvision")
 _AV_AVAILABLE = RequirementCache("av")
 _OBSTORE_AVAILABLE = RequirementCache("obstore")
-_ASYNCIO_AVAILABLE = RequirementCache("asyncio")
 
 _DEBUG = bool(int(os.getenv("DEBUG_LITDATA", "0")))
 _PRINT_DEBUG_LOGS = bool(int(os.getenv("PRINT_DEBUG_LOGS", "0")))

--- a/src/litdata/raw/dataset.py
+++ b/src/litdata/raw/dataset.py
@@ -10,185 +10,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
+
+import asyncio
 import logging
 import os
-import time
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable, Optional, Union
-from urllib.parse import urlparse
 
 from torch.utils.data import Dataset
 
-from litdata.constants import _ASYNCIO_AVAILABLE, _FSSPEC_AVAILABLE, _TQDM_AVAILABLE, _ZSTD_AVAILABLE
+from litdata.raw.indexer import BaseIndexer, FileIndexer, FileMetadata
 from litdata.streaming.downloader import Downloader, get_downloader
 from litdata.streaming.resolver import Dir, _resolve_dir
 from litdata.utilities.dataset_utilities import generate_md5_hash, get_default_cache_dir
 
-if not _ASYNCIO_AVAILABLE:
-    raise ModuleNotFoundError(
-        "The 'asyncio' package is required for streaming datasets. Please install it with `pip install asyncio`."
-    )
-else:
-    import asyncio
-
 logger = logging.getLogger(__name__)
-SUPPORTED_PROVIDERS = ("s3", "gs", "azure")
 
-
-@dataclass
-class FileMetadata:
-    """Metadata for a single file in the dataset."""
-
-    path: str
-    size: int
-
-    def to_dict(self) -> dict[str, Any]:
-        return {"path": self.path, "size": self.size}
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "FileMetadata":
-        return cls(path=data["path"], size=data["size"])
-
-
-class BaseIndexer(ABC):
-    """Abstract base class for file indexing strategies."""
-
-    @abstractmethod
-    def discover_files(self, input_dir: str, storage_options: Optional[dict[str, Any]]) -> list[FileMetadata]:
-        """Discover dataset files and return their metadata."""
-
-    def build_or_load_index(
-        self, input_dir: str, cache_dir: str, storage_options: Optional[dict[str, Any]]
-    ) -> list[FileMetadata]:
-        """Build or load a ZSTD-compressed index of file metadata."""
-        if not _ZSTD_AVAILABLE:
-            raise ModuleNotFoundError(str(_ZSTD_AVAILABLE))
-
-        import zstd
-
-        index_path = Path(cache_dir) / "index.json.zstd"
-
-        # Try loading cached index if it exists
-        if index_path.exists():
-            try:
-                with open(index_path, "rb") as f:
-                    compressed_data = f.read()
-                metadata = json.loads(zstd.decompress(compressed_data).decode("utf-8"))
-
-                return [FileMetadata.from_dict(file_data) for file_data in metadata["files"]]
-            except (FileNotFoundError, json.JSONDecodeError, zstd.ZstdError, KeyError) as e:
-                logger.warning(f"Failed to load cached index from {index_path}: {e}")
-
-        # Build fresh index
-        logger.info(f"Building index for {input_dir} at {index_path}")
-        files = self.discover_files(input_dir, storage_options)
-        if not files:
-            raise ValueError(f"No files found in {input_dir}")
-
-        # Cache the index with ZSTD compression
-        # TODO: upload the index to cloud storage
-        try:
-            metadata = {
-                "source": input_dir,
-                "files": [file.to_dict() for file in files],
-                "created_at": time.time(),
-            }
-            with open(index_path, "wb") as f:
-                f.write(zstd.compress(json.dumps(metadata).encode("utf-8")))
-        except (OSError, zstd.ZstdError) as e:
-            logger.warning(f"Error caching index to {index_path}: {e}")
-
-        logger.info(f"Built index with {len(files)} files from {input_dir} at {index_path}")
-        return files
-
-
-class FileIndexer(BaseIndexer):
-    """Indexes files recursively from cloud or local storage with optional extension filtering."""
-
-    def __init__(
-        self,
-        max_depth: int = 5,
-        extensions: Optional[list[str]] = None,
-    ):
-        self.max_depth = max_depth
-        self.extensions = [ext.lower() for ext in (extensions or [])]
-
-    def discover_files(self, input_dir: str, storage_options: Optional[dict[str, Any]]) -> list[FileMetadata]:
-        """Discover dataset files and return their metadata."""
-        parsed_url = urlparse(input_dir)
-
-        if parsed_url.scheme in SUPPORTED_PROVIDERS:
-            return self._discover_cloud_files(input_dir, storage_options)
-
-        if not parsed_url.scheme or parsed_url.scheme == "file":
-            return self._discover_local_files(input_dir)
-
-        raise ValueError(
-            f"Unsupported input directory scheme: {parsed_url.scheme}. Supported schemes are: {SUPPORTED_PROVIDERS}"
-        )
-
-    def _discover_cloud_files(self, input_dir: str, storage_options: Optional[dict[str, Any]]) -> list[FileMetadata]:
-        """Recursively list files in a cloud storage bucket."""
-        if not _FSSPEC_AVAILABLE:
-            raise ModuleNotFoundError(str(_FSSPEC_AVAILABLE))
-        import fsspec
-
-        obj = urlparse(input_dir)
-
-        # TODO: Research on switching to 'obstore' for file listing to potentially improve performance.
-        # Currently using 'fsspec' due to some issues with 'obstore' when handling multiple instances.
-        fs = fsspec.filesystem(obj.scheme, **(storage_options or {}))
-        files = fs.find(input_dir, maxdepth=self.max_depth, detail=True, withdirs=False)
-
-        if _TQDM_AVAILABLE:
-            from tqdm.auto import tqdm
-
-            pbar = tqdm(desc="Discovering files", total=len(files))
-
-        metadatas = []
-        for _, file_info in files.items():
-            if file_info.get("type") != "file":
-                continue
-
-            file_path = file_info["name"]
-            if self._should_include_file(file_path):
-                metadata = FileMetadata(
-                    path=f"{obj.scheme}://{file_path}",
-                    size=file_info.get("size", 0),
-                )
-                metadatas.append(metadata)
-            if _TQDM_AVAILABLE:
-                pbar.update(1)
-        if _TQDM_AVAILABLE:
-            pbar.close()
-        return metadatas
-
-    def _discover_local_files(self, input_dir: str) -> list[FileMetadata]:
-        """Recursively list files in the local filesystem."""
-        path = Path(input_dir)
-        metadatas = []
-
-        for file_path in path.rglob("*"):
-            if not file_path.is_file():
-                continue
-
-            if self._should_include_file(str(file_path)):
-                metadata = FileMetadata(
-                    path=str(file_path),
-                    size=file_path.stat().st_size,
-                )
-                metadatas.append(metadata)
-
-        return metadatas
-
-    def _should_include_file(self, file_path: str) -> bool:
-        """Return True if file matches allowed extensions."""
-        file_ext = Path(file_path).suffix.lower()
-        return not self.extensions or file_ext in self.extensions
 
 
 class CacheManager:

--- a/src/litdata/raw/indexer.py
+++ b/src/litdata/raw/indexer.py
@@ -108,10 +108,10 @@ class FileIndexer(BaseIndexer):
         """Discover dataset files and return their metadata."""
         parsed_url = urlparse(input_dir)
 
-        if parsed_url.scheme in _SUPPORTED_PROVIDERS:
+        if parsed_url.scheme in _SUPPORTED_PROVIDERS:  # Cloud storage
             return self._discover_cloud_files(input_dir, storage_options)
 
-        if not parsed_url.scheme or parsed_url.scheme == "file":
+        if not parsed_url.scheme:  # Local filesystem
             return self._discover_local_files(input_dir)
 
         raise ValueError(

--- a/src/litdata/raw/indexer.py
+++ b/src/litdata/raw/indexer.py
@@ -1,0 +1,178 @@
+# Copyright The Lightning AI team.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+from litdata.constants import _FSSPEC_AVAILABLE, _TQDM_AVAILABLE, _ZSTD_AVAILABLE
+
+logger = logging.getLogger(__name__)
+_SUPPORTED_PROVIDERS = ("s3", "gs", "azure")
+
+
+@dataclass
+class FileMetadata:
+    """Metadata for a single file in the dataset."""
+
+    path: str
+    size: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"path": self.path, "size": self.size}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "FileMetadata":
+        return cls(path=data["path"], size=data["size"])
+
+
+class BaseIndexer(ABC):
+    """Abstract base class for file indexing strategies."""
+
+    @abstractmethod
+    def discover_files(self, input_dir: str, storage_options: Optional[dict[str, Any]]) -> list[FileMetadata]:
+        """Discover dataset files and return their metadata."""
+
+    def build_or_load_index(
+        self, input_dir: str, cache_dir: str, storage_options: Optional[dict[str, Any]]
+    ) -> list[FileMetadata]:
+        """Build or load a ZSTD-compressed index of file metadata."""
+        if not _ZSTD_AVAILABLE:
+            raise ModuleNotFoundError(str(_ZSTD_AVAILABLE))
+
+        import zstd
+
+        index_path = Path(cache_dir) / "index.json.zstd"
+
+        # Try loading cached index if it exists
+        if index_path.exists():
+            try:
+                with open(index_path, "rb") as f:
+                    compressed_data = f.read()
+                metadata = json.loads(zstd.decompress(compressed_data).decode("utf-8"))
+
+                return [FileMetadata.from_dict(file_data) for file_data in metadata["files"]]
+            except (FileNotFoundError, json.JSONDecodeError, zstd.ZstdError, KeyError) as e:
+                logger.warning(f"Failed to load cached index from {index_path}: {e}")
+
+        # Build fresh index
+        logger.info(f"Building index for {input_dir} at {index_path}")
+        files = self.discover_files(input_dir, storage_options)
+        if not files:
+            raise ValueError(f"No files found in {input_dir}")
+
+        # Cache the index with ZSTD compression
+        # TODO: upload the index to cloud storage
+        try:
+            metadata = {
+                "source": input_dir,
+                "files": [file.to_dict() for file in files],
+                "created_at": time.time(),
+            }
+            with open(index_path, "wb") as f:
+                f.write(zstd.compress(json.dumps(metadata).encode("utf-8")))
+        except (OSError, zstd.ZstdError) as e:
+            logger.warning(f"Error caching index to {index_path}: {e}")
+
+        logger.info(f"Built index with {len(files)} files from {input_dir} at {index_path}")
+        return files
+
+
+class FileIndexer(BaseIndexer):
+    """Indexes files recursively from cloud or local storage with optional extension filtering."""
+
+    def __init__(
+        self,
+        max_depth: int = 5,
+        extensions: Optional[list[str]] = None,
+    ):
+        self.max_depth = max_depth
+        self.extensions = [ext.lower() for ext in (extensions or [])]
+
+    def discover_files(self, input_dir: str, storage_options: Optional[dict[str, Any]]) -> list[FileMetadata]:
+        """Discover dataset files and return their metadata."""
+        parsed_url = urlparse(input_dir)
+
+        if parsed_url.scheme in _SUPPORTED_PROVIDERS:
+            return self._discover_cloud_files(input_dir, storage_options)
+
+        if not parsed_url.scheme or parsed_url.scheme == "file":
+            return self._discover_local_files(input_dir)
+
+        raise ValueError(
+            f"Unsupported input directory scheme: {parsed_url.scheme}. Supported schemes are: {_SUPPORTED_PROVIDERS}"
+        )
+
+    def _discover_cloud_files(self, input_dir: str, storage_options: Optional[dict[str, Any]]) -> list[FileMetadata]:
+        """Recursively list files in a cloud storage bucket."""
+        if not _FSSPEC_AVAILABLE:
+            raise ModuleNotFoundError(str(_FSSPEC_AVAILABLE))
+        import fsspec
+
+        obj = urlparse(input_dir)
+
+        # TODO: Research on switching to 'obstore' for file listing to potentially improve performance.
+        # Currently using 'fsspec' due to some issues with 'obstore' when handling multiple instances.
+        fs = fsspec.filesystem(obj.scheme, **(storage_options or {}))
+        files = fs.find(input_dir, maxdepth=self.max_depth, detail=True, withdirs=False)
+
+        if _TQDM_AVAILABLE:
+            from tqdm.auto import tqdm
+
+            pbar = tqdm(desc="Discovering files", total=len(files))
+
+        metadatas = []
+        for _, file_info in files.items():
+            if file_info.get("type") != "file":
+                continue
+
+            file_path = file_info["name"]
+            if self._should_include_file(file_path):
+                metadata = FileMetadata(
+                    path=f"{obj.scheme}://{file_path}",
+                    size=file_info.get("size", 0),
+                )
+                metadatas.append(metadata)
+            if _TQDM_AVAILABLE:
+                pbar.update(1)
+        if _TQDM_AVAILABLE:
+            pbar.close()
+        return metadatas
+
+    def _discover_local_files(self, input_dir: str) -> list[FileMetadata]:
+        """Recursively list files in the local filesystem."""
+        path = Path(input_dir)
+        metadatas = []
+
+        for file_path in path.rglob("*"):
+            if not file_path.is_file():
+                continue
+
+            if self._should_include_file(str(file_path)):
+                metadata = FileMetadata(
+                    path=str(file_path),
+                    size=file_path.stat().st_size,
+                )
+                metadatas.append(metadata)
+
+        return metadatas
+
+    def _should_include_file(self, file_path: str) -> bool:
+        """Return True if file matches allowed extensions."""
+        file_ext = Path(file_path).suffix.lower()
+        return not self.extensions or file_ext in self.extensions

--- a/src/litdata/raw/types.py
+++ b/src/litdata/raw/types.py
@@ -1,0 +1,14 @@
+# Copyright The Lightning AI team.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: Add types for TIFF, Video

--- a/tests/raw/test_dataset.py
+++ b/tests/raw/test_dataset.py
@@ -2,171 +2,14 @@ import os
 import sys
 import threading
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 from torch.utils.data import DataLoader
 
-from litdata.streaming.raw_dataset import (
-    CacheManager,
-    FileIndexer,
-    FileMetadata,
-    StreamingRawDataset,
-)
-
-
-def test_file_metadata():
-    """Test FileMetadata creation and serialization."""
-    data = {
-        "path": "/path/to/file.jpg",
-        "size": 1024,
-    }
-    metadata = FileMetadata(**data)
-
-    # Basic attribute checks
-    assert metadata.path == data["path"]
-    assert metadata.size == data["size"]
-
-    # Serialization round-trip
-    dict_repr = metadata.to_dict()
-    assert dict_repr == data
-    metadata2 = FileMetadata.from_dict(dict_repr)
-    assert metadata2 == metadata
-
-
-def test_file_indexer_init():
-    """Test FileIndexer initialization."""
-    indexer = FileIndexer()
-    assert indexer.max_depth == 5
-    assert indexer.extensions == []
-
-    indexer = FileIndexer(max_depth=3, extensions=[".jpg", ".png"])
-    assert indexer.max_depth == 3
-    assert indexer.extensions == [".jpg", ".png"]
-
-
-def test_should_include_file_no_extensions():
-    """Test file inclusion when no extensions filter is set."""
-    indexer = FileIndexer()
-
-    assert indexer._should_include_file("/path/to/file.jpg") is True
-    assert indexer._should_include_file("/path/to/file.txt") is True
-    assert indexer._should_include_file("/path/to/file") is True
-
-
-def test_should_include_file_with_extensions():
-    """Test file inclusion with extensions filter."""
-    indexer = FileIndexer(extensions=[".jpg", ".png"])
-
-    assert indexer._should_include_file("/path/to/file.jpg") is True
-    assert indexer._should_include_file("/path/to/file.JPG") is True  # Case insensitive
-    assert indexer._should_include_file("/path/to/file.png") is True
-    assert indexer._should_include_file("/path/to/file.txt") is False
-    assert indexer._should_include_file("/path/to/file") is False
-
-
-def test_discover_local_files(tmp_path):
-    """Test local file discovery."""
-    # Create test directory structure
-    (tmp_path / "file1.jpg").write_text("content1")
-    (tmp_path / "file2.png").write_text("content2")
-    (tmp_path / "file3.txt").write_text("content3")
-    (tmp_path / "subdir").mkdir()
-    (tmp_path / "subdir" / "file4.jpg").write_text("content4")
-
-    indexer = FileIndexer(extensions=[".jpg", ".png"])
-    files = indexer._discover_local_files(str(tmp_path))
-
-    # Should find 3 files (.jpg and .png files)
-    assert len(files) == 3
-
-    # Check that all returned files are FileMetadata objects
-    for file_metadata in files:
-        assert isinstance(file_metadata, FileMetadata)
-        assert file_metadata.size > 0
-
-
-@patch("fsspec.filesystem")
-def test_discover_cloud_files_s3(mock_filesystem):
-    """Test cloud file discovery for S3."""
-    # Mock fsspec filesystem
-    mock_fs = Mock()
-    mock_filesystem.return_value = mock_fs
-
-    # Mock file discovery result
-    mock_files = {
-        "s3://bucket/file1.jpg": {
-            "type": "file",
-            "name": "bucket/file1.jpg",
-            "size": 1024,
-            "LastModified": None,
-            "ETag": "abc123",
-        },
-        "s3://bucket/file2.png": {
-            "type": "file",
-            "name": "bucket/file2.png",
-            "size": 2048,
-            "LastModified": None,
-            "ETag": "def456",
-        },
-        "s3://bucket/subdir/": {
-            "type": "directory",
-            "name": "bucket/subdir/",
-        },
-    }
-    mock_fs.find.return_value = mock_files
-
-    indexer = FileIndexer(extensions=[".jpg", ".png"])
-    files = indexer._discover_cloud_files("s3://bucket/", {})
-
-    # Should find 2 files (excluding directory)
-    assert len(files) == 2
-    assert all(isinstance(f, FileMetadata) for f in files)
-    assert all(f.path.startswith("s3://") for f in files)
-
-
-@pytest.mark.skipif(condition=sys.platform == "win32", reason="Not supported on windows")
-def test_build_or_load_index_creates_new(tmp_path):
-    """Test that build_or_load_index creates a new index when none exists."""
-    # Create test files
-    (tmp_path / "file1.jpg").write_text("content1")
-    (tmp_path / "file2.jpg").write_text("content2")
-
-    cache_dir = tmp_path / "cache"
-    cache_dir.mkdir()
-
-    indexer = FileIndexer(extensions=[".jpg"])
-    files = indexer.build_or_load_index(str(tmp_path), str(cache_dir), {})
-
-    assert len(files) == 2
-
-    # Check that index file was created
-    index_file = cache_dir / "index.json.zstd"
-    assert index_file.exists()
-
-
-@pytest.mark.skipif(condition=sys.platform == "win32", reason="Not supported on windows")
-def test_build_or_load_index_loads_existing(tmp_path):
-    """Test that build_or_load_index loads existing index when available."""
-    # Create test files
-    (tmp_path / "file1.jpg").write_text("content1")
-
-    cache_dir = tmp_path / "cache"
-    cache_dir.mkdir()
-
-    indexer = FileIndexer(extensions=[".jpg"])
-
-    # Build index first time
-    files1 = indexer.build_or_load_index(str(tmp_path), str(cache_dir), {})
-
-    # Load index second time (should load from cache)
-    with patch.object(indexer, "discover_files") as mock_discover:
-        files2 = indexer.build_or_load_index(str(tmp_path), str(cache_dir), {})
-        # discover_files should not be called if loading from cache
-        mock_discover.assert_not_called()
-
-    assert len(files1) == len(files2)
-    assert files1[0].path == files2[0].path
+from litdata import StreamingRawDataset
+from litdata.raw.dataset import CacheManager
+from litdata.raw.indexer import FileMetadata
 
 
 def test_cache_manager_init_with_caching(tmp_path):
@@ -384,20 +227,6 @@ def test_streaming_raw_dataset_getitems_index_error(tmp_path):
 
 
 @pytest.mark.skipif(condition=sys.platform == "win32", reason="Not supported on windows")
-def test_streaming_raw_dataset_with_custom_indexer(tmp_path):
-    """Test dataset with custom indexer."""
-    (tmp_path / "file1.jpg").write_text("content1")
-    (tmp_path / "file2.png").write_text("content2")
-    (tmp_path / "file3.txt").write_text("content3")
-
-    custom_indexer = FileIndexer(extensions=[".jpg"])
-
-    dataset = StreamingRawDataset(input_dir=str(tmp_path), indexer=custom_indexer, cache_files=False)
-
-    assert len(dataset) == 1  # Only .jpg file should be indexed
-
-
-@pytest.mark.skipif(condition=sys.platform == "win32", reason="Not supported on windows")
 def test_streaming_raw_dataset_transform(tmp_path):
     """Test transform support in StreamingRawDataset."""
     test_content = b"raw"
@@ -494,13 +323,6 @@ def test_streaming_raw_dataset_invalid_setup(tmp_path):
     (tmp_path / "file1.jpg").write_text("content1")
     with pytest.raises(TypeError, match="The setup method must return a list"):
         BadDataset(input_dir=str(tmp_path))
-
-
-def test_file_indexer_should_include_file_edge():
-    idx = FileIndexer(extensions=None)
-    assert idx._should_include_file("foo.bar") is True
-    idx2 = FileIndexer(extensions=[".jpg"])
-    assert idx2._should_include_file("foo.txt") is False
 
 
 @pytest.mark.skipif(condition=sys.platform == "win32", reason="Not supported on windows")

--- a/tests/raw/test_indexer.py
+++ b/tests/raw/test_indexer.py
@@ -1,0 +1,182 @@
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+from litdata import StreamingRawDataset
+from litdata.raw.indexer import FileIndexer, FileMetadata
+
+
+def test_file_metadata():
+    """Test FileMetadata creation and serialization."""
+    data = {
+        "path": "/path/to/file.jpg",
+        "size": 1024,
+    }
+    metadata = FileMetadata(**data)
+
+    # Basic attribute checks
+    assert metadata.path == data["path"]
+    assert metadata.size == data["size"]
+
+    # Serialization round-trip
+    dict_repr = metadata.to_dict()
+    assert dict_repr == data
+    metadata2 = FileMetadata.from_dict(dict_repr)
+    assert metadata2 == metadata
+
+
+def test_file_indexer_init():
+    """Test FileIndexer initialization."""
+    indexer = FileIndexer()
+    assert indexer.max_depth == 5
+    assert indexer.extensions == []
+
+    indexer = FileIndexer(max_depth=3, extensions=[".jpg", ".png"])
+    assert indexer.max_depth == 3
+    assert indexer.extensions == [".jpg", ".png"]
+
+
+def test_should_include_file_no_extensions():
+    """Test file inclusion when no extensions filter is set."""
+    indexer = FileIndexer()
+
+    assert indexer._should_include_file("/path/to/file.jpg") is True
+    assert indexer._should_include_file("/path/to/file.txt") is True
+    assert indexer._should_include_file("/path/to/file") is True
+
+
+def test_should_include_file_with_extensions():
+    """Test file inclusion with extensions filter."""
+    indexer = FileIndexer(extensions=[".jpg", ".png"])
+
+    assert indexer._should_include_file("/path/to/file.jpg") is True
+    assert indexer._should_include_file("/path/to/file.JPG") is True  # Case insensitive
+    assert indexer._should_include_file("/path/to/file.png") is True
+    assert indexer._should_include_file("/path/to/file.txt") is False
+    assert indexer._should_include_file("/path/to/file") is False
+
+
+def test_file_indexer_should_include_file_edge():
+    idx = FileIndexer(extensions=None)
+    assert idx._should_include_file("foo.bar") is True
+    idx2 = FileIndexer(extensions=[".jpg"])
+    assert idx2._should_include_file("foo.txt") is False
+
+
+def test_discover_local_files(tmp_path):
+    """Test local file discovery."""
+    # Create test directory structure
+    (tmp_path / "file1.jpg").write_text("content1")
+    (tmp_path / "file2.png").write_text("content2")
+    (tmp_path / "file3.txt").write_text("content3")
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "subdir" / "file4.jpg").write_text("content4")
+
+    indexer = FileIndexer(extensions=[".jpg", ".png"])
+    files = indexer._discover_local_files(str(tmp_path))
+
+    # Should find 3 files (.jpg and .png files)
+    assert len(files) == 3
+
+    # Check that all returned files are FileMetadata objects
+    for file_metadata in files:
+        assert isinstance(file_metadata, FileMetadata)
+        assert file_metadata.size > 0
+
+
+@patch("fsspec.filesystem")
+def test_discover_cloud_files_s3(mock_filesystem):
+    """Test cloud file discovery for S3."""
+    # Mock fsspec filesystem
+    mock_fs = Mock()
+    mock_filesystem.return_value = mock_fs
+
+    # Mock file discovery result
+    mock_files = {
+        "s3://bucket/file1.jpg": {
+            "type": "file",
+            "name": "bucket/file1.jpg",
+            "size": 1024,
+            "LastModified": None,
+            "ETag": "abc123",
+        },
+        "s3://bucket/file2.png": {
+            "type": "file",
+            "name": "bucket/file2.png",
+            "size": 2048,
+            "LastModified": None,
+            "ETag": "def456",
+        },
+        "s3://bucket/subdir/": {
+            "type": "directory",
+            "name": "bucket/subdir/",
+        },
+    }
+    mock_fs.find.return_value = mock_files
+
+    indexer = FileIndexer(extensions=[".jpg", ".png"])
+    files = indexer._discover_cloud_files("s3://bucket/", {})
+
+    # Should find 2 files (excluding directory)
+    assert len(files) == 2
+    assert all(isinstance(f, FileMetadata) for f in files)
+    assert all(f.path.startswith("s3://") for f in files)
+
+
+@pytest.mark.skipif(condition=sys.platform == "win32", reason="Not supported on windows")
+def test_build_or_load_index_creates_new(tmp_path):
+    """Test that build_or_load_index creates a new index when none exists."""
+    # Create test files
+    (tmp_path / "file1.jpg").write_text("content1")
+    (tmp_path / "file2.jpg").write_text("content2")
+
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+
+    indexer = FileIndexer(extensions=[".jpg"])
+    files = indexer.build_or_load_index(str(tmp_path), str(cache_dir), {})
+
+    assert len(files) == 2
+
+    # Check that index file was created
+    index_file = cache_dir / "index.json.zstd"
+    assert index_file.exists()
+
+
+@pytest.mark.skipif(condition=sys.platform == "win32", reason="Not supported on windows")
+def test_build_or_load_index_loads_existing(tmp_path):
+    """Test that build_or_load_index loads existing index when available."""
+    # Create test files
+    (tmp_path / "file1.jpg").write_text("content1")
+
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+
+    indexer = FileIndexer(extensions=[".jpg"])
+
+    # Build index first time
+    files1 = indexer.build_or_load_index(str(tmp_path), str(cache_dir), {})
+
+    # Load index second time (should load from cache)
+    with patch.object(indexer, "discover_files") as mock_discover:
+        files2 = indexer.build_or_load_index(str(tmp_path), str(cache_dir), {})
+        # discover_files should not be called if loading from cache
+        mock_discover.assert_not_called()
+
+    assert len(files1) == len(files2)
+    assert files1[0].path == files2[0].path
+
+
+@pytest.mark.skipif(condition=sys.platform == "win32", reason="Not supported on windows")
+def test_streaming_raw_dataset_with_custom_indexer(tmp_path):
+    """Test dataset with custom indexer."""
+    (tmp_path / "file1.jpg").write_text("content1")
+    (tmp_path / "file2.png").write_text("content2")
+    (tmp_path / "file3.txt").write_text("content3")
+
+    custom_indexer = FileIndexer(extensions=[".jpg"])
+
+    dataset = StreamingRawDataset(input_dir=str(tmp_path), indexer=custom_indexer, cache_files=False)
+
+    assert len(dataset) == 1  # Only .jpg file should be indexed


### PR DESCRIPTION
## What does this PR do ?

This PR reorganizes all raw dataset-related files into the new `litdata/raw` directory and moves corresponding tests to `tests/raw`.

Also, exposes StreamingRawDataset in the top-level `litdata` import for easier access.

> No functional changes; only refactoring and import improvements.

