### PR TITLE
ci: pin pyarrow <25 to unblock CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch <2.13.0  # TODO: unpin once the torch 2.13 processing-test hang is resolved
+torch
 torchvision
 lightning-utilities
 filelock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch
+torch <2.13.0  # TODO: unpin once the torch 2.13 processing-test hang is resolved
 torchvision
 lightning-utilities
 filelock

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,6 +1,6 @@
 pillow
 viztracer
-pyarrow
+pyarrow <25.0.0  # TODO: unpin once pyarrow 25 parquet segfault is resolved
 tqdm
 lightning-sdk==2026.2.6 # Must be pinned to ensure compatibility
 google-cloud-storage

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ pytest-rerunfailures ==16.1
 pytest-random-order ==1.2.0
 pytest-xdist >=3.8.0
 pandas
-pyarrow >=20.0.0
+pyarrow >=20.0.0,<25.0.0  # TODO: unpin once pyarrow 25 parquet segfault is resolved
 polars >1.0.0
 lightning
 transformers >=4.51.0


### PR DESCRIPTION
## What does this PR do?

pyarrow 25.0.0 (released 10th july) causes a segmentation fault and 16 parquet-test failures in `tests/streaming/test_parquet.py` when reading row groups during parquet indexing. 
The last known-good CI run used pyarrow 24.0.0. 

This pr pins `pyarrow<25.0.0` as a stopgap to unblock CI until the regression is root-caused upstream in pyarrow.

(Originally this PR pinned torch <2.13, but further investigation showed torch was not the culprit — pyarrow 25 is.)