### PR TITLE
fix: natural sort worker index files in merge to preserve chunk order

### DIFF
--- a/src/litdata/streaming/writer.py
+++ b/src/litdata/streaming/writer.py
@@ -13,6 +13,7 @@
 
 import json
 import os
+import re
 import uuid
 import warnings
 from dataclasses import dataclass
@@ -499,7 +500,10 @@ class BinaryWriter:
             chunks_info.extend(existing_index["chunks"])
             config = existing_index["config"]
 
-        for index_filename in sorted(index_files):
+        def _natural_key(s: str) -> list:
+            return [int(t) if t.isdigit() else t for t in re.split(r"(\d+)", s)]
+
+        for index_filename in sorted(index_files, key=_natural_key):
             chunk_path = os.path.join(self._cache_dir, index_filename)
             with open(chunk_path) as f:
                 data = json.load(f)

--- a/tests/streaming/test_writer.py
+++ b/tests/streaming/test_writer.py
@@ -290,3 +290,36 @@ def test_writer_save_checkpoint(tmpdir):
     for file in os.listdir(os.path.join(cache_dir, ".checkpoints")):
         assert file.__contains__("checkpoint-0")
         assert file.endswith(".json")
+
+
+def test_merge_natural_sort_order_with_many_workers(tmpdir):
+    # With 11+ workers, index files are named 0.index.json ... 10.index.json.
+    # sorted() puts "10.index.json" before "2.index.json" alphabetically, making
+    # chunk-10-0.bin appear before chunk-2-0.bin in the merged index. Fixes #826.
+    config = {
+        "chunk_bytes": None,
+        "chunk_size": 1,
+        "compression": None,
+        "data_format": ["scalar"],
+        "data_spec": None,
+        "encryption": None,
+        "item_loader": "PyTreeLoader",
+    }
+    from litdata.constants import _INDEX_FILENAME
+
+    n_workers = 11
+    for rank in range(n_workers):
+        chunk = {"chunk_size": 1, "column_sizes": [4], "dim": None, "filename": f"chunk-{rank}-0.bin"}
+        with open(os.path.join(str(tmpdir), f"{rank}.{_INDEX_FILENAME}"), "w") as f:
+            json.dump({"chunks": [chunk], "config": config}, f, sort_keys=True)
+
+    writer = BinaryWriter(str(tmpdir), chunk_size=1)
+    writer._is_done = True
+    writer._rank = 0
+    writer._merge_no_wait()
+
+    with open(os.path.join(str(tmpdir), _INDEX_FILENAME)) as f:
+        data = json.load(f)
+
+    filenames = [c["filename"] for c in data["chunks"]]
+    assert filenames == [f"chunk-{i}-0.bin" for i in range(n_workers)]


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #826.
closes #829

When a dataset is optimized with 11 or more workers, each worker writes its own index file named `{rank}.index.json`. The `_merge_no_wait` function then merges them using `sorted(index_files)`, which applies lexicographic ordering. This places `10.index.json` before `2.index.json`, so `chunk-10-*.bin` ends up before `chunk-2-*.bin` in the merged `index.json`. With `shuffle=False`, `train_test_split` then reads items in this wrong order rather than the original creation order.

The fix replaces `sorted(index_files)` with a natural sort that compares embedded integers numerically, restoring the intended chunk order.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃