### PR TITLE
fix: forward storage_options as kwargs in CloudParquetDir

### DIFF
--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -150,7 +150,7 @@ class CloudParquetDir(ParquetDir):
         for provider in _CLOUD_PROVIDER:
             if self.dir.url.startswith(provider):
                 # Initialize the cloud filesystem
-                self.fs = fsspec.filesystem(provider, *self.storage_options)
+                self.fs = fsspec.filesystem(provider, **self.storage_options)
                 print(f"using provider: {provider}")
                 break
 

--- a/tests/streaming/test_parquet.py
+++ b/tests/streaming/test_parquet.py
@@ -129,6 +129,20 @@ def test_get_parquet_indexer_cls(pq_url, tmp_path, cls, expectation, monkeypatch
         assert isinstance(indexer_obj, cls)
 
 
+@pytest.mark.skipif(condition=sys.platform == "win32", reason="Fails on windows bcoz of urllib.parse")
+def test_cloud_parquet_dir_forwards_storage_options(tmp_path, monkeypatch, fsspec_mock):
+    fsspec_fs_mock = Mock()
+    fsspec_fs_mock.ls = Mock(return_value=[])
+    fsspec_mock.filesystem = Mock(return_value=fsspec_fs_mock)
+
+    monkeypatch.setattr("litdata.utilities.parquet._FSSPEC_AVAILABLE", True)
+
+    storage_options = {"key": "ACCESS_KEY", "secret": "SECRET_KEY", "endpoint_url": "https://s3.example.com"}
+    CloudParquetDir("s3://some_bucket/some_path", tmp_path, storage_options=storage_options)
+
+    fsspec_mock.filesystem.assert_called_once_with("s3", **storage_options)
+
+
 @pytest.mark.usefixtures("clean_pq_index_cache")
 @patch("litdata.utilities.parquet._HF_HUB_AVAILABLE", True)
 @patch("litdata.streaming.downloader._HF_HUB_AVAILABLE", True)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #835.

`CloudParquetDir` unpacked `storage_options` positionally with `fsspec.filesystem(provider, *self.storage_options)`, which passes the dict keys as positional arguments and raises `TypeError: filesystem() takes 1 positional argument but ... were given` whenever a non-empty `storage_options` is supplied (e.g. S3 credentials). Switching to `**self.storage_options` forwards them as keyword arguments, matching how `litdata/raw/indexer.py` already calls `fsspec.filesystem`.

Added a regression test asserting the storage options reach `fsspec.filesystem` as keyword arguments.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
