### PR TITLE
Remove unnecessary fixed sleep by adding predicate-based path check

### DIFF
--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -17,7 +17,7 @@ from litdata.utilities.subsample import shuffle_lists_together, subsample_filena
 
 
 def wait_for_predicate(
-    predicate: Callable[[], bool],
+    predicate: Callable[[Any], bool],
     timeout: float,
 ) -> bool:
     """Wait until the given predicate becomes True or the timeout expires.
@@ -86,8 +86,8 @@ def subsample_streaming_dataset(
             downloader = get_downloader(input_dir.url, input_dir.path, [], storage_options, session_options)
             downloader.download_file(os.path.join(input_dir.url, _INDEX_FILENAME), cache_index_filepath)
 
-    def path_exists(p: os.PathLike):
-        return wait_for_predicate(lambda x: os.path.exists(p), timeout=0.5)
+    def path_exists(p: str) -> bool:
+        return wait_for_predicate(lambda: os.path.exists(p), timeout=0.5)
 
     if not path_exists(input_dir.path):
         raise FileNotFoundError(f"The provided dataset path `{input_dir.path}` does not exist.")

--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -30,9 +30,8 @@ def wait_for_predicate(
         True if predicate became True within timeout, else False.
     """
     start = time.time()
-    while time.time() - start < timeout:
-        if predicate():
             return True
+        time.sleep(0.01)
     return False
 
 

--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import tempfile
 import time
-from typing import Any, Optional, Callable
+from typing import Any, Callable, Optional
 
 import numpy as np
 
@@ -15,12 +15,12 @@ from litdata.streaming.item_loader import BaseItemLoader, TokensLoader
 from litdata.streaming.resolver import Dir, _resolve_dir
 from litdata.utilities.subsample import shuffle_lists_together, subsample_filenames_and_roi
 
+
 def wait_for_predicate(
     predicate: Callable[[], bool],
     timeout: float,
 ) -> bool:
-    """
-    Wait until the given predicate becomes True or the timeout expires.
+    """Wait until the given predicate becomes True or the timeout expires.
 
     Args:
         predicate: A function returning a boolean condition to check.
@@ -34,6 +34,7 @@ def wait_for_predicate(
         if predicate():
             return True
     return False
+
 
 def subsample_streaming_dataset(
     input_dir: Dir,
@@ -84,7 +85,6 @@ def subsample_streaming_dataset(
         else:
             downloader = get_downloader(input_dir.url, input_dir.path, [], storage_options, session_options)
             downloader.download_file(os.path.join(input_dir.url, _INDEX_FILENAME), cache_index_filepath)
-
 
     def path_exists(p: os.PathLike):
         return wait_for_predicate(lambda x: os.path.exists(p), timeout=0.5)

--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -17,7 +17,7 @@ from litdata.utilities.subsample import shuffle_lists_together, subsample_filena
 
 
 def wait_for_predicate(
-    predicate: Callable[[Any], bool],
+    predicate: Callable[[], bool],
     timeout: float,
 ) -> bool:
     """Wait until the given predicate becomes True or the timeout expires.

--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -30,6 +30,8 @@ def wait_for_predicate(
         True if predicate became True within timeout, else False.
     """
     start = time.time()
+    while time.time() - start < timeout:
+        if predicate():
             return True
         time.sleep(0.01)
     return False

--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import tempfile
 import time
-from typing import Any, Optional
+from typing import Any, Optional, Callable
 
 import numpy as np
 
@@ -15,6 +15,25 @@ from litdata.streaming.item_loader import BaseItemLoader, TokensLoader
 from litdata.streaming.resolver import Dir, _resolve_dir
 from litdata.utilities.subsample import shuffle_lists_together, subsample_filenames_and_roi
 
+def wait_for_predicate(
+    predicate: Callable[[], bool],
+    timeout: float,
+) -> bool:
+    """
+    Wait until the given predicate becomes True or the timeout expires.
+
+    Args:
+        predicate: A function returning a boolean condition to check.
+        timeout: Maximum time (in seconds) to wait.
+
+    Returns:
+        True if predicate became True within timeout, else False.
+    """
+    start = time.time()
+    while time.time() - start < timeout:
+        if predicate():
+            return True
+    return False
 
 def subsample_streaming_dataset(
     input_dir: Dir,
@@ -66,9 +85,11 @@ def subsample_streaming_dataset(
             downloader = get_downloader(input_dir.url, input_dir.path, [], storage_options, session_options)
             downloader.download_file(os.path.join(input_dir.url, _INDEX_FILENAME), cache_index_filepath)
 
-    time.sleep(0.5)  # Give some time for the file to be available
 
-    if not os.path.exists(input_dir.path):
+    def path_exists(p: os.PathLike):
+        return wait_for_predicate(lambda x: os.path.exists(p), timeout=0.5)
+
+    if not path_exists(input_dir.path):
         raise FileNotFoundError(f"The provided dataset path `{input_dir.path}` does not exist.")
 
     if os.path.exists(os.path.join(input_dir.path, _INDEX_FILENAME)):


### PR DESCRIPTION
## What does this PR do?

Replaces the fixed `time.sleep(0.5)` with a predicate-based check using `wait_for_predicate`.
This removes unnecessary waiting when the dataset path already exists, while still handling cases where it appears slightly later.  
This significantly speeds up cache loading when there are thousands of optimized dirs


