### PR TITLE
chore: pin GitHub Actions to verified commit SHAs

### DIFF
--- a/.github/workflows/ci-benchmark.yml
+++ b/.github/workflows/ci-benchmark.yml
@@ -23,10 +23,10 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Extract make args
         id: extract
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fullComment = context.payload.comment.body;
@@ -36,7 +36,7 @@ jobs:
 
       - name: Reply to PR comment and save ID
         id: comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -84,7 +84,7 @@ jobs:
           LIGHTNING_API_KEY: ${{ secrets.LIGHTNING_API_KEY }}
 
       - name: Update the same comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COMMENT_ID: ${{ steps.comment.outputs.comment_id }}
           USERNAME: ${{ steps.comment.outputs.username }}

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -12,17 +12,17 @@ concurrency:
 
 jobs:
   check-typing:
-    uses: Lightning-AI/utilities/.github/workflows/check-typing.yml@main
+    uses: Lightning-AI/utilities/.github/workflows/check-typing.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
       actions-ref: main
 
   check-schema:
-    uses: Lightning-AI/utilities/.github/workflows/check-schema.yml@main
+    uses: Lightning-AI/utilities/.github/workflows/check-schema.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
       azure-dir: ""
 
   check-package:
-    uses: Lightning-AI/utilities/.github/workflows/check-package.yml@main
+    uses: Lightning-AI/utilities/.github/workflows/check-package.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
       actions-ref: main
       import-name: "litdata"
@@ -34,13 +34,13 @@ jobs:
         }
 
   check-docs:
-    uses: Lightning-AI/utilities/.github/workflows/check-docs.yml@main
+    uses: Lightning-AI/utilities/.github/workflows/check-docs.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
       requirements-file: "requirements/docs.txt"
       python-version: "3.10"
 
   check-md-links:
-    uses: Lightning-AI/utilities/.github/workflows/check-md-links.yml@main
+    uses: Lightning-AI/utilities/.github/workflows/check-md-links.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
       config-file: ".github/markdown-links-config.json"
       base-branch: "main"

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -43,9 +43,9 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install ffmpeg
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install uv and setup python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: ${{ matrix.python-version }}
@@ -78,7 +78,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cleanup
         run: |

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -23,15 +23,15 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6 # deploy needs git credentials
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 (deploy needs git credentials)
       - name: Download prepared docs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs-html-${{ github.sha }}
           path: docs/build/html
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.8.0
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         if: ${{ github.event_name == 'push' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build-docs:
-    uses: Lightning-AI/utilities/.github/workflows/check-docs.yml@main
+    uses: Lightning-AI/utilities/.github/workflows/check-docs.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
       requirements-file: "requirements/docs.txt"
       python-version: "3.10"

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -7,7 +7,7 @@ jobs:
   greeting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/first-interaction@v3
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-message: "Hi! thanks for your contribution!, great first issue!"

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
## What does this PR do?

Pins all GitHub Actions and reusable workflows to verified commit SHAs for supply chain security.

Follows the same pattern as [pytorch-lightning#21735](https://github.com/Lightning-AI/pytorch-lightning/pull/21735).

## Pinned references

| Action | Release | Commit SHA |
|--------|---------|------------|
| `actions/checkout` | [v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2) | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/setup-python` | [v6.2.0](https://github.com/actions/setup-python/releases/tag/v6.2.0) | `a309ff8b426b58ec0e2a45f0f869d46889d02405` |
| `actions/download-artifact` | [v8.0.1](https://github.com/actions/download-artifact/releases/tag/v8.0.1) | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |
| `actions/github-script` | [v9.0.0](https://github.com/actions/github-script/releases/tag/v9.0.0) | `3a2844b7e9c422d3c10d287c895573f7108da1b3` |
| `actions/first-interaction` | [v3.1.0](https://github.com/actions/first-interaction/releases/tag/v3.1.0) | `1c4688942c71f71d4f5502a26ea67c331730fa4d` |
| `astral-sh/setup-uv` | [v7.6.0](https://github.com/astral-sh/setup-uv/releases/tag/v7.6.0) | `37802adc94f370d6bfd71619e3f0bf239e1f3b78` |
| `codecov/codecov-action` | [v6.0.1](https://github.com/codecov/codecov-action/releases/tag/v6.0.1) | `e79a6962e0d4c0c17b229090214935d2e33f8354` |
| `pypa/gh-action-pypi-publish` | [v1.14.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.0) | `cef221092ed1bacb1cc03d23a2d87d1d172e277b` |
| `JamesIves/github-pages-deploy-action` | [v4.8.0](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.8.0) | `d92aa235d04922e8f08b40ce78cc5442fcfbfa2f` |
| `Lightning-AI/utilities` reusable workflows | [v0.15.3](https://github.com/Lightning-AI/utilities/releases/tag/v0.15.3) | `86fe1b20b4609835ba9e8c8739cd39707ba76868` |