### PR TITLE
Fix(litData): Handle truncated index.json files without failure

### DIFF
--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -312,6 +312,16 @@ def load_index_file(input_dir: str) -> dict[str, Any]:
         return data
     except FileNotFoundError:
         raise FileNotFoundError(f"Index file not found at {index_filepath}.")
+    except json.decoder.JSONDecodeError:
+        with open(index_filepath) as f:
+            raw_data = f.read()
+            raw_data += "}" # close the json content it has been truncated by a character
+            data = json.loads(raw_data) # load json from string
+        if "chunks" not in data and "shards" in data:
+            # load mds shard-based index file and adapt to chunks format
+            return adapt_mds_shards_to_chunks(data)
+
+        return data
 
 
 def adapt_mds_shards_to_chunks(data: dict[str, Any]) -> dict[str, Any]:

--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -315,8 +315,8 @@ def load_index_file(input_dir: str) -> dict[str, Any]:
     except json.decoder.JSONDecodeError:
         with open(index_filepath) as f:
             raw_data = f.read()
-            raw_data += "}" # close the json content it has been truncated by a character
-            data = json.loads(raw_data) # load json from string
+            raw_data += "}"  # close the json content it has been truncated by a character
+            data = json.loads(raw_data)  # load json from string
         if "chunks" not in data and "shards" in data:
             # load mds shard-based index file and adapt to chunks format
             return adapt_mds_shards_to_chunks(data)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes an issue that occurs every 20-30 streaming datasets, where the `index.json` file that is read is truncated and missing its closing bracket `}`.

I attempted both redownloading the file and checking the cache copy location and this did not fix the issue, but with consistency in certain cases the closing bracket is missing.

This is fairly highly reproducible:

Main.py
```
from litdata import StreamingDataset, StreamingDataLoader, optimize
import time


def should_keep(data):
    if data % 2 == 0:
        yield data


if __name__ == "__main__":
    output_dir = (
        "/teamspace/lightning_storage/cloud-experiments/litdata_optimize_bug/test_11"
    )
    optimize(
        fn=should_keep,
        inputs=list(range(5000)),
        output_dir=output_dir,
        chunk_bytes="64MB",
        num_workers=4,
        compression="zstd",  # Without this, no error.
        mode="overwrite",
    )
    print("done optimizing dataset, now waiting before reading")
    # time.sleep(10)  # There is the error with or without this sleep
    dataset = StreamingDataset(output_dir)
    print(f"length of datset is {len(dataset)}")

    dataloader = StreamingDataLoader(dataset, batch_size=32, num_workers=4)
    for _ in dataloader:
        pass

    print("Successfully iterated through the data")
```

Iterate with this bash script:
```
#!/bin/bash
count=0
while python main.py; do
  count=$((count + 1))
  echo "Run #$count succeeded."
  if [ "$count" -ge 100 ]; then
    echo "main.py succeeded 100 times, stopping."
    exit 0
  fi
done

echo "main.py failed on run #$((count + 1)), stopping."
```

And we will see failure between iteration 20 and 30 every time without this fix.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
