### PR TITLE
fix(parquet): pass storage_options as **kwargs to fsspec.filesystem, fix mutable default args

### DIFF
--- a/src/litdata/utilities/parquet.py
+++ b/src/litdata/utilities/parquet.py
@@ -78,7 +78,7 @@ class LocalParquetDir(ParquetDir):
         self,
         dir_path: str | Dir | None,
         cache_path: str | None = None,
-        storage_options: dict | None = {},
+        storage_options: dict | None = None,
         num_workers: int = 4,
     ):
         if not _PYARROW_AVAILABLE:
@@ -150,7 +150,7 @@ class CloudParquetDir(ParquetDir):
         for provider in _CLOUD_PROVIDER:
             if self.dir.url.startswith(provider):
                 # Initialize the cloud filesystem
-                self.fs = fsspec.filesystem(provider, *self.storage_options)
+                self.fs = fsspec.filesystem(provider, **self.storage_options)
                 print(f"using provider: {provider}")
                 break
 
@@ -304,7 +304,7 @@ class HFParquetDir(ParquetDir):
 def get_parquet_indexer_cls(
     dir_path: str,
     cache_path: str | None = None,
-    storage_options: dict | None = {},
+    storage_options: dict | None = None,
     num_workers: int = 4,
 ) -> ParquetDir:
     """Get the appropriate ParquetDir class based on the directory path scheme.


### PR DESCRIPTION
## Problem

`index_parquet_dataset()` crashes with a `TypeError` when passing `storage_options` for S3 or any cloud filesystem:

```
TypeError: filesystem() takes 1 positional argument but 4 were given
```

The bug is in `src/litdata/utilities/parquet.py` line 153 — `storage_options` (a `dict`) is unpacked with `*` (which iterates keys as positional args) instead of `**` (which passes key-value pairs as keyword args):

```python
# Before ❌ — unpacks dict keys as positional args
self.fs = fsspec.filesystem(provider, *self.storage_options)

# After ✅ — passes key-value pairs as keyword args
self.fs = fsspec.filesystem(provider, **self.storage_options)
```

## Additional fixes

Two places used a mutable default argument (`{}`) for `storage_options`, which is a well-known Python antipattern — a single dict is shared across all calls if not overridden:

```python
# Before ❌
storage_options: dict | None = {}

# After ✅
storage_options: dict | None = None
```

Fixed in `ParquetCloudIndexer.__init__` (line 81) and `get_parquet_indexer_cls()` (line 307). The existing `None` → `{}` guard in the base class handles the empty-dict default correctly.

## Reproduction

```python
import litdata as ld

ld.index_parquet_dataset(
    "s3://bucket/path/to/parquet/",
    storage_options={
        "key": "ACCESS_KEY",
        "secret": "SECRET_KEY",
        "endpoint_url": "https://s3.example.com",
    },
)
# Before fix: TypeError: filesystem() takes 1 positional argument but 4 were given
# After fix:  Works correctly
```

Closes #835