### PR TITLE
fix(streaming): eager reference-counting to stop FileNotFoundError on shared chunks

### DIFF
--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -15,10 +15,14 @@ import contextlib
 import logging
 import os
 from collections import defaultdict
+from contextlib import suppress
 from time import sleep, time
 from typing import Any, Optional
 
+from filelock import FileLock, Timeout
+
 from litdata.constants import _INDEX_FILENAME, _MAX_WAIT_TIME
+from litdata.debugger import _get_log_msg
 from litdata.streaming.compression import _COMPRESSORS, Compressor
 from litdata.streaming.downloader import get_downloader
 from litdata.streaming.item_loader import BaseItemLoader, Interval, PyTreeLoader, TokensLoader
@@ -107,6 +111,10 @@ class ChunksConfig:
             self._compressor = _COMPRESSORS[self._compressor_name]
 
         self._skip_chunk_indexes_deletion: list[int] | None = None
+        # Chunk indexes that are shared across workers on this node. Shared chunks are
+        # reference-counted *eagerly* (incremented at iteration start by the reader), so their
+        # lazy download-time increment is skipped to keep the count balanced. See reader.py.
+        self._shared_chunk_indexes: set[int] = set()
         self.zero_based_roi: list[tuple[int, int]] | None = None
         self.filename_to_size_map: dict[str, int] = {}
         for cnk in _original_chunks:
@@ -118,6 +126,67 @@ class ChunksConfig:
         if self._skip_chunk_indexes_deletion is None:
             return True
         return chunk_index not in self._skip_chunk_indexes_deletion
+
+    def _chunk_lock_filepath(self, chunk_index: int) -> str:
+        """The (decompressed) local chunk path whose ``.cnt``/``.lock`` files hold the refcount."""
+        chunk_filepath, _, _ = self[ChunkedIndex(index=-1, chunk_index=chunk_index)]
+        return chunk_filepath
+
+    def remaining_locks(self, chunk_index: int) -> int:
+        """Return the current reference count held on a chunk (0 if none)."""
+        countpath = self._chunk_lock_filepath(chunk_index) + ".cnt"
+        if not os.path.exists(countpath):
+            return 0
+        with suppress(FileNotFoundError), open(countpath) as count_f:
+            try:
+                return int(count_f.read().strip())
+            except Exception:
+                return 1
+        return 0
+
+    def increment_local_lock(self, chunk_index: int) -> None:
+        """Add one reference to a chunk's local lock (a co-reader intends to use it)."""
+        if self._downloader is None:
+            return
+        self._downloader._increment_local_lock(self._chunk_lock_filepath(chunk_index), chunk_index)
+
+    def decrement_local_lock(self, chunk_index: int) -> int:
+        """Remove one reference from a chunk's local lock; return the remaining count.
+
+        Moved here (from ``PrepareChunksThread``) so the reader can release eagerly-acquired locks
+        during teardown without depending on the prefetch thread still being alive.
+        """
+        countpath = self._chunk_lock_filepath(chunk_index) + ".cnt"
+        lock_path = countpath + ".lock"
+        curr_count = 0
+        remove_lock = False
+        with suppress(Timeout, FileNotFoundError), FileLock(lock_path, timeout=3):
+            if os.path.exists(countpath):
+                with open(countpath) as count_f:
+                    try:
+                        curr_count = int(count_f.read().strip())
+                    except Exception:
+                        curr_count = 1
+                curr_count -= 1
+                if curr_count <= 0:
+                    with suppress(FileNotFoundError, PermissionError):
+                        os.remove(countpath)
+                    remove_lock = True
+                else:
+                    with open(countpath, "w+") as count_f:
+                        logger.debug(_get_log_msg({"name": f"decrement_lock_{chunk_index}_to_{curr_count}", "ph": "B"}))
+                        count_f.write(str(curr_count))
+                        logger.debug(_get_log_msg({"name": f"decrement_lock_{chunk_index}_to_{curr_count}", "ph": "E"}))
+            else:
+                remove_lock = True
+        # FileLock doesn't delete its lock file on release — we clean it up manually.
+        # This must happen after release (Windows can't delete open files) and after the
+        # work is done (on Linux, deleting an in-use lock file lets other processes lock
+        # on a new inode, bypassing mutual exclusion).
+        if remove_lock:
+            with suppress(FileNotFoundError, PermissionError):
+                os.remove(lock_path)
+        return curr_count
 
     @property
     def skip_chunk_indexes_deletion(self) -> list[int] | None:
@@ -133,22 +202,26 @@ class ChunksConfig:
 
         local_chunkpath = os.path.join(self._cache_dir, chunk_filename)
 
+        # Shared chunks are reference-counted eagerly by the reader (before any reading), so their
+        # download-time increment is skipped here to avoid double-counting. Non-shared chunks keep
+        # the original pay-as-you-download refcounting.
+        lazily_ref_counted = chunk_index not in self._shared_chunk_indexes
+
         if os.path.exists(local_chunkpath):
             self.try_decompress(local_chunkpath)
 
-            if self._downloader is not None and not skip_lock:
+            if self._downloader is not None and not skip_lock and lazily_ref_counted:
                 # We don't want to redownload the base, but we should mark
                 # it as having been requested by something
                 self._downloader._increment_local_lock(
                     local_chunkpath.replace(f".{self._compressor_name}", ""), chunk_index
                 )
-                pass
             return
 
         if self._downloader is None:
             return
 
-        if not skip_lock:
+        if not skip_lock and lazily_ref_counted:
             self._downloader._increment_local_lock(
                 local_chunkpath.replace(f".{self._compressor_name}", ""), chunk_index
             )

--- a/src/litdata/streaming/dataset.py
+++ b/src/litdata/streaming/dataset.py
@@ -40,10 +40,7 @@ from litdata.utilities.encryption import Encryption
 from litdata.utilities.env import _DistributedEnv, _is_in_dataloader_worker, _WorkerEnv
 from litdata.utilities.format import _convert_bytes_to_int
 from litdata.utilities.hf_dataset import index_hf_dataset
-from litdata.utilities.shuffle import (
-    _find_chunks_per_workers_on_which_to_skip_deletion,
-    _map_node_worker_rank_to_chunk_indexes_to_not_delete,
-)
+from litdata.utilities.shuffle import _get_shared_chunks
 
 logger = logging.getLogger("litdata.streaming.dataset")
 
@@ -381,36 +378,29 @@ class StreamingDataset(IterableDataset):
         # The max number of samples to return from `__next__` (in worker)
         self.stop_length = sum(interval[2] - interval[1] for interval in self.worker_intervals)
 
+        # Eagerly reference-count the chunks this worker shares with other workers on the node.
+        # A chunk can straddle worker boundaries and therefore be read by several workers; if a
+        # worker deletes it after finishing its own slice while a co-worker still needs it, the
+        # co-worker hits `FileNotFoundError`. Incrementing the shared chunks' reference counts now —
+        # before any item is read — guarantees every co-reader has claimed a shared chunk before any
+        # worker can finish and delete it (the reader releases them as it goes; see
+        # BinaryReader.acquire_shared_locks). This runs for BOTH fresh and resumed epochs.
+        node_size = self.distributed_env.world_size // self.distributed_env.num_nodes
+        first_rank_this_node = (self.distributed_env.global_rank // node_size) * node_size
+        num_workers_per_node = node_size * self.num_workers
+        # `workers_chunks` is a flat list indexed by `rank * num_workers + worker`, so the workers
+        # belonging to this node begin at `first_rank_this_node * self.num_workers`.
+        worker_start = first_rank_this_node * self.num_workers
+        worker_end = worker_start + num_workers_per_node
+
+        shared_chunks = _get_shared_chunks(workers_chunks[worker_start:worker_end])
+        my_shared_chunks = {chunk_index for chunk_index in self.worker_chunks if chunk_index in shared_chunks}
+        self.cache._reader.acquire_shared_locks(my_shared_chunks)
+
         # Handle restart
         if self._state_dict:
             self._resume(workers_chunks, workers_intervals)
         else:
-            # Find the chunks shared across all workers of the current node.
-            # For each shared chunk, find the rank and worker to use the chunk last and prevent
-            # premature deletion for the other workers.
-            node_size = self.distributed_env.world_size // self.distributed_env.num_nodes
-            first_rank_this_node = (self.distributed_env.global_rank // node_size) * node_size
-            num_workers_per_node = node_size * self.num_workers
-            worker_start = first_rank_this_node * num_workers_per_node
-            worker_end = worker_start + num_workers_per_node
-            local_rank = self.distributed_env.global_rank % node_size
-
-            chunks_indexes_skip_deletion = _find_chunks_per_workers_on_which_to_skip_deletion(
-                self.num_workers,
-                self.batch_size,
-                workers_chunks[worker_start:worker_end],
-                workers_intervals[worker_start:worker_end],
-            )
-            worker_node_rank_to_chunk_indexes = _map_node_worker_rank_to_chunk_indexes_to_not_delete(
-                chunks_indexes_skip_deletion
-            )
-
-            worker_rank_local_node = local_rank * self.num_workers + self.worker_env.rank
-            if worker_rank_local_node in worker_node_rank_to_chunk_indexes:
-                self.cache._reader.config.skip_chunk_indexes_deletion = worker_node_rank_to_chunk_indexes[
-                    worker_rank_local_node
-                ]
-
             self.num_chunks = len(self.worker_chunks)
             self.upcoming_indexes = []
             self.worker_next_chunk_index = 0

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -109,40 +109,12 @@ class PrepareChunksThread(Thread):
                 return 1
 
     def _decrement_local_lock(self, chunk_index: int) -> int:
-        """Remove a count from the local lock, return the remaining count."""
-        chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
+        """Remove a count from the local lock, return the remaining count.
 
-        countpath = chunk_filepath + ".cnt"
-        lock_path = countpath + ".lock"
-        curr_count = 0
-        remove_lock = False
-        with suppress(Timeout, FileNotFoundError), FileLock(lock_path, timeout=3):
-            if os.path.exists(countpath):
-                with open(countpath) as count_f:
-                    try:
-                        curr_count = int(count_f.read().strip())
-                    except Exception:
-                        curr_count = 1
-                curr_count -= 1
-                if curr_count <= 0:
-                    with suppress(FileNotFoundError, PermissionError):
-                        os.remove(countpath)
-                    remove_lock = True
-                else:
-                    with open(countpath, "w+") as count_f:
-                        logger.debug(_get_log_msg({"name": f"decrement_lock_{chunk_index}_to_{curr_count}", "ph": "B"}))
-                        count_f.write(str(curr_count))
-                        logger.debug(_get_log_msg({"name": f"decrement_lock_{chunk_index}_to_{curr_count}", "ph": "E"}))
-            else:
-                remove_lock = True
-        # FileLock doesn't delete its lock file on release — we clean it up manually.
-        # This must happen after release (Windows can't delete open files) and after the
-        # work is done (on Linux, deleting an in-use lock file lets other processes lock
-        # on a new inode, bypassing mutual exclusion).
-        if remove_lock:
-            with suppress(FileNotFoundError, PermissionError):
-                os.remove(lock_path)
-        return curr_count
+        Delegates to ``ChunksConfig`` so the reader can also release eagerly-acquired locks during
+        teardown without the prefetch thread.
+        """
+        return self._config.decrement_local_lock(chunk_index)
 
     def _cleanup_download_locks(self, chunk_filepath: str, chunk_index: int) -> None:
         """Remove stale download lock files for a chunk.
@@ -172,10 +144,15 @@ class PrepareChunksThread(Thread):
     def _apply_delete(self, chunk_index: int, skip_lock: bool = False) -> None:
         """Inform the item loader of the chunk to delete."""
         logger.debug(f"_apply_delete({chunk_index}, skip_lock={skip_lock}) called")
-        # TODO: Fix the can_delete method
         can_delete_chunk = self._config.can_delete(chunk_index)
         chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
 
+        # A chunk is deleted only once its reference count reaches zero, i.e. every worker that
+        # will read it has finished with it. Shared chunks are reference-counted *eagerly* (the
+        # reader increments them before any reading begins, see BinaryReader._acquire_shared_locks),
+        # so a zero count here reliably means "no worker still needs this chunk" — closing the race
+        # where a fast worker deleted a shared chunk a slower co-worker had not yet incremented.
+        # `skip_lock` is the force-redownload path (a worker re-fetching its own chunk).
         if not skip_lock:
             remaining_locks = self._remaining_locks(chunk_filepath)
             if remaining_locks > 0:  # Can't delete this, something has it
@@ -368,6 +345,10 @@ class BinaryReader:
         self._last_chunk_index: int | None = None
         self._last_chunk_size: int | None = None
         self._chunks_queued_for_download = False
+        # Shared chunks this worker reference-counts eagerly (before any reading), and the ones it
+        # still holds. See `acquire_shared_locks` / `_release_shared_locks`.
+        self._shared_chunk_indexes: set[int] = set()
+        self._held_shared: set[int] = set()
         self._max_cache_size = int(os.getenv("MAX_CACHE_SIZE", max_cache_size or 0))
         self._storage_options = storage_options
         self._session_options = session_options
@@ -394,6 +375,38 @@ class BinaryReader:
             self._session_options,
         )
         return self._config
+
+    def acquire_shared_locks(self, shared_chunk_indexes: set[int]) -> None:
+        """Eagerly reference-count the chunks this worker shares with other workers.
+
+        Called once per epoch, before any item is read. Incrementing the shared chunks' reference
+        counts up-front guarantees that every worker which will read a shared chunk has incremented
+        its count before any worker can finish and delete it — closing the increment-lag race where
+        a fast worker deletes a shared chunk a slower co-worker has not yet claimed. The matching
+        decrements happen as each chunk is finished in `read`, and any still-held locks are released
+        in `_release_shared_locks` on teardown (so early / partial iteration cannot leak counts).
+        """
+        if self._config is None and self._try_load_config() is None:
+            return
+        assert self._config is not None
+        # Release anything left over from a previous epoch on this reader before re-acquiring.
+        self._release_shared_locks()
+        self._shared_chunk_indexes = set(shared_chunk_indexes)
+        self._config._shared_chunk_indexes = self._shared_chunk_indexes
+        for chunk_index in self._shared_chunk_indexes:
+            self._config.increment_local_lock(chunk_index)
+            self._held_shared.add(chunk_index)
+
+    def _release_shared_locks(self) -> None:
+        """Release any eagerly-acquired shared-chunk locks this worker still holds."""
+        if not self._held_shared:
+            return
+        if self._config is None:
+            self._held_shared.clear()
+            return
+        for chunk_index in list(self._held_shared):
+            self._config.decrement_local_lock(chunk_index)
+            self._held_shared.discard(chunk_index)
 
     def setup_thread_and_download_chunk(self, index: ChunkedIndex) -> None:
         if self._config and (self._config._remote_dir or self._config._compressor):
@@ -486,6 +499,7 @@ class BinaryReader:
         ):
             # inform the chunk has been completely consumed
             self._prepare_thread._decrement_local_lock(self._last_chunk_index)
+            self._held_shared.discard(self._last_chunk_index)
             self._prepare_thread.delete([self._last_chunk_index])
 
         if index.chunk_index != self._last_chunk_index:
@@ -515,7 +529,10 @@ class BinaryReader:
 
             # inform the thread it is time to stop
             self._prepare_thread._decrement_local_lock(index.chunk_index)
+            self._held_shared.discard(index.chunk_index)
             self._prepare_thread.delete([index.chunk_index])
+            # Release any shared-chunk locks still held (e.g. chunks assigned but never reached).
+            self._release_shared_locks()
             self._prepare_thread.stop()
             if self._max_cache_size and self._prepare_thread.is_alive():
                 try:
@@ -573,6 +590,11 @@ class BinaryReader:
         return state
 
     def __del__(self) -> None:
+        # Release eagerly-acquired shared-chunk locks that were never released (e.g. the loop was
+        # broken out of before the last item). Without this, an aborted epoch would leak reference
+        # counts and prevent those chunks from ever being deleted.
+        with suppress(Exception):
+            self._release_shared_locks()
         if self._prepare_thread and not self._prepare_thread._has_exited:
             self._prepare_thread.force_stop()
             self._prepare_thread = None

--- a/tests/streaming/test_shared_chunk_deletion.py
+++ b/tests/streaming/test_shared_chunk_deletion.py
@@ -1,0 +1,387 @@
+"""Regression tests for the shared-chunk deletion race.
+
+A chunk can be assigned to several workers on the same node (the shuffle splits a chunk's
+interval across worker boundaries). If a worker deletes such a chunk after finishing its own
+slice while another worker still needs it, the other worker raises
+``FileNotFoundError: The <...>.bin hasn't been found`` (item_loader.py).
+
+The fix is *eager reference counting*: each worker increments the ``.cnt`` of every shared chunk
+it will read BEFORE reading anything (``BinaryReader.acquire_shared_locks``), decrements as it
+finishes each chunk, and drains any still-held locks on teardown. A shared chunk is deleted only
+once its reference count reaches zero — i.e. every worker that will read it has incremented (so the
+increment can never lag behind another worker's delete) and every worker has finished. These tests
+pin that behaviour, including that counts stay balanced (no leak) across full, partial, and
+multi-epoch iteration.
+"""
+
+import os
+import shutil
+import sys
+import time
+
+import pytest
+
+from litdata import StreamingDataLoader, StreamingDataset
+from litdata.constants import _INDEX_FILENAME
+from litdata.streaming.cache import Cache
+from litdata.streaming.config import ChunkedIndex, ChunksConfig
+from litdata.streaming.downloader import LocalDownloaderWithCache, register_downloader
+from litdata.streaming.item_loader import PyTreeLoader
+from litdata.streaming.reader import PrepareChunksThread
+from litdata.streaming.resolver import Dir
+from litdata.streaming.serializers import _get_serializers
+from litdata.utilities.env import _DistributedEnv
+
+# Env flag that turns on the flaky-remote behaviour. Off by default so registering this downloader
+# for the ``local:`` scheme is a no-op for every other test (it then behaves exactly like the stock
+# LocalDownloaderWithCache). The flag is set only inside the flaky test and, being an env var, is
+# inherited by spawned DataLoader workers.
+_FLAKY_ENV = "LITDATA_TEST_FLAKY_REMOTE"
+
+
+class _FlakyRemoteDownloader(LocalDownloaderWithCache):
+    """Emulates a slow/flaky remote (e.g. S3) that will NOT re-serve an already-evicted chunk.
+
+    The first fetch of a chunk copies it and drops a ``.served`` marker. If that chunk is later
+    evicted from the cache and requested again, the "remote" refuses to serve it. A *premature*
+    deletion of a shared chunk (one another worker still needs) therefore becomes an unrecoverable
+    ``FileNotFoundError`` — the exact production failure — while a legitimate final deletion (nobody
+    needs the chunk again) stays harmless. This lets an in-process test distinguish the fix, which a
+    plain local remote cannot (it just re-downloads instantly).
+    """
+
+    def download_file(self, remote_filepath: str, local_filepath: str) -> None:
+        if os.getenv(_FLAKY_ENV) != "1" or local_filepath.endswith(_INDEX_FILENAME):
+            super().download_file(remote_filepath, local_filepath)
+            return
+        served_marker = local_filepath + ".served"
+        if os.path.exists(served_marker) and not os.path.exists(local_filepath):
+            # Chunk was fetched before, then evicted, and is now requested again: emulate a remote
+            # that cannot recover it in time. Do nothing -> the reader eventually times out.
+            return
+        super().download_file(remote_filepath, local_filepath)
+        with open(served_marker, "w") as marker:
+            marker.write("1")
+
+
+# Route the ``local:`` scheme (the resolver only treats a fixed set of schemes as remote) through
+# the flaky downloader. Harmless when the env flag is off.
+register_downloader("local:", _FlakyRemoteDownloader, overwrite=True)
+
+
+def _build_remote_dataset(tmpdir, num_items=10, chunk_size=2):
+    """Optimize a tiny dataset into ``remote_dir`` and return an empty local ``cache_dir``."""
+    cache_dir = os.path.join(tmpdir, "cache_dir")
+    remote_dir = os.path.join(tmpdir, "remote_dir")
+    os.makedirs(cache_dir, exist_ok=True)
+
+    cache = Cache(input_dir=Dir(path=cache_dir, url=remote_dir), chunk_size=chunk_size, compression="zstd")
+    for i in range(num_items):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    shutil.copytree(cache_dir, remote_dir)
+    shutil.rmtree(cache_dir)
+    os.makedirs(cache_dir, exist_ok=True)
+    return cache_dir, remote_dir
+
+
+def test_lock_primitives_balance(tmpdir):
+    """`increment_local_lock` / `decrement_local_lock` / `remaining_locks` are balanced."""
+    cache_dir, remote_dir = _build_remote_dataset(tmpdir)
+    config = ChunksConfig.load(cache_dir, _get_serializers(None), remote_dir, PyTreeLoader())
+    assert config is not None
+
+    assert config.remaining_locks(0) == 0
+    config.increment_local_lock(0)
+    assert config.remaining_locks(0) == 1
+    config.increment_local_lock(0)
+    assert config.remaining_locks(0) == 2
+    assert config.decrement_local_lock(0) == 1
+    assert config.remaining_locks(0) == 1
+    assert config.decrement_local_lock(0) == 0
+    assert config.remaining_locks(0) == 0  # count file removed at zero
+
+
+def test_shared_chunk_deleted_only_at_refcount_zero(tmpdir):
+    """A shared chunk (eagerly counted by both readers) is deleted only when the last one finishes.
+
+    Reproduces the customer's ``FileNotFoundError`` at the mechanism level: two workers share chunk
+    0. Because both increment its count eagerly (before reading), the first worker to finish sees a
+    non-zero count and does NOT delete it — so the second worker still finds the file.
+    """
+    cache_dir, remote_dir = _build_remote_dataset(tmpdir)
+    item_loader = PyTreeLoader()
+    config = ChunksConfig.load(cache_dir, _get_serializers(None), remote_dir, item_loader)
+    assert config is not None
+
+    # Chunk 0 is shared -> download must not add its own (lazy) reference.
+    config._shared_chunk_indexes = {0}
+    config.increment_local_lock(0)  # worker A claims it eagerly
+    config.increment_local_lock(0)  # worker B claims it eagerly  -> count 2
+    config.download_chunk_from_index(0)  # materialise the file (shared -> no extra increment)
+
+    chunk0_path, _, _ = config[ChunkedIndex(index=-1, chunk_index=0)]
+    assert os.path.exists(chunk0_path)
+    assert config.remaining_locks(0) == 2
+
+    thread = PrepareChunksThread(config, item_loader, _DistributedEnv.detect(), max_cache_size=1, rank=0)
+
+    config.decrement_local_lock(0)  # worker A finishes
+    thread._apply_delete(0)
+    assert os.path.exists(chunk0_path), "shared chunk must survive while a co-worker still holds it"
+
+    config.decrement_local_lock(0)  # worker B finishes -> count 0
+    thread._apply_delete(0)
+    assert not os.path.exists(chunk0_path), "shared chunk should be deleted once the last reader is done"
+
+
+def test_reader_acquire_and_release_shared_locks_balanced(tmpdir):
+    """`acquire_shared_locks` increments eagerly and every count is released on teardown."""
+    from litdata.streaming.reader import BinaryReader
+
+    cache_dir, remote_dir = _build_remote_dataset(tmpdir)
+    reader = BinaryReader(cache_dir, remote_input_dir=remote_dir, item_loader=PyTreeLoader())
+    assert reader._try_load_config() is not None
+
+    reader.acquire_shared_locks({0, 1})
+    assert reader._held_shared == {0, 1}
+    assert reader.config.remaining_locks(0) == 1
+    assert reader.config.remaining_locks(1) == 1
+
+    # Re-acquiring must first release the previous holds (no double counting across epochs).
+    reader.acquire_shared_locks({0, 1})
+    assert reader.config.remaining_locks(0) == 1
+    assert reader.config.remaining_locks(1) == 1
+
+    reader._release_shared_locks()
+    assert reader._held_shared == set()
+    assert reader.config.remaining_locks(0) == 0
+    assert reader.config.remaining_locks(1) == 0
+
+
+def test_apply_delete_still_deletes_when_not_protected(tmpdir):
+    """Sanity check: with no skip list, a chunk at refcount zero is deleted as before."""
+    cache_dir, remote_dir = _build_remote_dataset(tmpdir)
+
+    item_loader = PyTreeLoader()
+    config = ChunksConfig.load(cache_dir, _get_serializers(None), remote_dir, item_loader)
+    assert config is not None
+
+    config.download_chunk_from_index(0)
+    thread = PrepareChunksThread(config, item_loader, _DistributedEnv.detect(), max_cache_size=1, rank=0)
+
+    chunk0_path, _, _ = config[ChunkedIndex(index=-1, chunk_index=0)]
+    assert os.path.exists(chunk0_path)
+
+    thread._decrement_local_lock(0)
+    assert thread._remaining_locks(chunk0_path) == 0
+    assert config.skip_chunk_indexes_deletion is None
+
+    thread._apply_delete(0)
+    assert not os.path.exists(chunk0_path)
+
+
+def test_apply_delete_skips_when_refcount_positive(tmpdir):
+    """A positive ``.cnt`` refcount blocks deletion regardless of the skip list."""
+    cache_dir, remote_dir = _build_remote_dataset(tmpdir)
+
+    item_loader = PyTreeLoader()
+    config = ChunksConfig.load(cache_dir, _get_serializers(None), remote_dir, item_loader)
+    assert config is not None
+
+    # Two holders incremented the lock; only one has finished (one decrement).
+    config.download_chunk_from_index(0)
+    config._downloader._increment_local_lock(chunk0 := config[ChunkedIndex(index=-1, chunk_index=0)][0], 0)
+
+    thread = PrepareChunksThread(config, item_loader, _DistributedEnv.detect(), max_cache_size=1, rank=0)
+    thread._decrement_local_lock(0)
+    assert thread._remaining_locks(chunk0) == 1
+
+    thread._apply_delete(0)
+    assert os.path.exists(chunk0), "A chunk still referenced by another holder must not be deleted."
+
+
+def _skewed_transform(x, *args, **kwargs):
+    """Slow down worker 0 so it reads its (shared) chunks much later than the other workers.
+
+    Worker 0 owns the first slice of the dataset, so the chunk on the worker-0/worker-1 boundary
+    is worker 0's *last* chunk but worker 1's *first*. Slowing worker 0 guarantees worker 1 reaches
+    and finishes that shared chunk (and, with a tiny cache, tries to evict it) long before worker 0
+    reads it -- deterministically exercising the shared-chunk deletion race.
+    """
+    import torch.utils.data
+
+    info = torch.utils.data.get_worker_info()
+    if info is not None and info.id == 0:
+        time.sleep(0.03)
+    return x
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Not tested on windows")
+def test_multiworker_dataloader_shared_chunk_not_deleted_early(tmpdir):
+    """End-to-end: streaming a full dataset across workers must not lose shared chunks.
+
+    Uses a ``local:`` remote (so the download / lock / delete path is active) and a tiny
+    ``max_cache_size`` (so eviction runs aggressively). Chunks straddle worker boundaries, and
+    worker 0 is deliberately slowed so a faster co-worker would, pre-fix, evict a shared chunk that
+    worker 0 still needs -> ``FileNotFoundError``. After the fix every item must be returned exactly
+    once with no error.
+    """
+    cache_dir = os.path.join(tmpdir, "cache_dir")
+    data_dir = os.path.join(tmpdir, "data_dir")
+    os.makedirs(cache_dir)
+    os.makedirs(data_dir)
+
+    num_items = 200
+    # chunk_size=7 makes chunk boundaries misalign with the per-worker item split, so several
+    # chunks are shared between adjacent workers.
+    cache = Cache(str(data_dir), chunk_size=7)
+    for i in range(num_items):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    dataset = StreamingDataset(
+        f"local:{data_dir}",
+        cache_dir=str(cache_dir),
+        shuffle=False,
+        drop_last=False,
+        # Tiny cache -> num_bytes_per_node > max_cache_size -> aggressive "delete when processed".
+        max_cache_size=512,
+        transform=_skewed_transform,
+    )
+    assert len(dataset) == num_items
+
+    dataloader = StreamingDataLoader(dataset, batch_size=1, num_workers=3)
+
+    seen = []
+    for batch in dataloader:
+        seen.extend(int(v) for v in batch)
+
+    assert sorted(seen) == list(range(num_items)), (
+        f"Expected all {num_items} items exactly once; got {len(seen)} items "
+        f"(missing: {sorted(set(range(num_items)) - set(seen))}, "
+        f"duplicated: {sorted({v for v in seen if seen.count(v) > 1})})."
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Not tested on windows")
+def test_multiworker_flaky_remote_shared_chunk_race(tmpdir, monkeypatch):
+    """The distinguishing end-to-end test: fails pre-fix, passes post-fix.
+
+    Same setup as above but over a ``flaky:`` remote that will not re-serve an evicted chunk, and
+    with short timeouts so a lost chunk fails fast. Pre-fix, a non-designated worker deletes a
+    shared chunk that the (slowed) worker 0 still needs and the remote won't give it back ->
+    ``FileNotFoundError``. Post-fix, the shared chunk is protected until its last reader is done.
+    """
+    # Short timeouts so a genuinely lost chunk raises quickly. Patch both the env (spawn workers
+    # re-import and read it) and the already-imported module globals (fork workers inherit them).
+    monkeypatch.setenv(_FLAKY_ENV, "1")
+    monkeypatch.setenv("MAX_WAIT_TIME", "4")
+    monkeypatch.setenv("FORCE_DOWNLOAD_TIME", "1")
+    import litdata.streaming.config as config_mod
+    import litdata.streaming.item_loader as item_loader_mod
+
+    monkeypatch.setattr(item_loader_mod, "_MAX_WAIT_TIME", 4, raising=False)
+    monkeypatch.setattr(item_loader_mod, "_FORCE_DOWNLOAD_TIME", 1, raising=False)
+    monkeypatch.setattr(config_mod, "_MAX_WAIT_TIME", 4, raising=False)
+
+    cache_dir = os.path.join(tmpdir, "cache_dir")
+    data_dir = os.path.join(tmpdir, "data_dir")
+    os.makedirs(cache_dir)
+    os.makedirs(data_dir)
+
+    num_items = 200
+    cache = Cache(str(data_dir), chunk_size=7)
+    for i in range(num_items):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    dataset = StreamingDataset(
+        f"local:{data_dir}",
+        cache_dir=str(cache_dir),
+        shuffle=False,
+        drop_last=False,
+        max_cache_size=512,
+        transform=_skewed_transform,
+    )
+    assert len(dataset) == num_items
+
+    dataloader = StreamingDataLoader(dataset, batch_size=1, num_workers=3)
+
+    seen = []
+    for batch in dataloader:
+        seen.extend(int(v) for v in batch)
+
+    assert sorted(seen) == list(range(num_items)), (
+        f"Lost or duplicated items streaming a shared-chunk dataset over a flaky remote. "
+        f"Missing: {sorted(set(range(num_items)) - set(seen))}."
+    )
+
+
+def _count_files(root, suffix):
+    return sum(1 for dirpath, _, files in os.walk(root) for f in files if f.endswith(suffix))
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Not tested on windows")
+def test_no_refcount_leak_after_full_and_multi_epoch_iteration(tmpdir):
+    """Full iteration (repeated) must leave no ``.cnt`` reference-count files behind.
+
+    Guards the eager-refcount balance: an over-increment would leave ``.cnt`` files (and prevent
+    chunk deletion) that accumulate across epochs.
+    """
+    cache_dir = os.path.join(tmpdir, "cache_dir")
+    data_dir = os.path.join(tmpdir, "data_dir")
+    os.makedirs(cache_dir)
+    os.makedirs(data_dir)
+
+    num_items = 120
+    cache = Cache(str(data_dir), chunk_size=7)
+    for i in range(num_items):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    dataset = StreamingDataset(
+        f"local:{data_dir}", cache_dir=str(cache_dir), shuffle=False, drop_last=False, max_cache_size=512
+    )
+    dataloader = StreamingDataLoader(dataset, batch_size=1, num_workers=3)
+
+    for _ in range(3):  # multiple epochs
+        seen = [int(v) for batch in dataloader for v in batch]
+        assert sorted(seen) == list(range(num_items))
+
+    leftover_cnt = _count_files(cache_dir, ".cnt")
+    assert leftover_cnt == 0, f"Reference-count (.cnt) files leaked after full iteration: {leftover_cnt}"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Not tested on windows")
+def test_reader_teardown_releases_held_shared_locks(tmpdir):
+    """Abandoning a reader mid-epoch (early break) must release its eagerly-acquired locks.
+
+    Without the teardown release, aborted iteration would leak reference counts and permanently
+    prevent those shared chunks from being deleted.
+    """
+    import gc
+
+    from litdata.streaming.reader import BinaryReader
+
+    cache_dir, remote_dir = _build_remote_dataset(tmpdir, num_items=40, chunk_size=4)
+    reader = BinaryReader(cache_dir, remote_input_dir=remote_dir, item_loader=PyTreeLoader())
+    assert reader._try_load_config() is not None
+
+    reader.acquire_shared_locks({0, 1, 2})  # pretend this worker shares chunks 0,1,2
+    assert _count_files(cache_dir, ".cnt") == 3
+
+    # Simulate: worker consumed chunk 0 only, then the loop was broken.
+    reader.config.decrement_local_lock(0)
+    reader._held_shared.discard(0)
+
+    del reader
+    gc.collect()  # triggers BinaryReader.__del__ -> _release_shared_locks()
+
+    leftover = _count_files(cache_dir, ".cnt")
+    assert leftover == 0, f"Held shared-chunk locks leaked after reader teardown: {leftover}"


### PR DESCRIPTION
## Summary

Fixes the intermittent `FileNotFoundError` for missing chunks that several users hit during multi-worker streaming, e.g.:

```
FileNotFoundError: The /cache/chunks/4123a781.../1770957492.65/chunk-59-0.bin hasn't been found.
```

(raised at `item_loader.py::load_item_from_chunk` after the reader waits `MAX_WAIT_TIME` for a chunk that never comes back).

## Why it happened

The shuffler splits a chunk's item interval across worker boundaries (`_associate_chunks_and_intervals_to_workers`), so a single chunk can be assigned to **several workers on the same node**, all reading the **same local chunk file**. To avoid one worker deleting a chunk another still needs, LitData reference-counts each chunk with a `<chunk>.bin.cnt` file and only deletes when the count reaches zero.

The bug: the count was incremented **lazily** — when a worker's prefetch thread *downloaded* the chunk (bounded by `max_pre_download`). Decrement + delete happen when a worker *finishes* a chunk. There was no ordering guarantee between the two across workers:

1. Fast worker **A** downloads shared chunk `X` (count → 1), reads its slice, finishes.
2. **A** decrements (count → 0) and deletes `X.bin` — but slow worker **B**, which also reads `X`, had **not prefetched/incremented it yet**.
3. **B** reaches `X`, the file is gone. On a local disk it is re-downloaded instantly (so this never reproduced locally), but on a **slow/flaky remote (S3)** the re-fetch can't complete within `MAX_WAIT_TIME` → `FileNotFoundError`.

The leftover `chunk-*.zstd.bin.<random>` files users noticed in the cache are `boto3`/`s3transfer` temp files from these interrupted re-download attempts — a symptom, not the cause.

The existing `skip_chunk_indexes_deletion` / `can_delete` guard was **computed but never consulted** in `_apply_delete` (it was only used in a debug string — see the old `# TODO: Fix the can_delete method`), so the reference count was the only active guard, and it raced.

## The fix: eager reference-counting

Reference-count shared chunks **eagerly**, before any reading begins:

- `StreamingDataset.__iter__` computes the set of chunks this worker shares with node-local co-workers (`_get_shared_chunks` over the node's worker slice) and calls `BinaryReader.acquire_shared_locks(...)`.
- `acquire_shared_locks` increments each shared chunk's count **up front**, records them, and re-acquires cleanly each epoch.
- The reader decrements as it finishes each chunk, and **drains any still-held locks on teardown** (`is_last_index` + `__del__`) so early / partial iteration can't leak counts.
- Deletion (`_apply_delete`) gates purely on the count reaching zero. Because every co-reader has incremented **before** any worker can finish and delete, a zero count now provably means "no worker still needs this chunk."

Non-shared chunks keep their original pay-as-you-download refcounting (small blast radius). The lock primitives (`increment_local_lock` / `decrement_local_lock` / `remaining_locks`) moved to `ChunksConfig` so the reader can release locks during teardown without the prefetch thread. The multi-node worker-slice used to derive the shared set is also corrected (`first_rank_this_node * num_workers`, previously overshot by a factor of `node_size`).

## Tests

New `tests/streaming/test_shared_chunk_deletion.py`:

- **`test_multiworker_flaky_remote_shared_chunk_race`** — a real `StreamingDataLoader` (3 workers) over an emulated flaky remote that refuses to re-serve an evicted chunk. **Reproduces the exact `FileNotFoundError` before the fix and passes after.**
- `test_multiworker_dataloader_shared_chunk_not_deleted_early` — full-dataset correctness across workers.
- `test_no_refcount_leak_after_full_and_multi_epoch_iteration` / `test_reader_teardown_releases_held_shared_locks` — the eager counts stay balanced (no `.cnt` leak) across full, multi-epoch, and early-break iteration.
- Unit tests for the lock primitives, refcount-gated deletion, and acquire/release balance.

Also verified with a 1440-config sweep (single + multi-node) that the sharding conserves items, never assigns an item to two workers, and that the shared-set derivation never under-includes a sharing worker (which would reintroduce the lag).

### Verification

- `tests/streaming/test_shared_chunk_deletion.py`: all pass; the flaky-remote test fails on `main`, passes here.
- No regressions: `test_dataset.py` + `test_dataloader.py` (74 passed / 16 skipped), and `test_reader.py` / `test_config.py` / `test_lock_cleanup.py` / `test_shuffle.py` (27 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
