### PR TITLE
perf(streaming): memoize per-chunk metadata on the read hot path

### DIFF
--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -108,6 +108,9 @@ class ChunksConfig:
 
         self._skip_chunk_indexes_deletion: list[int] | None = None
         self.zero_based_roi: list[tuple[int, int]] | None = None
+        # Memoizes ``__getitem__`` results per chunk_index (invariant once the config is loaded);
+        # avoids rebuilding the chunk path on every item read.
+        self._chunk_meta_cache: dict[int, tuple[str, int, int]] = {}
         self.filename_to_size_map: dict[str, int] = {}
         for cnk in _original_chunks:
             # since files downloaded while reading will be decompressed, we need to store the name without compression
@@ -287,7 +290,17 @@ class ChunksConfig:
         )
 
     def __getitem__(self, index: ChunkedIndex) -> tuple[str, int, int]:
-        """Find the associated chunk metadata."""
+        """Find the associated chunk metadata.
+
+        This is called once per item on the read hot path, but its result depends only on
+        ``index.chunk_index`` (the local path, the chunk's begin offset and its byte size are all
+        fixed once the config is loaded). The per-chunk tuple is therefore memoized to avoid
+        rebuilding the path (``os.path.join`` + decompression-suffix stripping) on every item.
+        """
+        cached = self._chunk_meta_cache.get(index.chunk_index)
+        if cached is not None:
+            return cached
+
         assert self._chunks is not None
         chunk = self._chunks[index.chunk_index]
 
@@ -300,7 +313,9 @@ class ChunksConfig:
 
         filesize_bytes = chunk["chunk_bytes"]
 
-        return local_chunkpath, begin, filesize_bytes
+        meta = (local_chunkpath, begin, filesize_bytes)
+        self._chunk_meta_cache[index.chunk_index] = meta
+        return meta
 
     def download_filepath(self, chunk_index: int) -> str:
         """The raw on-disk path that the chunk is downloaded to before any decompression."""

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -69,6 +69,11 @@ class BaseItemLoader(ABC):
             serializer.setup(data_format)
             self._serializers[data_format] = serializer
 
+        # Precompute the per-leaf serializer list and the data spec so the per-item `deserialize`
+        # hot path avoids a dict lookup per leaf and a config lookup per item.
+        self._serializers_list = [self._serializers[data_format] for data_format in self._data_format]
+        self._data_spec = self._config["data_spec"]
+
     def force_download(self, chunk_index: int) -> None:
         if self._force_download_queue:
             self._force_download_queue.put(chunk_index)
@@ -316,12 +321,11 @@ class PyTreeLoader(BaseItemLoader):
         idx = self._shift_idx
         sizes = np.frombuffer(raw_item_data[:idx], np.uint32)
         data = []
-        for size, data_format in zip(sizes, self._data_format):
-            serializer = self._serializers[data_format]
+        for size, serializer in zip(sizes, self._serializers_list):
             data_bytes = raw_item_data[idx : idx + size]
             data.append(serializer.deserialize(data_bytes))
             idx += size
-        return tree_unflatten(data, self._config["data_spec"])
+        return tree_unflatten(data, self._data_spec)
 
     def close(self, chunk_index: int) -> None:
         """Close the open file handle."""


### PR DESCRIPTION
## Summary

Small, safe read-path speedup found by profiling the streaming iteration loop. Two per-item costs turned out to be **invariant per chunk** and are now memoized. No behavioural change.

## How it was found

Profiled a pure local read (no network, `num_workers=0`) with cProfile over `StreamingDataset` + `StreamingDataLoader` iteration. The hottest per-item entries that weren't intrinsic work (deserialize / file IO / pytree) were:

- `posixpath.join` — **40k calls** (one per item) from `ChunksConfig.__getitem__`, even though the chunk path depends only on `chunk_index`.
- serializer dict lookups per leaf and a `config["data_spec"]` lookup per item in `PyTreeLoader.deserialize`.

## Changes

- **`ChunksConfig.__getitem__`** memoizes its `(local_path, begin, filesize)` tuple per `chunk_index`. These are all fixed once the config is loaded (`_cache_dir`, `_chunks`, `_intervals`, `_compressor` never change), so this is a pure lookup cache — no invalidation needed.
- **`BaseItemLoader.setup`** precomputes the per-leaf serializer list and the data spec; `deserialize` uses them instead of re-looking-up a dict per leaf and the config per item.

## Benchmark

Local dataset, 40k items (`{"x": float32[128], "y": int}`), `chunk_size=2000`, `num_workers=0`, median of 5 runs:

| | items/s |
|---|---|
| before | ~104,800 |
| after | ~110,600 |
| | **~+6%** |

The gain is per-item decode CPU, so it helps most when decode-bound (`num_workers=0`, or many workers saturating cores); it won't move an I/O- or GPU-bound run. Reproduced repeatedly; the `posixpath.join` per-item calls disappear from the profile after the change.

## Follow-ups (not in this PR)

The remaining per-item hot spots are the vendored pytree `unflatten` (~16%, deliberately left alone — it mirrors torch's pytree) and the 2 `seek`+2 `read` per item in `_load_data`. A future change could cache each chunk's offset table on open to halve the per-item file syscalls; it touches the core read path so it deserves its own reviewed PR.

## Verification

No regressions: `test_reader.py`, `test_config.py`, `test_item_loader.py`, `test_serializer.py` (48 passed). ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
