### PR TITLE
ci: add 2-day package install cooldown (supply-chain guard)

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -32,6 +32,8 @@ jobs:
     timeout-minutes: 60
     env:
       UV_TORCH_BACKEND: "cpu"
+      # Supply-chain guard: skip PyPI releases newer than this. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+      UV_EXCLUDE_NEWER: "2 days"
 
     steps:
       # FFmpeg is required for Video Deserializer tests


### PR DESCRIPTION
## What does this PR do?

Adds a CI-only supply-chain guard: the resolver refuses any PyPI release published within the last **2 days**, so typosquats and malicious uploads that get yanked within ~24h never land in our CI environment.

Sets `UV_EXCLUDE_NEWER: "2 days"` on the uv-based `ci-testing` workflow (the only uv-based workflow in this repo). pip-based workflows are out of scope for now.

Follows the same pattern as [pytorch-lightning#21722](https://github.com/Lightning-AI/pytorch-lightning/pull/21722).

Ref: https://docs.astral.sh/uv/reference/settings/#exclude-newer