### PR TITLE
feat: support S3 data connections on non-AWS providers using temp credentials

### DIFF
--- a/src/litdata/streaming/client.py
+++ b/src/litdata/streaming/client.py
@@ -45,6 +45,63 @@ class _CustomRetryAdapter(HTTPAdapter):
         return super().send(request, **kwargs)
 
 
+def _login_and_get_temp_bucket_credentials(data_connection_id: str) -> dict[str, Any]:
+    """Mint temporary bucket credentials for a data connection via the Lightning Cloud API.
+
+    Shared by R2 (lightning storage) connections and by S3 connections marked
+    ``available_in_non_aws_providers``: both bypass the FUSE mount and need short-lived creds
+    from the same control-plane ``temp-bucket-credentials`` endpoint. Returns the raw response
+    (accessKeyId/secretAccessKey/sessionToken, plus accountId for R2).
+    """
+    retry_strategy = Retry(
+        total=_CONNECTION_RETRY_TOTAL,
+        backoff_factor=_CONNECTION_RETRY_BACKOFF_FACTOR,
+        status_forcelist=[
+            408,  # Request Timeout
+            429,  # Too Many Requests
+            500,  # Internal Server Error
+            502,  # Bad Gateway
+            503,  # Service Unavailable
+            504,  # Gateway Timeout
+        ],
+    )
+    adapter = _CustomRetryAdapter(max_retries=retry_strategy, timeout=_DEFAULT_REQUEST_TIMEOUT)
+    session = requests.Session()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+    cloud_url = os.getenv("LIGHTNING_CLOUD_URL", "https://lightning.ai")
+    api_key = os.getenv("LIGHTNING_API_KEY")
+    username = os.getenv("LIGHTNING_USERNAME")
+    project_id = os.getenv("LIGHTNING_CLOUD_PROJECT_ID")
+
+    if not all([api_key, username, project_id]):
+        raise RuntimeError("Missing required environment variables")
+
+    # Login to get token
+    payload = {"apiKey": api_key, "username": username}
+    login_url = f"{cloud_url}/v1/auth/login"
+    response = session.post(login_url, data=json.dumps(payload))
+
+    if "token" not in response.json():
+        raise RuntimeError("Failed to get authentication token")
+
+    token = response.json()["token"]
+
+    # Get temporary bucket credentials
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    credentials_url = (
+        f"{cloud_url}/v1/projects/{project_id}/data-connections/{data_connection_id}/temp-bucket-credentials"
+    )
+
+    credentials_response = session.get(credentials_url, headers=headers, timeout=10)
+
+    if credentials_response.status_code != 200:
+        raise RuntimeError(f"Failed to get credentials: {credentials_response.status_code}")
+
+    return credentials_response.json()
+
+
 class S3Client:
     # TODO: Generalize to support more cloud providers.
 
@@ -61,6 +118,15 @@ class S3Client:
         self._session_options: dict = session_options or {}
 
     def _create_client(self) -> None:
+        # S3 data connections marked available on non-AWS providers can't reach the bucket via the
+        # FUSE mount or an instance profile off AWS, so mint temporary project-role credentials from
+        # the control plane instead (mirrors R2Client). Gated on data_connection_id being threaded
+        # through storage_options, so plain S3 access is unaffected.
+        data_connection_id = self._storage_options.get("data_connection_id")
+        if data_connection_id:
+            self._create_client_from_temp_credentials(data_connection_id)
+            return
+
         has_shared_credentials_file = (
             os.getenv("AWS_SHARED_CREDENTIALS_FILE") == os.getenv("AWS_CONFIG_FILE") == "/.credentials/.aws_credentials"
         )
@@ -85,6 +151,29 @@ class S3Client:
                 aws_session_token=credentials.token,
                 config=botocore.config.Config(retries={"max_attempts": 1000, "mode": "adaptive"}),
             )
+
+    def _create_client_from_temp_credentials(self, data_connection_id: str) -> None:
+        """Create an S3 client backed by temporary project-role credentials for a data connection.
+
+        Used for S3 connections available on non-AWS providers. Unlike R2 there is no custom
+        endpoint — this is real AWS S3, so botocore resolves the bucket region on first use.
+        """
+        temp_credentials = _login_and_get_temp_bucket_credentials(data_connection_id)
+
+        # data_connection_id is our own metadata; drop it before handing options to boto3.
+        storage_options = {k: v for k, v in self._storage_options.items() if k != "data_connection_id"}
+
+        session = boto3.Session(**self._session_options)
+        self._client = session.client(
+            "s3",
+            **{
+                "aws_access_key_id": temp_credentials["accessKeyId"],
+                "aws_secret_access_key": temp_credentials["secretAccessKey"],
+                "aws_session_token": temp_credentials["sessionToken"],
+                "config": botocore.config.Config(retries={"max_attempts": 1000, "mode": "adaptive"}),
+                **storage_options,
+            },
+        )
 
     @property
     def client(self) -> Any:
@@ -121,56 +210,8 @@ class R2Client(S3Client):
 
     def get_r2_bucket_credentials(self, data_connection_id: str) -> dict[str, str]:
         """Fetch temporary R2 credentials for the current lightning storage connection."""
-        # Create session with retry logic
-        retry_strategy = Retry(
-            total=_CONNECTION_RETRY_TOTAL,
-            backoff_factor=_CONNECTION_RETRY_BACKOFF_FACTOR,
-            status_forcelist=[
-                408,  # Request Timeout
-                429,  # Too Many Requests
-                500,  # Internal Server Error
-                502,  # Bad Gateway
-                503,  # Service Unavailable
-                504,  # Gateway Timeout
-            ],
-        )
-        adapter = _CustomRetryAdapter(max_retries=retry_strategy, timeout=_DEFAULT_REQUEST_TIMEOUT)
-        session = requests.Session()
-        session.mount("http://", adapter)
-        session.mount("https://", adapter)
-
         try:
-            # Get Lightning Cloud API token
-            cloud_url = os.getenv("LIGHTNING_CLOUD_URL", "https://lightning.ai")
-            api_key = os.getenv("LIGHTNING_API_KEY")
-            username = os.getenv("LIGHTNING_USERNAME")
-            project_id = os.getenv("LIGHTNING_CLOUD_PROJECT_ID")
-
-            if not all([api_key, username, project_id]):
-                raise RuntimeError("Missing required environment variables")
-
-            # Login to get token
-            payload = {"apiKey": api_key, "username": username}
-            login_url = f"{cloud_url}/v1/auth/login"
-            response = session.post(login_url, data=json.dumps(payload))
-
-            if "token" not in response.json():
-                raise RuntimeError("Failed to get authentication token")
-
-            token = response.json()["token"]
-
-            # Get temporary bucket credentials
-            headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-            credentials_url = (
-                f"{cloud_url}/v1/projects/{project_id}/data-connections/{data_connection_id}/temp-bucket-credentials"
-            )
-
-            credentials_response = session.get(credentials_url, headers=headers, timeout=10)
-
-            if credentials_response.status_code != 200:
-                raise RuntimeError(f"Failed to get credentials: {credentials_response.status_code}")
-
-            temp_credentials = credentials_response.json()
+            temp_credentials = _login_and_get_temp_bucket_credentials(data_connection_id)
 
             endpoint_url = f"https://{temp_credentials['accountId']}.r2.cloudflarestorage.com"
 

--- a/src/litdata/streaming/resolver.py
+++ b/src/litdata/streaming/resolver.py
@@ -217,7 +217,19 @@ def _resolve_data_connection(dir_path: str) -> "V1DataConnection":
 def _resolve_s3_connections(dir_path: str) -> Dir:
     data_connection = _resolve_data_connection(dir_path)
 
-    return Dir(path=dir_path, url=os.path.join(data_connection.aws.source, *dir_path.split("/")[4:]))
+    # S3 connections flagged available on non-AWS providers can't rely on the FUSE mount or an
+    # instance profile off AWS, so thread the connection id through. That makes the S3 client mint
+    # temporary project-role credentials (same mechanism as R2 / lightning_storage below). Plain
+    # AWS-only S3 connections leave this unset and keep using the ambient credentials.
+    data_connection_id = (
+        data_connection.id if getattr(data_connection.aws, "available_in_non_aws_providers", False) else None
+    )
+
+    return Dir(
+        path=dir_path,
+        url=os.path.join(data_connection.aws.source, *dir_path.split("/")[4:]),
+        data_connection_id=data_connection_id,
+    )
 
 
 def _resolve_gcs_connections(dir_path: str) -> Dir:

--- a/tests/streaming/test_client.py
+++ b/tests/streaming/test_client.py
@@ -290,6 +290,40 @@ def test_r2_client_create_client_success(monkeypatch):
     )
 
 
+def test_s3_client_uses_temp_credentials_with_data_connection_id(monkeypatch):
+    """S3Client should mint temporary project-role creds when a data_connection_id is provided.
+
+    This is the path for S3 connections marked available on non-AWS providers.
+    """
+    boto3_session = mock.MagicMock()
+    boto3 = mock.MagicMock(Session=boto3_session)
+    monkeypatch.setattr(client, "boto3", boto3)
+
+    botocore = mock.MagicMock()
+    monkeypatch.setattr(client, "botocore", botocore)
+
+    # The S3 temp-credentials response has no accountId (real AWS S3, no custom endpoint).
+    temp_credentials = {
+        "accessKeyId": "test-access-key",
+        "secretAccessKey": "test-secret-key",
+        "sessionToken": "test-session-token",
+    }
+    monkeypatch.setattr(client, "_login_and_get_temp_bucket_credentials", mock.MagicMock(return_value=temp_credentials))
+
+    s3_client = client.S3Client(storage_options={"data_connection_id": "test-connection", "region_name": "us-west-2"})
+    assert s3_client.client
+
+    # data_connection_id is dropped before boto3; temp creds + remaining options are forwarded.
+    boto3_session().client.assert_called_with(
+        "s3",
+        aws_access_key_id="test-access-key",
+        aws_secret_access_key="test-secret-key",
+        aws_session_token="test-session-token",
+        config=botocore.config.Config(retries={"max_attempts": 1000, "mode": "adaptive"}),
+        region_name="us-west-2",
+    )
+
+
 def test_r2_client_filters_metadata_from_storage_options(monkeypatch):
     """Test that R2Client filters out metadata keys from storage options."""
     boto3_session = mock.MagicMock()

--- a/tests/streaming/test_resolver.py
+++ b/tests/streaming/test_resolver.py
@@ -107,6 +107,63 @@ def test_src_resolver_s3_connections(monkeypatch, lightning_cloud_mock):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="windows isn't supported")
+def test_src_resolver_s3_connections_non_aws_providers(monkeypatch, lightning_cloud_mock):
+    """S3 connections available on non-AWS providers should carry the data_connection_id.
+
+    That id is what makes the S3 client mint temporary project-role credentials (same mechanism
+    as R2 / lightning_storage). AWS-only S3 connections must leave it unset.
+    """
+    auth = login.Auth()
+    auth.save(user_id="7c8455e3-7c5f-4697-8a6d-105971d6b9bd", api_key="e63fae57-2b50-498b-bc46-d6204cbf330e")
+
+    monkeypatch.setenv("LIGHTNING_CLOUD_PROJECT_ID", "project_id")
+
+    # Available on non-AWS providers -> data_connection_id is threaded through.
+    resolver._resolve_data_connection.cache_clear()
+    client_mock = mock.MagicMock()
+    client_mock.data_connection_service_list_data_connections.return_value = V1ListDataConnectionsResponse(
+        data_connections=[
+            V1DataConnection(
+                id="data_connection_id",
+                name="imagenet",
+                aws=mock.MagicMock(source="s3://imagenet-bucket", available_in_non_aws_providers=True),
+            )
+        ],
+    )
+    client_cls_mock = mock.MagicMock()
+    client_cls_mock.return_value = client_mock
+    lightning_cloud_mock.rest_client.LightningClient = client_cls_mock
+
+    resolved = resolver._resolve_dir("/teamspace/s3_connections/imagenet")
+    assert resolved.url == "s3://imagenet-bucket"
+    assert resolved.data_connection_id == "data_connection_id"
+    assert resolver._resolve_dir("/teamspace/s3_connections/imagenet/train").url == "s3://imagenet-bucket/train"
+
+    # AWS-only (flag unset) -> no data_connection_id, so ambient credentials are used.
+    resolver._resolve_data_connection.cache_clear()
+    client_mock = mock.MagicMock()
+    client_mock.data_connection_service_list_data_connections.return_value = V1ListDataConnectionsResponse(
+        data_connections=[
+            V1DataConnection(
+                id="data_connection_id",
+                name="imagenet",
+                aws=mock.MagicMock(source="s3://imagenet-bucket", available_in_non_aws_providers=False),
+            )
+        ],
+    )
+    client_cls_mock = mock.MagicMock()
+    client_cls_mock.return_value = client_mock
+    lightning_cloud_mock.rest_client.LightningClient = client_cls_mock
+
+    resolved = resolver._resolve_dir("/teamspace/s3_connections/imagenet")
+    assert resolved.url == "s3://imagenet-bucket"
+    assert resolved.data_connection_id is None
+
+    resolver._resolve_data_connection.cache_clear()
+    auth.clear()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="windows isn't supported")
 def test_src_resolver_studios(monkeypatch, lightning_cloud_mock):
     auth = login.Auth()
     auth.save(user_id="7c8455e3-7c5f-4697-8a6d-105971d6b9bd", api_key="e63fae57-2b50-498b-bc46-d6204cbf330e")


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the contributor guideline, Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Enables S3 data connections marked **available on non-AWS providers** to be resolved and accessed directly (bypassing the FUSE mount) from non-AWS Studios (GCP, Nebius, etc.), by minting temporary project-role credentials — mirroring the existing R2 / `lightning_storage` flow.

Previously `_resolve_s3_connections` returned a `Dir` without a `data_connection_id`, so the `s3://` path fell back to ambient AWS credentials (instance profile / shared credentials file). Off AWS there are none, so `S3Client._create_client` crashed:

```
AttributeError: 'NoneType' object has no attribute 'access_key'
```

### Changes

- **`streaming/resolver.py`**: `_resolve_s3_connections` now threads `data_connection_id` through when the connection has `available_in_non_aws_providers` set (parallel to `_resolve_lightning_storage`). AWS-only connections leave it unset and keep using ambient credentials.
- **`streaming/client.py`**: extracted the shared token-login + `temp-bucket-credentials` fetch into `_login_and_get_temp_bucket_credentials`, reused by both R2 and S3. `S3Client` now mints temporary project-role credentials when a `data_connection_id` is present (real AWS S3 — no custom endpoint). This covers both the read (`S3Downloader`) and write (`S3FsProvider`) paths, since both share the `s3://` scheme and `S3Client`.
- Credential refresh is handled by the existing `refetch_interval` mechanism.
- Added unit tests for the resolver and client paths.

> [!NOTE]
> Requires the `lightning_sdk` `V1AwsDataConnection` model to expose `available_in_non_aws_providers` (added separately in the SDK). Without it the field is dropped on deserialize and the connection continues to use ambient credentials.

## PR review

Anyone in the community is free to review the PR once the tests have passed.

## Did you have fun?

🙃

Made with [Cursor](https://cursor.com)