### PR TITLE
pin: torchaudio to `>=2.7.0,<2.9`

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,7 +2,7 @@ av >=14.0.0
 coverage ==7.10.*
 cryptography==45.0.7
 mosaicml-streaming==0.11.0
-torchaudio ==2.7.*
+torchaudio>=2.7.0,<2.9
 pytest ==8.4.*
 pytest-asyncio>=1.0.0
 pytest-cov ==7.0.0


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

From [Torchaudio >=2.9](https://github.com/pytorch/audio/releases/tag/v2.9.0), Most APIs marked as https://github.com/pytorch/audio/issues/3902#issue-3017467084 are now removed. This results in CI tests failing for `litdata-torchaudio` dataset optimization. [check failing tests here](https://github.com/Lightning-AI/litData/actions/runs/18554789434/job/52889600313?pr=737).

We can either bump `torchaudio` to older release as a quick fix, or for latest torchaudio support, we need to update existing api calls, and install `ffmpeg` followed by `torchcodec` to pass tests.

As a quick fix, this PR pins torchaudio to an older compatible release to restore CI stability.

If we’d prefer to support the latest `Torchaudio` release instead, I can update this PR to include the necessary API adjustments and add `ffmpeg`, `torchcodec`, and `torchaudio` installation steps in the CI workflow.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
