### PR TITLE
feat: add `align_chunking` option to preserve deterministic chunk boundaries across workers

### DIFF
--- a/src/litdata/processing/functions.py
+++ b/src/litdata/processing/functions.py
@@ -431,7 +431,8 @@ def optimize(
         chunk_bytes: The maximum number of bytes to hold within a chunk.
         align_chunking: Ensures chunk boundaries match the single-worker layout by packing full chunks first
             and placing all remaining items in the final worker. Each worker will receive chunks of this size,
-            except possibly the last worker which may receive a smaller chunk.
+            except possibly the last worker which may receive a smaller chunk. Note: this will result in uneven
+            workload distribution among workers, and last worker may receive more data than others.
         compression: The compression algorithm to use over the chunks.
         encryption: The encryption algorithm to use over the chunks.
         num_workers: The number of workers to use during processing

--- a/tests/processing/test_data_processor.py
+++ b/tests/processing/test_data_processor.py
@@ -389,7 +389,8 @@ def test_map_items_to_workers_sequentially_align_chunking(monkeypatch):
     # 2 nodes, 2 workers per node, chunk_size=2.
     # Total items = 5 => only the final worker should receive them,
     # because no worker except the last can form even one full chunk. (5/ (2*2*2) = 0.625 ~ 0)
-    workers_user_items = _map_items_to_workers_sequentially(2, list(range(5)), chunk_size=2)
+    with pytest.warns(UserWarning, match="Consider reducing chunk_size or using fewer workers"):
+        workers_user_items = _map_items_to_workers_sequentially(2, list(range(5)), chunk_size=2)
     assert workers_user_items == [[], []]
 
     monkeypatch.setenv("DATA_OPTIMIZER_NUM_NODES", "2")

--- a/tests/processing/test_functions.py
+++ b/tests/processing/test_functions.py
@@ -1,5 +1,6 @@
 import glob
 import io
+import math
 import os
 import random
 import shutil
@@ -104,10 +105,6 @@ def compress(index):
     return index, index**2
 
 
-def getter(index: int):
-    return torch.Tensor(torch.full((4096, 128), index, dtype=torch.long))
-
-
 def different_compress(index):
     return index, index**2, index**3
 
@@ -133,7 +130,7 @@ def test_optimize_align_chunking_requires_chunk_size(tmp_path):
 
     with pytest.raises(ValueError, match="`chunk_size` needs to be defined"):
         optimize(
-            fn=getter,
+            fn=compress,
             inputs=list(range(7 * 64)),
             chunk_bytes="1MB",
             output_dir=str(output_dir),
@@ -143,22 +140,17 @@ def test_optimize_align_chunking_requires_chunk_size(tmp_path):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="too slow")
-@pytest.mark.parametrize(
-    ("num_workers", "expected_worker_chunks"),
-    [
-        # num_workers = 1 => worker 0 writes 7 chunks: chunk-0-0.bin .. chunk-0-6.bin
-        (1, {0: range(7)}),
-        # num_workers = 2 => worker 0 writes 3 chunks, worker 1 writes 4 chunks
-        (2, {0: range(3), 1: range(4)}),
-    ],
-)
-def test_optimize_align_chunking_creates_expected_chunks(tmp_path, num_workers, expected_worker_chunks):
+@pytest.mark.parametrize("num_workers", [1, 2])
+@pytest.mark.parametrize("chunk_size", [16, 32, 64])
+def test_optimize_align_chunking_creates_expected_chunks(tmp_path, chunk_size, num_workers):
     output_dir = tmp_path / f"output_workers_{num_workers}"
 
+    inputs = list(range(7 * 64))
+
     optimize(
-        fn=getter,
-        inputs=list(range(7 * 64)),
-        chunk_size=64,
+        fn=compress,
+        inputs=inputs,
+        chunk_size=chunk_size,
         output_dir=str(output_dir),
         num_workers=num_workers,
         align_chunking=True,
@@ -167,8 +159,20 @@ def test_optimize_align_chunking_creates_expected_chunks(tmp_path, num_workers, 
     assert output_dir.exists()
 
     actual_files = set(os.listdir(output_dir))
+
+    total_items = len(inputs)
+    items_per_worker = total_items / num_workers
+    chunks_per_worker = items_per_worker / chunk_size
+
+    # each worker should create `math.floor(chunks_per_worker)` chunks,
+    # except the last worker which will create the chunk with remaining items `math.ceil(chunks_per_worker)`
+    expected_chunks_by_worker = {
+        worker_id: (math.floor(chunks_per_worker) if worker_id < num_workers - 1 else math.ceil(chunks_per_worker))
+        for worker_id in range(num_workers)
+    }
+
     expected_chunk_files = {
-        f"chunk-{worker_id}-{i}.bin" for worker_id, indices in expected_worker_chunks.items() for i in indices
+        f"chunk-{worker_id}-{i}.bin" for worker_id, indices in expected_chunks_by_worker.items() for i in range(indices)
     }
     expected_files = expected_chunk_files | {"index.json"}
 

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -500,7 +500,7 @@ def test_dataloader_dataset_transform_inheritance(tmpdir, shuffle):
 
 
 def getter(index: int):
-    return torch.Tensor(torch.full((4096, 128), index, dtype=torch.long))
+    return index
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="too slow")
@@ -519,11 +519,13 @@ def test_dataloader_with_align_chunking(tmp_path, num_workers):
 
     # Ensure batches contain elements from the same chunk when using align_chunking
     dataset = StreamingDataset(str(output_dir), shuffle=True)
+
+    # make sure batch_size of dataloader is equal to chunk_size used during optimize
     dataloader = StreamingDataLoader(dataset, batch_size=64, num_workers=num_workers, shuffle=True)
+
     for i, batch in enumerate(dataloader):
-        index = batch[:, 0, 0]
-        min_element_in_batch = torch.min(index).item()
-        max_element_in_batch = torch.max(index).item()
+        min_element_in_batch = torch.min(batch).item()
+        max_element_in_batch = torch.max(batch).item()
         assert max_element_in_batch - min_element_in_batch < 64, (
             f"Batch {i} contains elements from multiple chunks: min {min_element_in_batch}, max {max_element_in_batch}"
         )


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #758

This PR introduces a new `align_chunking` option to `optimize()` and internal item-mapping logic. When enabled, items are assigned to workers using a deterministic chunk-aligned strategy that mirrors the single-worker chunk layout. All workers receive only full chunks of the specified size, except for the final worker, which may receive a partial chunk.

This eliminates the inconsistent partial-chunk patterns that occur when multiple workers independently chunk their own subsets, ensuring downstream samplers and loaders see stable chunk boundaries regardless of `num_workers`.

### Key points:

• Supports both `None` (current behavior) and an integer chunk size.
• Guarantees chunk alignment equivalent to `num_workers=1` & `num_nodes = 1`.
• Multi-node support ✅.
• Adds thorough tests verifying alignment behavior.

This provides a predictable chunk layout for users who rely on `chunk_size` semantics, especially when batch size is a multiple of chunk size, **`while maintaining full backwards compatibility`**.

---

### Code

- Optimize dataset
```python
import litdata as ld
import torch


def getter(index: int):
    return torch.Tensor(torch.full((4096, 128), index, dtype=torch.long))


if __name__ == "__main__":
    ld.optimize(
        fn=getter,
        inputs=list(range(7 * 64)),
        chunk_size=64,
        align_chunking=True,
        output_dir="worker_size_1",
        num_workers=1,
        mode="overwrite",
    )
    ld.optimize(
        fn=getter,
        inputs=list(range(7 * 64)),
        align_chunking=True,
        chunk_size=64,
        output_dir="worker_size_2",
        num_workers=2,
        mode="overwrite",
    )
```

- Stream and assert that each batch is from same chunk only.
```python
import litdata as ld

if __name__ == "__main__":
    print(" Worker num = 1 ".center(60, "-"))
    dataset = ld.StreamingDataset("worker_size_1/", shuffle=True)
    dataloader = ld.StreamingDataLoader(dataset, batch_size=64, num_workers=1)
    for i, batch in enumerate(dataloader):
        index = batch[:, 0, 0]
        min_item = index.min().item()
        max_item = index.max().item()
        assert max_item - min_item < 64, "each batch should belong to the same chunk."
        print(f"{i} ~ max-min-diff:", (index.max() - index.min()).item())


    print(" Worker num = 2 ".center(60, "-"))
    dataset = ld.StreamingDataset("worker_size_2/", shuffle=True)
    dataloader = ld.StreamingDataLoader(dataset, batch_size=64, num_workers=1)
    for i, batch in enumerate(dataloader):
        index = batch[:, 0, 0]
        min_item = index.min().item()
        max_item = index.max().item()
        assert max_item - min_item < 64, "each batch should belong to the same chunk."
        print(f"{i} ~ max-min-diff:", (index.max() - index.min()).item())
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
