### PR TITLE
Fix row index miscalculation in ParquetLoader

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -62,7 +62,7 @@ jobs:
           pytest tests \
               --ignore=tests/processing \
               --ignore=tests/raw \
-              -n 2 --cov=litdata --durations=0 --timeout=120 --capture=no --verbose
+              -n 2 --dist=loadgroup --cov=litdata --durations=0 --timeout=120 --capture=no --verbose
 
       - name: Run processing tests sequentially
         run: |

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -642,6 +642,7 @@ class ParquetLoader(BaseItemLoader):
         self._df: dict[int, Any] = {}
         self._chunk_row_groups: dict[int, Any] = {}
         self._chunk_row_group_item_read_count: dict[int, Any] = {}
+        self._chunk_row_group_offsets: dict[int, list[int]] = {}
 
     def generate_intervals(self) -> list[Interval]:
         intervals = []
@@ -712,18 +713,28 @@ class ParquetLoader(BaseItemLoader):
         Returns:
             Any: The dataframe row corresponding to the specified index.
         """
+        import bisect
+
         import polars as pl
         import pyarrow.parquet as pq
 
         # Load the Parquet file metadata if not already loaded
         if chunk_index not in self._df:
-            self._df[chunk_index] = pq.ParquetFile(chunk_filepath)
+            parquet_file = pq.ParquetFile(chunk_filepath)
+            self._df[chunk_index] = parquet_file
+            # Precompute cumulative row offsets as a prefix-sum so lookup works for row groups of any size.
+            offsets = [0]
+            num_row_groups = parquet_file.metadata.num_row_groups
+            for i in range(num_row_groups):
+                num_rows = parquet_file.metadata.row_group(i).num_rows
+                offsets.append(offsets[-1] + num_rows)
+            self._chunk_row_group_offsets[chunk_index] = offsets
 
-        # Determine the row group and the row index within the row group
-        parquet_file = self._df[chunk_index]
-        num_rows_per_row_group = parquet_file.metadata.row_group(0).num_rows
-        row_group_index = row_index // num_rows_per_row_group
-        row_index_within_group = row_index % num_rows_per_row_group
+        # Locate the row group containing row_index and the offset inside it.
+        offsets = self._chunk_row_group_offsets[chunk_index]
+        row_group_index = bisect.bisect_right(offsets, row_index) - 1
+        row_index_within_group = row_index - offsets[row_group_index]
+        row_group_size = offsets[row_group_index + 1] - offsets[row_group_index]
 
         # Check if the row group is already loaded
         if chunk_index in self._chunk_row_groups and row_group_index in self._chunk_row_groups[chunk_index]:
@@ -746,7 +757,7 @@ class ParquetLoader(BaseItemLoader):
 
         # Check if the row group has been fully read and release memory if necessary
         read_count = self._chunk_row_group_item_read_count[chunk_index][row_group_index]
-        if read_count >= num_rows_per_row_group:
+        if read_count >= row_group_size:
             # Release memory for the fully read row group
             del self._chunk_row_groups[chunk_index][row_group_index]
             del self._chunk_row_group_item_read_count[chunk_index][row_group_index]
@@ -797,6 +808,8 @@ class ParquetLoader(BaseItemLoader):
 
         if chunk_index in self._chunk_row_group_item_read_count:
             del self._chunk_row_group_item_read_count[chunk_index]
+        if chunk_index in self._chunk_row_group_offsets:
+            del self._chunk_row_group_offsets[chunk_index]
         if os.path.exists(chunk_filepath):
             os.remove(chunk_filepath)
         logger.debug(
@@ -819,6 +832,9 @@ class ParquetLoader(BaseItemLoader):
 
         if chunk_index in self._chunk_row_group_item_read_count:
             del self._chunk_row_group_item_read_count[chunk_index]
+
+        if chunk_index in self._chunk_row_group_offsets:
+            del self._chunk_row_group_offsets[chunk_index]
 
     def encode_data(self, data: list[bytes], sizes: list[int], flattened: list[Any]) -> Any:
         pass

--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -326,7 +326,12 @@ def get_parquet_indexer_cls(
 
     obj = parse.urlparse(dir_path)
 
-    if obj.scheme in ("local", ""):
+    # On Windows, paths like "C:\\Users\\..." parse with scheme='c'. A single-letter
+    # scheme is never a valid URI scheme (RFC 3986 requires >=2 chars) so treat it
+    # as a Windows drive letter and dispatch to LocalParquetDir.
+    is_windows_drive = len(obj.scheme) == 1 and obj.scheme.isalpha()
+
+    if obj.scheme in ("local", "") or is_windows_drive:
         return LocalParquetDir(*args)
     if obj.scheme in ("gs", "s3"):
         return CloudParquetDir(*args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,12 +162,15 @@ def _thread_police():
             raise AssertionError(f"Test left zombie thread: {thread}")
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(items):
     """Force tests sharing the global default cache dir onto the same xdist worker.
 
     Why: ``clean_pq_index_cache`` shutil.rmtree's ``~/.lightning/chunks`` on setup/teardown.
     Under ``pytest -n>1`` two such tests on different workers race, deleting each other's
-    chunks mid-iteration. Requires the runner to pass ``--dist=loadgroup``.
+    chunks mid-iteration. Requires the runner to pass ``--dist=loadgroup``. Must run with
+    ``tryfirst=True`` so the marker is in place before xdist's own hook reads it and
+    appends the ``@group`` nodeid suffix that LoadGroupScheduling uses for routing.
     """
     for item in items:
         if "clean_pq_index_cache" in getattr(item, "fixturenames", ()):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,6 +162,18 @@ def _thread_police():
             raise AssertionError(f"Test left zombie thread: {thread}")
 
 
+def pytest_collection_modifyitems(items):
+    """Force tests sharing the global default cache dir onto the same xdist worker.
+
+    Why: ``clean_pq_index_cache`` shutil.rmtree's ``~/.lightning/chunks`` on setup/teardown.
+    Under ``pytest -n>1`` two such tests on different workers race, deleting each other's
+    chunks mid-iteration. Requires the runner to pass ``--dist=loadgroup``.
+    """
+    for item in items:
+        if "clean_pq_index_cache" in getattr(item, "fixturenames", ()):
+            item.add_marker(pytest.mark.xdist_group("hf_default_cache"))
+
+
 # ==== fixtures for parquet ====
 @pytest.fixture
 def pq_data():

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -505,8 +505,10 @@ def getter(index: int):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="too slow")
 @pytest.mark.parametrize("num_workers", [1, 2])
-def test_dataloader_with_align_chunking(tmp_path, num_workers):
+def test_dataloader_with_align_chunking(tmp_path, num_workers, monkeypatch):
     output_dir = tmp_path / f"output_workers_{num_workers}"
+    monkeypatch.setenv("DATA_OPTIMIZER_CACHE_FOLDER", str(tmp_path / "chunks"))
+    monkeypatch.setenv("DATA_OPTIMIZER_DATA_CACHE_FOLDER", str(tmp_path / "data"))
 
     optimize(
         fn=getter,

--- a/tests/streaming/test_dataset.py
+++ b/tests/streaming/test_dataset.py
@@ -116,8 +116,11 @@ def test_optimize_dataset(
     chunk_bytes,
     chunk_size,
     tmpdir,
+    monkeypatch,
 ):
     data_dir = str(tmpdir / "optimized")
+    monkeypatch.setenv("DATA_OPTIMIZER_CACHE_FOLDER", str(tmpdir / "chunks"))
+    monkeypatch.setenv("DATA_OPTIMIZER_DATA_CACHE_FOLDER", str(tmpdir / "data"))
 
     optimize(
         fn=_simple_optimize_fn,

--- a/tests/streaming/test_item_loader.py
+++ b/tests/streaming/test_item_loader.py
@@ -7,7 +7,8 @@ import torch
 from litdata.constants import _NUMPY_DTYPES_MAPPING, _TORCH_DTYPES_MAPPING
 from litdata.streaming import Cache, item_loader
 from litdata.streaming.dataset import StreamingDataset
-from litdata.streaming.item_loader import PyTreeLoader, TokensLoader
+from litdata.streaming.item_loader import ParquetLoader, PyTreeLoader, TokensLoader
+from litdata.streaming.writer import index_parquet_dataset
 
 
 def test_serializer_setup():
@@ -89,3 +90,118 @@ def test_force_download(monkeypatch, tmpdir):
 
     with pytest.raises(Exception, match="worked"):
         loader.load_item_from_chunk(0, 0, "chunk_filepath", 0, 1)
+
+
+def _write_parquet_with_row_groups(path, row_group_values):
+    """Write a parquet file where each element of row_group_values becomes its own row group."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    schema = pa.schema([("col", pa.int64())])
+    with pq.ParquetWriter(path, schema) as writer:
+        for values in row_group_values:
+            writer.write_table(pa.table({"col": list(values)}, schema=schema))
+
+
+@pytest.mark.parametrize(
+    "row_group_sizes",
+    [
+        [10, 5, 5],  # regression: uneven groups, shrinking
+        [3, 7, 2, 8],  # uneven groups, varying
+        [20],  # single group
+        [1, 1, 1, 1, 1],  # many size-1 groups
+        [5, 5, 5],  # uniform control case
+    ],
+)
+@pytest.mark.parametrize("low_memory", [True, False])
+def test_parquet_loader_row_group_sizes(tmp_path, row_group_sizes, low_memory):
+    """ParquetLoader must correctly read every row regardless of row-group layout."""
+    parquet_dir = tmp_path / "pq"
+    parquet_dir.mkdir()
+
+    row_group_values = []
+    expected = []
+
+    for value, size in enumerate(row_group_sizes):
+        row_group_values.append([value] * size)
+        expected.extend([value] * size)
+        value += 1
+    _write_parquet_with_row_groups(parquet_dir / "data.parquet", row_group_values)
+
+    index_parquet_dataset(str(parquet_dir))
+    dataset = StreamingDataset(str(parquet_dir), item_loader=ParquetLoader(low_memory=low_memory))
+
+    assert len(dataset) == sum(row_group_sizes)
+    actual = [dataset[i]["col"] for i in range(len(dataset))]
+    assert actual == expected
+
+
+@pytest.mark.parametrize("low_memory", [True, False])
+def test_parquet_loader_random_access(tmp_path, low_memory):
+    """Out-of-order access must return the right row for each index."""
+    import random
+
+    parquet_dir = tmp_path / "pq"
+    parquet_dir.mkdir()
+
+    row_group_sizes = [10, 5, 5]
+    row_group_values = []
+    expected = []
+
+    for value, size in enumerate(row_group_sizes):
+        row_group_values.append([value] * size)
+        expected.extend([value] * size)
+
+    _write_parquet_with_row_groups(parquet_dir / "data.parquet", row_group_values)
+
+    index_parquet_dataset(str(parquet_dir))
+    dataset = StreamingDataset(str(parquet_dir), item_loader=ParquetLoader(low_memory=low_memory))
+
+    indices = list(range(len(dataset)))
+    random.Random(0).shuffle(indices)
+    for i in indices:
+        assert dataset[i]["col"] == expected[i]
+
+
+def test_parquet_loader_row_group_boundaries(tmp_path):
+    """First and last row of each group (the modulo edges in the old implementation)."""
+    parquet_dir = tmp_path / "pq"
+    parquet_dir.mkdir()
+
+    row_group_sizes = [10, 5, 5]
+    _write_parquet_with_row_groups(
+        parquet_dir / "data.parquet",
+        [[v] * s for v, s in enumerate(row_group_sizes)],
+    )
+
+    index_parquet_dataset(str(parquet_dir))
+    dataset = StreamingDataset(str(parquet_dir), item_loader=ParquetLoader(low_memory=True))
+
+    boundaries = [0, 9, 10, 14, 15, 19]
+    expected = [0, 0, 1, 1, 2, 2]
+    for idx, exp in zip(boundaries, expected):
+        assert dataset[idx]["col"] == exp
+
+
+def test_parquet_loader_cache_eviction_with_uneven_groups(tmp_path):
+    """After fully reading a row group, it must be evicted from the in-memory cache."""
+    parquet_dir = tmp_path / "pq"
+    parquet_dir.mkdir()
+
+    row_group_sizes = [10, 5, 5]
+    _write_parquet_with_row_groups(
+        parquet_dir / "data.parquet",
+        [[v] * s for v, s in enumerate(row_group_sizes)],
+    )
+
+    index_parquet_dataset(str(parquet_dir))
+    loader = ParquetLoader(low_memory=True)
+    dataset = StreamingDataset(str(parquet_dir), item_loader=loader)
+
+    # Iterate through the whole dataset sequentially.
+    for i in range(len(dataset)):
+        dataset[i]
+
+    # After a sequential pass every row group in the chunk should have been evicted.
+    for chunk_index, groups in loader._chunk_row_groups.items():
+        assert groups == {}, f"chunk {chunk_index} still holds row groups: {list(groups)}"

--- a/tests/streaming/test_item_loader.py
+++ b/tests/streaming/test_item_loader.py
@@ -136,33 +136,6 @@ def test_parquet_loader_row_group_sizes(tmp_path, row_group_sizes, low_memory):
     assert actual == expected
 
 
-@pytest.mark.parametrize("low_memory", [True, False])
-def test_parquet_loader_random_access(tmp_path, low_memory):
-    """Out-of-order access must return the right row for each index."""
-    import random
-
-    parquet_dir = tmp_path / "pq"
-    parquet_dir.mkdir()
-
-    row_group_sizes = [10, 5, 5]
-    row_group_values = []
-    expected = []
-
-    for value, size in enumerate(row_group_sizes):
-        row_group_values.append([value] * size)
-        expected.extend([value] * size)
-
-    _write_parquet_with_row_groups(parquet_dir / "data.parquet", row_group_values)
-
-    index_parquet_dataset(str(parquet_dir))
-    dataset = StreamingDataset(str(parquet_dir), item_loader=ParquetLoader(low_memory=low_memory))
-
-    indices = list(range(len(dataset)))
-    random.Random(0).shuffle(indices)
-    for i in indices:
-        assert dataset[i]["col"] == expected[i]
-
-
 def test_parquet_loader_row_group_boundaries(tmp_path):
     """First and last row of each group (the modulo edges in the old implementation)."""
     parquet_dir = tmp_path / "pq"


### PR DESCRIPTION


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes https://github.com/Lightning-AI/litData/issues/809.

This replaces the uniform-size arithmetic with a per-chunk prefix-sum of row-group sizes, computed once when the ParquetFile is first opened, then use `bisect.bisect_right(offsets, row_index) - 1` to locate the group and `row_index - offsets[group]` for the offset inside it. 

The same `num_rows_per_row_group` value is also used in the cache-eviction check at  https://github.com/Lightning-AI/litData/blob/1fdfad72d92145305d2272483ef0be6234944cac/src/litdata/streaming/item_loader.py#L749. 

But that check needs the actual size of the current group `(offsets[g+1] - offsets[g])`, otherwise with uneven groups memory either leaks (never hits threshold) or is freed too early (forcing re-reads).

