### PR TITLE
feat: add deadlock guardrail check for `ParquetLoader` with `fork context`

### DIFF
--- a/src/litdata/streaming/dataloader.py
+++ b/src/litdata/streaming/dataloader.py
@@ -631,7 +631,7 @@ class StreamingDataLoader(DataLoader):
                 "The `ParquetLoader` uses Polars, which is not compatible with the `fork` multiprocessing context "
                 "used by PyTorch's DataLoader on Linux. Using `fork` will cause deadlocks due to Polars' "
                 "internal thread pool. Please pass `multiprocessing_context='spawn'` (or 'forkserver') to "
-                "`StreamingDataLoader`."
+                "`StreamingDataLoader`. Check thread: https://github.com/Lightning-AI/litData/issues/823"
             )
 
         if not isinstance(dataset, (StreamingDataset, _BaseStreamingDatasetWrapper)):

--- a/src/litdata/streaming/dataloader.py
+++ b/src/litdata/streaming/dataloader.py
@@ -519,6 +519,43 @@ class StreamingDataLoaderCollateFn:
         return self.collate_fn(items)
 
 
+def _is_fork_context(multiprocessing_context: Any) -> bool:
+    import multiprocessing as mp
+
+    if multiprocessing_context is None:
+        try:
+            return mp.get_start_method(allow_none=False) == "fork"
+        except Exception:
+            return False
+
+    if isinstance(multiprocessing_context, str):
+        return multiprocessing_context == "fork"
+
+    if hasattr(multiprocessing_context, "get_start_method"):
+        try:
+            return multiprocessing_context.get_start_method() == "fork"
+        except Exception:
+            return False
+
+    if hasattr(multiprocessing_context, "start_method"):
+        return multiprocessing_context.start_method == "fork"
+
+    return False
+
+
+def _has_parquet_loader(dataset: Any) -> bool:
+    from litdata.streaming.dataset import StreamingDataset
+    from litdata.streaming.item_loader import ParquetLoader
+
+    if isinstance(dataset, StreamingDataset):
+        return isinstance(dataset.item_loader, ParquetLoader)
+
+    if hasattr(dataset, "_datasets") and isinstance(dataset._datasets, (list, tuple)):
+        return any(_has_parquet_loader(d) for d in dataset._datasets)
+
+    return False
+
+
 class StreamingDataLoader(DataLoader):
     r"""The StreamingDataLoader combines a dataset and a sampler, and provides an iterable over the given dataset.
 
@@ -589,6 +626,14 @@ class StreamingDataLoader(DataLoader):
         collate_fn: Callable | None = None,
         **kwargs: Any,
     ) -> None:  # pyright: ignore
+        if num_workers > 0 and _is_fork_context(kwargs.get("multiprocessing_context")) and _has_parquet_loader(dataset):
+            raise RuntimeError(
+                "The `ParquetLoader` uses Polars, which is not compatible with the `fork` multiprocessing context "
+                "used by PyTorch's DataLoader on Linux. Using `fork` will cause deadlocks due to Polars' "
+                "internal thread pool. Please pass `multiprocessing_context='spawn'` (or 'forkserver') to "
+                "`StreamingDataLoader`."
+            )
+
         if not isinstance(dataset, (StreamingDataset, _BaseStreamingDatasetWrapper)):
             raise RuntimeError(
                 "The provided dataset should be either an instance of StreamingDataset, CombinedStreamingDataset or "

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -531,3 +531,50 @@ def test_dataloader_with_align_chunking(tmp_path, num_workers, monkeypatch):
         assert max_element_in_batch - min_element_in_batch < 64, (
             f"Batch {i} contains elements from multiple chunks: min {min_element_in_batch}, max {max_element_in_batch}"
         )
+
+
+class DummyStreamingDataset(StreamingDataset):
+    def __init__(self, item_loader):
+        self.item_loader = item_loader
+        self.shuffle = False
+        self.drop_last = False
+        self.batch_size = 1
+        self.num_workers = 1
+
+
+class DummyCombinedDataset(TestCombinedStreamingDataset):
+    def __init__(self, datasets):
+        self._datasets = datasets
+        self.batch_size = 1
+        self.num_workers = 1
+
+
+def test_dataloader_fork_parquet_loader_deadlock_guard():
+    from litdata.streaming.item_loader import ParquetLoader, PyTreeLoader
+
+    # Create dummy dataset using ParquetLoader
+    dataset_with_parquet = DummyStreamingDataset(item_loader=ParquetLoader())
+    dataset_with_pytree = DummyStreamingDataset(item_loader=PyTreeLoader())
+
+    # 1. No workers should not raise any error, regardless of loader
+    StreamingDataLoader(dataset_with_parquet, num_workers=0)
+    StreamingDataLoader(dataset_with_pytree, num_workers=0)
+
+    # 2. PyTreeLoader with fork and num_workers > 0 should not raise any error
+    StreamingDataLoader(dataset_with_pytree, num_workers=2, multiprocessing_context="fork")
+
+    # 3. ParquetLoader with spawn / forkserver context and num_workers > 0 should not raise any error
+    StreamingDataLoader(dataset_with_parquet, num_workers=2, multiprocessing_context="spawn")
+    StreamingDataLoader(dataset_with_parquet, num_workers=2, multiprocessing_context="forkserver")
+
+    # 4. ParquetLoader with fork context and num_workers > 0 must raise RuntimeError
+    with pytest.raises(RuntimeError, match="The `ParquetLoader` uses Polars, which is not compatible with the `fork`"):
+        StreamingDataLoader(dataset_with_parquet, num_workers=2, multiprocessing_context="fork")
+
+    # 5. Combined dataset wrapping ParquetLoader must also raise RuntimeError with fork context
+    combined_parquet = DummyCombinedDataset([dataset_with_parquet, dataset_with_pytree])
+    with pytest.raises(RuntimeError, match="The `ParquetLoader` uses Polars, which is not compatible with the `fork`"):
+        StreamingDataLoader(combined_parquet, num_workers=2, multiprocessing_context="fork")
+
+    combined_pytree = DummyCombinedDataset([dataset_with_pytree, dataset_with_pytree])
+    StreamingDataLoader(combined_pytree, num_workers=2, multiprocessing_context="fork")

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -549,6 +549,7 @@ class DummyCombinedDataset(TestCombinedStreamingDataset):
         self.num_workers = 1
 
 
+@pytest.mark.skipif(condition=sys.platform == "win32", reason="Not testing multiprocessing on windows")
 def test_dataloader_fork_parquet_loader_deadlock_guard():
     from litdata.streaming.item_loader import ParquetLoader, PyTreeLoader
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #823.

Adds an early `RuntimeError` guard in `StreamingDataLoader.__init__` that detects the `fork` + `ParquetLoader` combination before any workers are spawned, instead of silently hanging for minutes.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
