### PR TITLE
fix: honor index_path when input_dir is a local directory

### DIFF
--- a/src/litdata/utilities/dataset_utilities.py
+++ b/src/litdata/utilities/dataset_utilities.py
@@ -80,18 +80,18 @@ def subsample_streaming_dataset(
     cache_index_filepath = os.path.join(input_dir.path, _INDEX_FILENAME)
 
     # Check if `index.json` file exists in cache path
-    if not os.path.exists(cache_index_filepath) and isinstance(input_dir.url, str):
+    if not os.path.exists(cache_index_filepath) and index_path is not None:
+        # A user-provided `index_path` should be honored for both local and remote `input_dir`.
+        copy_index_to_cache_index_filepath(index_path, cache_index_filepath)
+    elif not os.path.exists(cache_index_filepath) and isinstance(input_dir.url, str):
         assert input_dir.url is not None
-        if index_path is not None:
-            copy_index_to_cache_index_filepath(index_path, cache_index_filepath)
-        else:
-            # Merge data_connection_id from resolved directory into storage_options for R2 connections
-            merged_storage_options = storage_options.copy() if storage_options is not None else {}
-            if hasattr(input_dir, "data_connection_id") and input_dir.data_connection_id:
-                merged_storage_options["data_connection_id"] = input_dir.data_connection_id
+        # Merge data_connection_id from resolved directory into storage_options for R2 connections
+        merged_storage_options = storage_options.copy() if storage_options is not None else {}
+        if hasattr(input_dir, "data_connection_id") and input_dir.data_connection_id:
+            merged_storage_options["data_connection_id"] = input_dir.data_connection_id
 
-            downloader = get_downloader(input_dir.url, input_dir.path, [], merged_storage_options, session_options)
-            downloader.download_file(os.path.join(input_dir.url, _INDEX_FILENAME), cache_index_filepath)
+        downloader = get_downloader(input_dir.url, input_dir.path, [], merged_storage_options, session_options)
+        downloader.download_file(os.path.join(input_dir.url, _INDEX_FILENAME), cache_index_filepath)
 
     def path_exists(p: str) -> bool:
         return wait_for_predicate(lambda: os.path.exists(p), timeout=0.5)

--- a/tests/utilities/test_dataset_utilities.py
+++ b/tests/utilities/test_dataset_utilities.py
@@ -7,6 +7,7 @@ import litdata.constants
 import litdata.utilities
 import litdata.utilities.dataset_utilities
 from litdata.constants import _DEFAULT_CACHE_DIR, _DEFAULT_LIGHTNING_CACHE_DIR, _INDEX_FILENAME
+from litdata.streaming.resolver import Dir
 from litdata.utilities.dataset_utilities import (
     _should_replace_path,
     _try_create_cache_dir,
@@ -14,6 +15,7 @@ from litdata.utilities.dataset_utilities import (
     generate_roi,
     get_default_cache_dir,
     load_index_file,
+    subsample_streaming_dataset,
 )
 
 
@@ -97,6 +99,25 @@ def test_adapt_mds_shards_to_chunks(mosaic_mds_index_data):
     assert "chunks" in adapted_data
     assert "config" in adapted_data
     assert len(mosaic_mds_index_data["shards"]) == len(adapted_data["chunks"])
+
+
+def test_subsample_streaming_dataset_with_local_index_path(tmpdir):
+    # `input_dir` is a local directory that does NOT contain an index.json file.
+    data_dir = tmpdir.mkdir("data")
+    # The index.json lives in a separate directory provided via `index_path`.
+    index_dir = tmpdir.mkdir("index")
+    index_data = {"chunks": [{"chunk_size": 30, "filename": "chunk-0.bin"}], "config": {}}
+    with open(os.path.join(index_dir, _INDEX_FILENAME), "w") as f:
+        f.write(json.dumps(index_data))
+
+    input_dir = Dir(path=str(data_dir), url=None)
+    with mock.patch.dict(os.environ, {}, clear=True):
+        subsampled_files, roi = subsample_streaming_dataset(input_dir, index_path=str(index_dir))
+
+    assert subsampled_files == ["chunk-0.bin"]
+    assert roi == [(0, 30)]
+    # The user-provided index is materialized into the local dataset directory.
+    assert os.path.exists(os.path.join(str(data_dir), _INDEX_FILENAME))
 
 
 def test_get_default_cache_dir():


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #800.

When `input_dir` points to a local directory, a user-provided `index_path` was ignored and loading failed. In `dataset_utilities.py` the branch that copies `index.json` from `index_path` into the cache directory was nested inside `isinstance(input_dir.url, str)`, so it only ran for remote inputs. For a local `input_dir` the `url` is `None`, the branch was skipped, the index was never materialized into the cache path, and the dataset could not resolve.

The fix checks `index_path` first, independent of whether the input is local or remote: if `index.json` is not already cached and an explicit `index_path` was provided, copy it into the cache path. The existing remote-download branch is preserved for the case where no `index_path` is given.

Added `test_subsample_streaming_dataset_with_local_index_path`, which uses a local `input_dir` with no `index.json` plus an `index_path` in a separate directory, and asserts that subsampling resolves correctly and the index is materialized into the local dataset directory. It fails on `main` and passes with this change.
