### PR TITLE
ci: [experiment] force torch >=2.13 to confirm CI hang

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch
+torch >=2.13.0  # experiment: force torch 2.13 to confirm CI hang
 torchvision
 lightning-utilities
 filelock


### PR DESCRIPTION
## What does this PR do?

Control experiment (do not merge). Forces `torch >=2.13` to confirm it causes the processing-test CI hang. Pairs with #841 (`torch <2.13`, expected green).