### PR TITLE
feat: add support to stream multiple optimized datasets using StreamingDataset

### DIFF
--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -47,7 +47,7 @@ class StreamingDataset(IterableDataset):
 
     def __init__(
         self,
-        input_dir: Union[str, "Dir"],
+        input_dir: Union[str, "Dir", list[str], list["Dir"]],
         cache_dir: Optional[Union[str, "Dir"]] = None,
         item_loader: Optional[BaseItemLoader] = None,
         shuffle: bool = False,
@@ -93,6 +93,9 @@ class StreamingDataset(IterableDataset):
         """
         _check_version_and_prompt_upgrade(__version__)
 
+        if not isinstance(input_dir, list):
+            input_dir = [input_dir]
+
         super().__init__()
         if not isinstance(shuffle, bool):
             raise ValueError(f"Shuffle should be a boolean. Found {shuffle}")
@@ -101,8 +104,12 @@ class StreamingDataset(IterableDataset):
             raise ValueError("subsample must be a float with value greater than 0.")
 
         fnmatch_pattern = None
-        if isinstance(input_dir, str) and input_dir.endswith(".parquet"):
-            input_dir, fnmatch_pattern = os.path.split(input_dir)
+        if len(input_dir) == 1 and isinstance(input_dir[0], str) and input_dir[0].endswith(".parquet"):
+            input_dir, fnmatch_pattern = os.path.split(input_dir[0])
+
+        if len(input_dir) > 1:
+            raise ValueError("Not implemented")
+        input_dir = input_dir[0]
 
         input_dir = _resolve_dir(input_dir)
         cache_dir = _resolve_dir(cache_dir)


### PR DESCRIPTION
…sets

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes # (issue).

This PR introduces a new feature to the `StreamingDataset` class, enabling it to accept multiple `input_dir` paths and combine their `index.json` files while preserving their respective remote path sources. This allows streaming from multiple buckets simultaneously without the need to copy or merge files, resulting in significant speed improvements.

## testing code

```python
import litdata as ld

optimized_datasets = ["s3://bucket1/ds1", "s3://bucket2/ds2", "s3://bucket3/ds8"]

ds = ld.StreamingDataset(optimized_datasets)

dataloader = ld.StreamingDataloader(ds, batch_size = 4)

for batch in dataloader:
    ...
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
