### PR TITLE
WIP: Fix: Force delete prior to force download

### DIFF
--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -194,6 +194,10 @@ class ChunksConfig:
         exists = os.path.exists(local_chunkpath) and os.stat(local_chunkpath).st_size >= chunk_bytes
         while not exists:
             sleep(0.1)
+            # Return if the actual file exists
+            if os.path.exists(target_local_chunkpath):
+                return
+            # find the local compressed file
             exists = os.path.exists(local_chunkpath) and os.stat(local_chunkpath).st_size >= chunk_bytes
 
             if (time() - start_time) > _MAX_WAIT_TIME:


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes a deadlock in deleting a chunk and forces a delete prior to redownloading.
This avoids timeouts in cases where there is a deadlock.

Successful runs show a dip in performance around the point deadlock would occur, but future deadlock points don't result in the same dip.
<img width="1126" height="454" alt="Screenshot 2025-09-23 at 7 03 37 PM" src="https://github.com/user-attachments/assets/25399488-da51-481a-89ae-df67c10f70e3" />

Before adding `skip_lock` to `_apply_delete` debug logs showed:
```
Skip delete /cache/chunks/efbefe0228a2074e53fb8a67da79bd8b/1755713448.3693707/chunk-44-17.bin by 0, current lock count: 3
Requested force download for /cache/chunks/efbefe0228a2074e53fb8a67da79bd8b/1755713448.3693707/chunk-44-17.bin by None
```
Followed by:
```
FileNotFoundError: The /cache/chunks/efbefe0228a2074e53fb8a67da79bd8b/1755713448.3693707/chunk-44-17.bin hasn't been found.
```

What this means is:

1. The file is not found
2. After 30s a force redownload is requested
3. This redownload doesn't succeed
4. The while loop looking for the file eventually times out and crashes the pipeline

When adding in the delete we see that it is skipped because of a deadlock situation with 3 workers wanting the file.
After forcing a delete, the download to the cache operates properly and a pipeline timeout is avoided.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
