### PR TITLE
🐛 Fix broken 'Get Started' link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Transform                              Optimize
 
 &nbsp;
 
-<a target="_blank" href="https://lightning.ai/docs/overview/prep-data/optimize-datasets-for-model-training-speed">
+<a target="_blank" href="https://lightning.ai/docs/overview/optimize-data/optimize-datasets">
   <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/get-started-badge.svg" height="36px" alt="Get started"/>
 </a>
 


### PR DESCRIPTION
🐛 Fix broken 'Get Started' link in README
--------------------------------------------------

<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests? (Not applicable here)

</details>

## What does this PR do?

Fixes #672

### 🔍 Summary

- The **"Get Started"** badge link in the `README.md` was broken:
  https://lightning.ai/docs/overview/prep-data/optimize-datasets-for-model-training-speed

- It has now been replaced with the correct documentation URL:
  https://lightning.ai/docs/overview/optimize-data/optimize-datasets

## PR review

This is a simple documentation fix and doesn't affect any logic or codebase functionality.  
Community members are welcome to review once the tests pass.

## Did you have fun?

Yes, Happy to contribute and help improve the developer experience!