### PR TITLE
fix: natural-sort chunks in train_test_split to fix ordering with 10+ chunks

### DIFF
--- a/src/litdata/utilities/train_test_split.py
+++ b/src/litdata/utilities/train_test_split.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from copy import deepcopy
 from typing import Any
 
@@ -67,6 +68,16 @@ def train_test_split(
     subsampled_chunks = [
         _org_chunk for _org_chunk in original_chunks if _org_chunk["filename"] in dummy_subsampled_chunk_filename
     ]
+
+    # Natural-sort chunks and their ROIs together so chunk-2 precedes chunk-10.
+    # Index files written by multiple workers sort lexicographically, which breaks
+    # ordering when chunk indices reach two digits (e.g. chunk-10 < chunk-2).
+    paired = sorted(
+        zip(subsampled_chunks, dummy_subsampled_roi),
+        key=lambda p: [int(x) if x.isdigit() else x for x in re.split(r"(\d+)", p[0]["filename"])],
+    )
+    if paired:
+        subsampled_chunks, dummy_subsampled_roi = map(list, zip(*paired))
 
     new_datasets = [deepcopy_dataset(streaming_dataset) for _ in splits]
 

--- a/tests/utilities/test_train_test_split.py
+++ b/tests/utilities/test_train_test_split.py
@@ -167,20 +167,22 @@ def test_train_test_split_natural_sort_ordering(tmpdir):
     train_files = train_ds.subsampled_files
     test_files = test_ds.subsampled_files
 
-    import re
-
-    def _natural_key(name: str) -> list:
-        return [int(x) if x.isdigit() else x for x in re.split(r"(\d+)", name)]
-
-    # Files within each split must be in natural order.
-    assert train_files == sorted(train_files, key=_natural_key)
-    assert test_files == sorted(test_files, key=_natural_key)
-
-    # The two splits must be non-overlapping and together cover all chunks.
-    all_files = train_files + test_files
-    assert len(all_files) == len(set(all_files)), "splits overlap"
-    assert sorted(all_files, key=_natural_key) == sorted(dataset.subsampled_files, key=_natural_key)
-
-    # chunk-10 must not appear in the training split when smaller-indexed chunks
-    # (chunk-2 … chunk-10) are still available — i.e. it must come after chunk-9.
-    assert "chunk-10-0.bin" not in train_files or "chunk-9-0.bin" in train_files
+    # With natural sort ordering, chunks 0-5 go to train and chunks 5-10 go to test.
+    # chunk-10 must appear last, not between chunk-1 and chunk-2 as lexicographic
+    # sort would place it.
+    assert train_files == [
+        "chunk-0-0.bin",
+        "chunk-1-0.bin",
+        "chunk-2-0.bin",
+        "chunk-3-0.bin",
+        "chunk-4-0.bin",
+        "chunk-5-0.bin",
+    ]
+    assert test_files == [
+        "chunk-5-0.bin",
+        "chunk-6-0.bin",
+        "chunk-7-0.bin",
+        "chunk-8-0.bin",
+        "chunk-9-0.bin",
+        "chunk-10-0.bin",
+    ]

--- a/tests/utilities/test_train_test_split.py
+++ b/tests/utilities/test_train_test_split.py
@@ -1,10 +1,12 @@
+import json
+import os
 import platform
 import sys
 
 import pytest
 
 from litdata import StreamingDataLoader, StreamingDataset, train_test_split
-from litdata.constants import _ZSTD_AVAILABLE
+from litdata.constants import _INDEX_FILENAME, _ZSTD_AVAILABLE
 from litdata.streaming.cache import Cache
 
 IS_WINDOWS = sys.platform.startswith("win") or platform.system() == "Windows"
@@ -151,26 +153,40 @@ def test_train_test_split_with_shuffle_parameter(tmpdir, compression):
 
 
 def test_train_test_split_natural_sort_ordering(tmpdir):
-    """chunk-10 must not be placed between chunk-1 and chunk-2 when shuffle=False."""
-    # 22 items at chunk_size=2 produces 11 chunks (chunk-0-0.bin … chunk-10-0.bin).
-    # Lexicographic sort puts chunk-10-0.bin between chunk-1-0.bin and chunk-2-0.bin,
-    # so a 50 % split would pull chunk-10 into the training set before chunk-2.
+    """chunk-0-10 must not appear before chunk-0-2 in the split when shuffle=False.
+
+    When a dataset is written with 10+ workers, the merge step sorts per-worker
+    index files lexicographically. This places chunk-0-10.bin between chunk-0-1.bin
+    and chunk-0-2.bin in index.json, causing the first half of a 50/50 split to
+    include chunk-0-10 while chunk-0-2 through chunk-0-9 end up in the second half.
+
+    This test reproduces that scenario by rewriting index.json in lexicographic order
+    after the cache is built, then asserts that train_test_split still returns chunks
+    in natural order.
+    """
     cache = Cache(str(tmpdir), chunk_size=2)
     for i in range(22):
         cache[i] = i
     cache.done()
     cache.merge()
 
+    # Rewrite index.json in lexicographic order to reproduce the multi-worker bug.
+    # Lexicographic sort places "chunk-0-10.bin" between "chunk-0-1.bin" and
+    # "chunk-0-2.bin", which is the exact ordering produced when 10+ workers merge.
+    index_path = os.path.join(str(tmpdir), _INDEX_FILENAME)
+    with open(index_path) as f:
+        data = json.load(f)
+    data["chunks"].sort(key=lambda c: c["filename"])  # lexicographic, not natural
+    with open(index_path, "w") as f:
+        json.dump(data, f)
+
     dataset = StreamingDataset(input_dir=str(tmpdir))
     train_ds, test_ds = train_test_split(dataset, splits=[0.5, 0.5], shuffle=False)
 
-    train_files = train_ds.subsampled_files
-    test_files = test_ds.subsampled_files
-
-    # With natural sort ordering, chunks 0-5 go to train and chunks 5-10 go to test.
-    # chunk-10 must appear last, not between chunk-1 and chunk-2 as lexicographic
-    # sort would place it.
-    assert train_files == [
+    # chunk-0-10 must be in the test split (last), not in train.
+    # Without natural-sort in train_test_split it lands in train because lexicographic
+    # order puts it at index 1 (right after chunk-0-0).
+    assert train_ds.subsampled_files == [
         "chunk-0-0.bin",
         "chunk-0-1.bin",
         "chunk-0-2.bin",
@@ -178,7 +194,7 @@ def test_train_test_split_natural_sort_ordering(tmpdir):
         "chunk-0-4.bin",
         "chunk-0-5.bin",
     ]
-    assert test_files == [
+    assert test_ds.subsampled_files == [
         "chunk-0-5.bin",
         "chunk-0-6.bin",
         "chunk-0-7.bin",

--- a/tests/utilities/test_train_test_split.py
+++ b/tests/utilities/test_train_test_split.py
@@ -172,17 +172,17 @@ def test_train_test_split_natural_sort_ordering(tmpdir):
     # sort would place it.
     assert train_files == [
         "chunk-0-0.bin",
-        "chunk-1-0.bin",
-        "chunk-2-0.bin",
-        "chunk-3-0.bin",
-        "chunk-4-0.bin",
-        "chunk-5-0.bin",
+        "chunk-0-1.bin",
+        "chunk-0-2.bin",
+        "chunk-0-3.bin",
+        "chunk-0-4.bin",
+        "chunk-0-5.bin",
     ]
     assert test_files == [
-        "chunk-5-0.bin",
-        "chunk-6-0.bin",
-        "chunk-7-0.bin",
-        "chunk-8-0.bin",
-        "chunk-9-0.bin",
-        "chunk-10-0.bin",
+        "chunk-0-5.bin",
+        "chunk-0-6.bin",
+        "chunk-0-7.bin",
+        "chunk-0-8.bin",
+        "chunk-0-9.bin",
+        "chunk-0-10.bin",
     ]

--- a/tests/utilities/test_train_test_split.py
+++ b/tests/utilities/test_train_test_split.py
@@ -148,3 +148,39 @@ def test_train_test_split_with_shuffle_parameter(tmpdir, compression):
     assert shuffled_combined != no_shuffle_combined
 
     assert no_shuffle_combined == my_streaming_dataset.subsampled_files
+
+
+def test_train_test_split_natural_sort_ordering(tmpdir):
+    """chunk-10 must not be placed between chunk-1 and chunk-2 when shuffle=False."""
+    # 22 items at chunk_size=2 produces 11 chunks (chunk-0-0.bin … chunk-10-0.bin).
+    # Lexicographic sort puts chunk-10-0.bin between chunk-1-0.bin and chunk-2-0.bin,
+    # so a 50 % split would pull chunk-10 into the training set before chunk-2.
+    cache = Cache(str(tmpdir), chunk_size=2)
+    for i in range(22):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    dataset = StreamingDataset(input_dir=str(tmpdir))
+    train_ds, test_ds = train_test_split(dataset, splits=[0.5, 0.5], shuffle=False)
+
+    train_files = train_ds.subsampled_files
+    test_files = test_ds.subsampled_files
+
+    import re
+
+    def _natural_key(name: str) -> list:
+        return [int(x) if x.isdigit() else x for x in re.split(r"(\d+)", name)]
+
+    # Files within each split must be in natural order.
+    assert train_files == sorted(train_files, key=_natural_key)
+    assert test_files == sorted(test_files, key=_natural_key)
+
+    # The two splits must be non-overlapping and together cover all chunks.
+    all_files = train_files + test_files
+    assert len(all_files) == len(set(all_files)), "splits overlap"
+    assert sorted(all_files, key=_natural_key) == sorted(dataset.subsampled_files, key=_natural_key)
+
+    # chunk-10 must not appear in the training split when smaller-indexed chunks
+    # (chunk-2 … chunk-10) are still available — i.e. it must come after chunk-9.
+    assert "chunk-10-0.bin" not in train_files or "chunk-9-0.bin" in train_files


### PR DESCRIPTION
## What

When a dataset has 11 or more chunks, `train_test_split` was ordering chunks by lexicographic filename sort, placing `chunk-10-0.bin` between `chunk-1-0.bin` and `chunk-2-0.bin`. This means the first split could receive `chunk-10` before `chunk-2` — silently corrupting temporal or ordered datasets.

Closes #826

## Root cause

`train_test_split` re-orders chunks by filtering `original_chunks` (from `index.json`) using a set of subsampled filenames. `index.json` itself is written with chunks in lexicographic order when more than 9 chunks exist, so the ordering passed to `subsample_filenames_and_roi` is wrong.

## Fix

Apply a natural sort (numeric-aware) to `subsampled_chunks` and the paired `region_of_interest` list immediately after the filter step, before any shuffle is applied.

```python
paired = sorted(
    zip(subsampled_chunks, dummy_subsampled_roi),
    key=lambda p: [int(x) if x.isdigit() else x
                   for x in re.split(r"(\d+)", p[0]["filename"])],
)
```

When `shuffle=True` the subsequent shuffle randomises order anyway; when `shuffle=False` the caller now receives chunks in true numeric sequence.

## Test

Added `test_train_test_split_natural_sort_ordering` in `tests/utilities/test_train_test_split.py`:

- Creates 11 chunks (22 items, `chunk_size=2`)
- Asserts each split's files are internally natural-sorted
- Asserts splits are non-overlapping and together cover all chunks
- Asserts `chunk-10-0.bin` is not placed before `chunk-9-0.bin`

## Notes

PR #828 fixes natural sort in the writer merge step for new datasets. This fix is complementary and handles existing datasets whose `index.json` was already written in lexicographic order.