### PR TITLE
Add readme docs for references to data connection dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1619,6 +1619,40 @@ if __name__ == "__main__":
 
 </details>
 
+<details>
+  <summary> ✅ Direct uploads to Lightning AI data connections</summary>
+
+&nbsp;
+
+[Lightning Studios](https://lightning.ai/) have special directories for data connections that are available to an entire teamspace. LitData functions that reference those directories will experience a significant performance increase as uploads and downloads will happen directly from the bucket that backs the folder.
+
+For example, output artifacts from this code will be directly uploaded to the `my-data-1` s3 bucket.
+
+```
+from litdata import optimize
+
+def should_keep(data):
+    if data % 2 == 0:
+        yield data
+
+if __name__ == "__main__":
+    optimize(
+        fn=should_keep,
+        inputs=list(range(1000)),
+        output_dir="/teamspace/s3_connections/my-data-1/output",
+        chunk_bytes="64MB",
+        num_workers=1
+    )
+```
+
+References to any of the following directories will work similarly:
+1. `/teamspace/lightning_storage/...`
+2. `/teamspace/s3_connections/...`
+3. `/teamspace/gcs_connections/...`
+4. `/teamspace/s3_folders/...`
+5. `/teamspace/gcs_folders/...`
+</details>
+
 &nbsp;
 
 

--- a/README.md
+++ b/README.md
@@ -1620,7 +1620,7 @@ if __name__ == "__main__":
 </details>
 
 <details>
-  <summary> ✅ Direct uploads to Lightning AI data connections</summary>
+  <summary> ✅ Lightning AI Data Connections - Direct download and upload </summary>
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -1645,6 +1645,21 @@ if __name__ == "__main__":
     )
 ```
 
+
+Similarly, data will be downloaded directly from the `my-data-1` s3 bucket in this example code.
+
+```
+from litdata import StreamingRawDataset
+
+if __name__ == "__main__":
+    data_dir = "/teamspace/s3_connections/my-bucket-1/data"
+
+    raw_dataset = StreamingRawDataset(data_dir)
+
+    data = list(raw_dataset)
+    print(data)
+```
+
 References to any of the following directories will work similarly:
 1. `/teamspace/lightning_storage/...`
 2. `/teamspace/s3_connections/...`


### PR DESCRIPTION
## What does this PR do?
Add docs to the readme that describes how users can reference data connection paths to get faster upload/download speeds.

<img width="708" height="803" alt="Screenshot 2025-09-09 at 3 01 01 PM" src="https://github.com/user-attachments/assets/49f0ee9e-971f-43d0-8f7d-a32bbacf6bd5" />


Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
