### PR TITLE
fix: don't force redownload chunks that have already completed or are still in progress

### DIFF
--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -302,6 +302,11 @@ class ChunksConfig:
 
         return local_chunkpath, begin, filesize_bytes
 
+    def download_filepath(self, chunk_index: int) -> str:
+        """The raw on-disk path that the chunk is downloaded to before any decompression."""
+        assert self._chunks is not None
+        return os.path.join(self._cache_dir, self._chunks[chunk_index]["filename"])
+
     def _get_chunk_index_from_filename(self, chunk_filename: str) -> int:
         """Retrieves the associated chunk_index for a given chunk filename."""
         assert self._chunks is not None

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -243,8 +243,7 @@ class PrepareChunksThread(Thread):
             return
 
         chunk_filepath, _, filesize_bytes = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
-        download_filename = self._config._chunks[chunk_index]["filename"]
-        download_lock_path = os.path.join(self._config._cache_dir, download_filename) + ".lock"
+        download_lock_path = self._config.download_filepath(chunk_index) + ".lock"
         try:
             with FileLock(download_lock_path, timeout=0):
                 # The chunk may have been fully downloaded by the time this

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -242,22 +242,29 @@ class PrepareChunksThread(Thread):
         if chunk_index is None:
             return
 
-        # The chunk may have been fully downloaded by the time this request was
-        # processed, so double check that it still needs downloading before we
-        # delete it.
         chunk_filepath, _, filesize_bytes = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
-        if os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes:
+        download_filename = self._config._chunks[chunk_index]["filename"]
+        download_lock_path = os.path.join(self._config._cache_dir, download_filename) + ".lock"
+        try:
+            with FileLock(download_lock_path, timeout=0):
+                # The chunk may have been fully downloaded by the time this
+                # request was processed, so double check that it still needs
+                # downloading before we delete it.
+                if os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes:
+                    return
+
+                # force apply deletion before redownload
+                self._apply_delete(chunk_index, skip_lock=True)
+                if _DEBUG:
+                    print(
+                        f"[Reader] Requested force download for {chunk_filepath} "
+                        f"by {self._rank} at {datetime.now().isoformat()}"
+                    )
+
+            self._config.download_chunk_from_index(chunk_index, skip_lock=True)
+        except Timeout:
+            # Another worker is actively downloading this chunk. Defer to them.
             return
-
-        # force apply deletion before redownload
-        self._apply_delete(chunk_index, skip_lock=True)
-        if _DEBUG:
-            print(
-                f"[Reader] Requested force download for {chunk_filepath} "
-                f"by {self._rank} at {datetime.now().isoformat()}"
-            )
-
-        self._config.download_chunk_from_index(chunk_index, skip_lock=True)
 
         # Preload item if possible to gain some time but only
         # if this is one of the pre-downloaded chunk

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -239,25 +239,33 @@ class PrepareChunksThread(Thread):
 
     def _force_download(self) -> None:
         chunk_index = _get_from_queue(self._force_download_queue)
-        if chunk_index is not None:
-            # force apply deletion before redownload
-            self._apply_delete(chunk_index, skip_lock=True)
-            if _DEBUG:
-                chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
-                print(
-                    f"[Reader] Requested force download for {chunk_filepath} "
-                    f"by {self._rank} at {datetime.now().isoformat()}"
-                )
+        if chunk_index is None:
+            return
 
-            self._config.download_chunk_from_index(chunk_index, skip_lock=True)
+        # The chunk may have been fully downloaded by the time this request was
+        # processed, so double check that it still needs downloading before we
+        # delete it.
+        chunk_filepath, _, filesize_bytes = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
+        if os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes:
+            return
 
-            # Preload item if possible to gain some time but only
-            # if this is one of the pre-downloaded chunk
-            if self._pre_download_counter > 0:
-                self._pre_load_chunk(chunk_index)
+        # force apply deletion before redownload
+        self._apply_delete(chunk_index, skip_lock=True)
+        if _DEBUG:
+            print(
+                f"[Reader] Requested force download for {chunk_filepath} "
+                f"by {self._rank} at {datetime.now().isoformat()}"
+            )
 
-            # Avoid downloading too many chunks in advance at the risk of over using the disk space
-            self._pre_download_counter += 1
+        self._config.download_chunk_from_index(chunk_index, skip_lock=True)
+
+        # Preload item if possible to gain some time but only
+        # if this is one of the pre-downloaded chunk
+        if self._pre_download_counter > 0:
+            self._pre_load_chunk(chunk_index)
+
+        # Avoid downloading too many chunks in advance at the risk of over using the disk space
+        self._pre_download_counter += 1
 
     def run(self) -> None:
         while True:

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -287,7 +287,7 @@ def test_force_download_defers_when_download_lock_held(tmpdir):
 
     # Hold the downloader's lock from a separate thread to simulate another worker
     # actively downloading the chunk.
-    download_lock_path = os.path.join(cache_dir, thread._config._chunks[0]["filename"]) + ".lock"
+    download_lock_path = thread._config.download_filepath(0) + ".lock"
     holder_acquired = Event()
     holder_release = Event()
 

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+from threading import Event, Thread
 from time import sleep
 from unittest import mock
 
@@ -245,6 +246,71 @@ def test_force_download_skips_complete_chunk(tmpdir):
 
     assert os.path.exists(chunk_filepath), "force-download deleted a fully-downloaded chunk"
     assert os.stat(chunk_filepath).st_ino == pre_inode, "force-download replaced a complete chunk file"
+
+
+def test_force_download_defers_when_download_lock_held(tmpdir):
+    """Force-download must defer when another worker is actively downloading the chunk.
+
+    Probes `<compressed_chunk>.lock` with timeout=0; if held, another worker is mid-download
+    and force_download should bail out rather than racing into a destructive delete.
+    """
+    from filelock import FileLock
+
+    cache_dir = os.path.join(tmpdir, "cache_dir")
+    remote_dir = os.path.join(tmpdir, "remote_dir")
+    os.makedirs(cache_dir, exist_ok=True)
+
+    cache = Cache(input_dir=Dir(path=cache_dir, url=remote_dir), chunk_size=2, max_cache_size=28020)
+    for i in range(10):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    shutil.copytree(cache_dir, remote_dir, dirs_exist_ok=True)
+    cache._reader._try_load_config()
+
+    thread = PrepareChunksThread(
+        cache._reader.config,
+        item_loader=PyTreeLoader(),
+        distributed_env=_DistributedEnv(1, 1, 1),
+        max_pre_download=2,
+        max_cache_size=28020,
+    )
+
+    chunk_filepath, _, filesize_bytes = thread._config[ChunkedIndex(index=-1, chunk_index=0)]
+    # Truncate the chunk to look partial — without the lock-held probe, _force_download
+    # would happily delete and redownload this.
+    with open(chunk_filepath, "r+b") as f:
+        f.truncate(filesize_bytes // 2)
+    assert os.stat(chunk_filepath).st_size < filesize_bytes
+    pre_inode = os.stat(chunk_filepath).st_ino
+
+    # Hold the downloader's lock from a separate thread to simulate another worker
+    # actively downloading the chunk.
+    download_lock_path = os.path.join(cache_dir, thread._config._chunks[0]["filename"]) + ".lock"
+    holder_acquired = Event()
+    holder_release = Event()
+
+    def hold_lock():
+        with FileLock(download_lock_path, timeout=5):
+            holder_acquired.set()
+            holder_release.wait(timeout=5)
+
+    holder = Thread(target=hold_lock, daemon=True)
+    holder.start()
+    assert holder_acquired.wait(timeout=5), "test holder thread failed to acquire the lock"
+
+    try:
+        thread._force_download_queue.put(0)
+        thread._force_download()
+
+        # Lock was held => we should have deferred, leaving the (partial) file untouched.
+        assert os.path.exists(chunk_filepath), "force-download deleted the chunk while another worker held the download lock"
+        assert os.stat(chunk_filepath).st_ino == pre_inode, "force-download replaced the chunk while another worker held the download lock"
+        assert os.stat(chunk_filepath).st_size < filesize_bytes, "force-download redownloaded the chunk while another worker held the download lock"
+    finally:
+        holder_release.set()
+        holder.join(timeout=5)
 
 
 @pytest.mark.parametrize("on_demand_bytes", [True, False])

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -305,9 +305,15 @@ def test_force_download_defers_when_download_lock_held(tmpdir):
         thread._force_download()
 
         # Lock was held => we should have deferred, leaving the (partial) file untouched.
-        assert os.path.exists(chunk_filepath), "force-download deleted the chunk while another worker held the download lock"
-        assert os.stat(chunk_filepath).st_ino == pre_inode, "force-download replaced the chunk while another worker held the download lock"
-        assert os.stat(chunk_filepath).st_size < filesize_bytes, "force-download redownloaded the chunk while another worker held the download lock"
+        assert os.path.exists(chunk_filepath), (
+            "force-download deleted the chunk while another worker held the download lock"
+        )
+        assert os.stat(chunk_filepath).st_ino == pre_inode, (
+            "force-download replaced the chunk while another worker held the download lock"
+        )
+        assert os.stat(chunk_filepath).st_size < filesize_bytes, (
+            "force-download redownloaded the chunk while another worker held the download lock"
+        )
     finally:
         holder_release.set()
         holder.join(timeout=5)

--- a/tests/streaming/test_reader.py
+++ b/tests/streaming/test_reader.py
@@ -208,6 +208,45 @@ def test_prepare_chunks_thread_eviction(tmpdir, monkeypatch):
     assert thread._has_exited
 
 
+def test_force_download_skips_complete_chunk(tmpdir):
+    """A queued force-download must not delete a chunk that is already complete on disk."""
+    cache_dir = os.path.join(tmpdir, "cache_dir")
+    remote_dir = os.path.join(tmpdir, "remote_dir")
+    os.makedirs(cache_dir, exist_ok=True)
+
+    cache = Cache(input_dir=Dir(path=cache_dir, url=remote_dir), chunk_size=2, max_cache_size=28020)
+    for i in range(10):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    shutil.copytree(cache_dir, remote_dir, dirs_exist_ok=True)
+
+    cache._reader._try_load_config()
+
+    thread = PrepareChunksThread(
+        cache._reader.config,
+        item_loader=PyTreeLoader(),
+        distributed_env=_DistributedEnv(1, 1, 1),
+        max_pre_download=2,
+        max_cache_size=28020,
+    )
+
+    chunk_filepath, _, filesize_bytes = thread._config[ChunkedIndex(index=-1, chunk_index=0)]
+    assert os.path.exists(chunk_filepath)
+    assert os.stat(chunk_filepath).st_size >= filesize_bytes
+    pre_inode = os.stat(chunk_filepath).st_ino
+
+    # Item loader timed out waiting and queued a force-download. The chunk is
+    # actually already on disk by the time the prepare-chunks thread services
+    # the queue.
+    thread._force_download_queue.put(0)
+    thread._force_download()
+
+    assert os.path.exists(chunk_filepath), "force-download deleted a fully-downloaded chunk"
+    assert os.stat(chunk_filepath).st_ino == pre_inode, "force-download replaced a complete chunk file"
+
+
 @pytest.mark.parametrize("on_demand_bytes", [True, False])
 def test_reader_read_bytes(tmpdir, monkeypatch, on_demand_bytes):
     monkeypatch.setattr(reader, "_LONG_DEFAULT_TIMEOUT", 0.1)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This fixes two separate issues:

1. `force_download` can delete a chunk that had successfully finished downloading. This can happen because `force_download` unconditionally deletes the chunk on disk, even if the chunk had finished downloading in between when `force_download` was enqueued and when it ran. This is fixed in https://github.com/Lightning-AI/litData/commit/e0f46b44cc0b4175570fe6d179cb8ca7b2a44e2a by double-checking the downloaded filesize before deleting it.

1. `force_download` can be queued multiple times across different workers, so we can end up deleting and attempting to redownload a chunk multiple times, even if a download is already in progress. This is fixed in https://github.com/Lightning-AI/litData/commit/b36f21b05346e26b4a6b0040a62ca18a5d02b81b by attempting to acquire the chunk `.lock` file first, which is otherwise only held by the downloader, meaning that `force_download` becomes a no-op if the chunk is currently being downloaded.