### PR TITLE
perf(streaming): tighten downloader↔reader handoff

### DIFF
--- a/scripts/bench_download_reader_overlap.py
+++ b/scripts/bench_download_reader_overlap.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Microbench for PrepareChunksThread ↔ ItemLoader handoff latency.
+
+Compares the current working tree against a baseline (default: origin/main) using
+local ``local:`` streaming so results are PR-ready without cloud credentials.
+
+Metrics:
+1. Prefetch side-poll timeouts when download work can proceed (should be 0.0 after).
+2. ItemLoader wake latency after a delayed chunk publish (ready Event vs 0.1s poll).
+3. End-to-end cold-cache iteration over many tiny remote chunks (handoff-dominated).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import statistics
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Ensure repo src/ is importable when run from a worktree or checkout.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+
+def _p50_p95(samples: list[float]) -> tuple[float, float]:
+    if not samples:
+        return float("nan"), float("nan")
+    ordered = sorted(samples)
+    n = len(ordered)
+    p50 = ordered[n // 2] if n % 2 else 0.5 * (ordered[n // 2 - 1] + ordered[n // 2])
+    idx95 = min(n - 1, max(0, int(round(0.95 * (n - 1)))))
+    return p50, ordered[idx95]
+
+
+def bench_prefetch_side_timeouts() -> dict[str, float]:
+    """Return force/delete poll timeouts observed while the prefetch buffer can accept work."""
+    from litdata.streaming.config import ChunksConfig
+    from litdata.streaming.reader import _DEFAULT_TIMEOUT, PrepareChunksThread
+    from litdata.utilities.env import _DistributedEnv
+
+    cache_dir = tempfile.mkdtemp(prefix="litdata-bench-prefetch-")
+    try:
+        config = MagicMock(spec=ChunksConfig)
+        config.num_bytes = 1024
+        config._cache_dir = cache_dir
+        config.download_chunk_from_index = MagicMock()
+        item_loader = MagicMock()
+        env = _DistributedEnv(1, 0, 1)
+        thread = PrepareChunksThread(config, item_loader, env, max_cache_size=10_000, max_pre_download=2)
+        observed: list[float] = []
+
+        def fake_force(timeout: float = _DEFAULT_TIMEOUT) -> None:
+            observed.append(timeout)
+
+        def fake_delete(timeout: float = _DEFAULT_TIMEOUT) -> None:
+            observed.append(timeout)
+            thread._force_stop_event.set()
+
+        thread._force_download = fake_force  # type: ignore[method-assign]
+        thread._maybe_delete_chunks = fake_delete  # type: ignore[method-assign]
+        thread.run()
+        return {
+            "force_timeout_s": observed[0] if observed else float("nan"),
+            "delete_timeout_s": observed[1] if len(observed) > 1 else float("nan"),
+        }
+    finally:
+        shutil.rmtree(cache_dir, ignore_errors=True)
+
+
+def bench_item_loader_wake(n_trials: int = 20, delay_s: float = 0.05) -> dict[str, float]:
+    """Measure how long load_item_from_chunk waits for a chunk published after ``delay_s``."""
+    from litdata.streaming import Cache
+    from litdata.streaming.dataset import StreamingDataset
+    from litdata.streaming.item_loader import PyTreeLoader
+    from litdata.streaming.sampler import ChunkedIndex
+
+    root = tempfile.mkdtemp(prefix="litdata-bench-wake-")
+    try:
+        cache = Cache(root, chunk_size=2)
+        for i in range(4):
+            cache[i] = i
+        cache.done()
+        cache.merge()
+
+        dataset = StreamingDataset(root)
+        _ = dataset[0]
+        loader = dataset.cache._reader._item_loader
+        assert isinstance(loader, PyTreeLoader)
+        chunk_filepath, begin, filesize = dataset.cache._reader.config[ChunkedIndex(2, chunk_index=1)]
+
+        samples: list[float] = []
+        for _ in range(n_trials):
+            # Reset open-chunk state so the wait path runs every trial.
+            loader._close_open_chunk()
+            loader._chunk_filepath = None
+
+            hidden = chunk_filepath + ".hidden"
+            os.rename(chunk_filepath, hidden)
+            ready = threading.Event()
+            # Prefer the ready-provider path when available (this branch); otherwise plain poll.
+            if hasattr(loader, "set_chunk_ready_provider"):
+                loader.set_chunk_ready_provider(lambda _idx: ready)
+
+            def restore_and_signal() -> None:
+                time.sleep(delay_s)
+                os.rename(hidden, chunk_filepath)
+                ready.set()
+
+            threading.Thread(target=restore_and_signal, daemon=True).start()
+            t0 = time.perf_counter()
+            item = loader.load_item_from_chunk(2, 1, chunk_filepath, begin, filesize)
+            elapsed = time.perf_counter() - t0
+            assert item == 2
+            samples.append(elapsed)
+
+        p50, p95 = _p50_p95(samples)
+        return {
+            "trials": float(n_trials),
+            "delay_s": delay_s,
+            "wake_p50_s": p50,
+            "wake_p95_s": p95,
+            "wake_mean_s": statistics.fmean(samples),
+            "has_ready_provider": float(hasattr(loader, "set_chunk_ready_provider")),
+        }
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def bench_e2e_local_remote(num_items: int = 400, chunk_size: int = 4, repeats: int = 3) -> dict[str, float]:
+    """Cold-cache StreamingDataset iteration over a local: remote with many small chunks."""
+    from litdata.streaming import Cache
+    from litdata.streaming.dataset import StreamingDataset
+
+    samples: list[float] = []
+    for _ in range(repeats):
+        root = tempfile.mkdtemp(prefix="litdata-bench-e2e-")
+        try:
+            data_dir = os.path.join(root, "data")
+            cache_dir = os.path.join(root, "cache")
+            os.makedirs(data_dir)
+            os.makedirs(cache_dir)
+            cache = Cache(data_dir, chunk_size=chunk_size)
+            for i in range(num_items):
+                cache[i] = i
+            cache.done()
+            cache.merge()
+
+            dataset = StreamingDataset(f"local:{data_dir}", cache_dir=cache_dir, shuffle=False, drop_last=False)
+            t0 = time.perf_counter()
+            total = 0
+            for item in dataset:
+                total += int(item)
+            elapsed = time.perf_counter() - t0
+            assert total == sum(range(num_items))
+            samples.append(elapsed)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    p50, p95 = _p50_p95(samples)
+    return {
+        "num_items": float(num_items),
+        "chunk_size": float(chunk_size),
+        "num_chunks": float((num_items + chunk_size - 1) // chunk_size),
+        "repeats": float(repeats),
+        "e2e_p50_s": p50,
+        "e2e_p95_s": p95,
+        "e2e_mean_s": statistics.fmean(samples),
+        "items_per_s": num_items / statistics.fmean(samples),
+    }
+
+
+def main() -> int:
+    """Run the microbench suite and print labeled results."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--label", default="current", help="Label printed with the results")
+    parser.add_argument("--wake-trials", type=int, default=20)
+    parser.add_argument("--wake-delay", type=float, default=0.05)
+    parser.add_argument("--e2e-items", type=int, default=400)
+    parser.add_argument("--e2e-chunk-size", type=int, default=4)
+    parser.add_argument("--e2e-repeats", type=int, default=3)
+    args = parser.parse_args()
+
+    print(f"=== bench_download_reader_overlap ({args.label}) ===")
+    print(f"repo: {REPO_ROOT}")
+    print(f"python: {sys.executable}")
+
+    side = bench_prefetch_side_timeouts()
+    print(f"prefetch_side_timeouts: force={side['force_timeout_s']:.3f}s delete={side['delete_timeout_s']:.3f}s")
+
+    wake = bench_item_loader_wake(n_trials=args.wake_trials, delay_s=args.wake_delay)
+    print(
+        "item_loader_wake: "
+        f"p50={wake['wake_p50_s'] * 1000:.1f}ms p95={wake['wake_p95_s'] * 1000:.1f}ms "
+        f"mean={wake['wake_mean_s'] * 1000:.1f}ms "
+        f"(delay={wake['delay_s'] * 1000:.0f}ms, ready_provider={bool(wake['has_ready_provider'])})"
+    )
+
+    e2e = bench_e2e_local_remote(num_items=args.e2e_items, chunk_size=args.e2e_chunk_size, repeats=args.e2e_repeats)
+    print(
+        "e2e_local_remote: "
+        f"p50={e2e['e2e_p50_s']:.3f}s p95={e2e['e2e_p95_s']:.3f}s mean={e2e['e2e_mean_s']:.3f}s "
+        f"({e2e['items_per_s']:.0f} items/s, {int(e2e['num_chunks'])} chunks)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -264,37 +264,58 @@ class ChunksConfig:
         if os.path.exists(target_local_chunkpath):
             return
 
-        # Ensure that the compressed file exists and is fully downloaded
+        # Wait until either the decompressed target appears (another worker finished) or the
+        # compressed source exists. Cloud downloaders publish the compressed path atomically, so
+        # existence of that path means the download is complete — do NOT use chunk_size (item
+        # count) as a byte threshold.
         start_time = time()
-        assert self._chunks is not None
-
-        filename = os.path.basename(local_chunkpath)
-        chunk_index = self._get_chunk_index_from_filename(filename)
-        chunk_bytes = self._chunks[chunk_index]["chunk_size"]
-        exists = os.path.exists(local_chunkpath) and os.stat(local_chunkpath).st_size >= chunk_bytes
-        while not exists:
+        while not os.path.exists(local_chunkpath) and not os.path.exists(target_local_chunkpath):
             sleep(0.1)
-            # Return if the actual file exists
-            if os.path.exists(target_local_chunkpath):
-                return
-            # find the local compressed file
-            exists = os.path.exists(local_chunkpath) and os.stat(local_chunkpath).st_size >= chunk_bytes
-
             if (time() - start_time) > _MAX_WAIT_TIME:
                 raise FileNotFoundError(f"The {local_chunkpath} hasn't been found.")
 
-        with open(local_chunkpath, "rb") as f:
-            data = f.read()
+        if os.path.exists(target_local_chunkpath):
+            return
 
-        # delete the files only if they were downloaded
-        if self._downloader is not None:
-            with contextlib.suppress(FileNotFoundError):
-                os.remove(local_chunkpath)
+        decompress_lock = target_local_chunkpath + ".decompress.lock"
+        try:
+            with FileLock(decompress_lock, timeout=_MAX_WAIT_TIME):
+                if os.path.exists(target_local_chunkpath):
+                    return
 
-        data = self._compressor.decompress(data)
+                with open(local_chunkpath, "rb") as f:
+                    data = f.read()
 
-        with open(target_local_chunkpath, "wb") as f:
-            f.write(data)
+                # delete the compressed file only if it was downloaded
+                if self._downloader is not None:
+                    with contextlib.suppress(FileNotFoundError):
+                        os.remove(local_chunkpath)
+
+                data = self._compressor.decompress(data)
+
+                assert self._chunks is not None
+                filename = os.path.basename(local_chunkpath)
+                chunk_index = self._get_chunk_index_from_filename(filename)
+                expected_bytes = int(self._chunks[chunk_index]["chunk_bytes"])
+
+                tmp_path = f"{target_local_chunkpath}.tmp.{os.getpid()}"
+                try:
+                    with open(tmp_path, "wb") as f:
+                        f.write(data)
+                    if os.stat(tmp_path).st_size < expected_bytes:
+                        raise OSError(
+                            f"Decompressed chunk {target_local_chunkpath} is smaller than expected "
+                            f"({os.stat(tmp_path).st_size} < {expected_bytes})."
+                        )
+                    os.replace(tmp_path, target_local_chunkpath)
+                except Exception:
+                    with contextlib.suppress(FileNotFoundError, PermissionError):
+                        os.remove(tmp_path)
+                    raise
+        finally:
+            # FileLock leaves its lock file behind; remove after release.
+            with contextlib.suppress(Exception):
+                os.remove(decompress_lock)
 
     @property
     def intervals(self) -> list[Interval]:

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -87,6 +87,16 @@ class Downloader(ABC):
     def download_file(self, remote_chunkpath: str, local_chunkpath: str) -> None:
         pass
 
+    @staticmethod
+    def _temp_download_path(local_filepath: str) -> str:
+        """Return a process-unique temp path used for atomic downloads."""
+        return f"{local_filepath}.tmp.{os.getpid()}"
+
+    @staticmethod
+    def _atomic_replace(tmp_path: str, local_filepath: str) -> None:
+        """Publish a completed download by atomically replacing the destination path."""
+        os.replace(tmp_path, local_filepath)
+
     def download_bytes(self, remote_chunkpath: str, offset: int, length: int, local_chunkpath: str) -> bytes:
         """Download a specific range of bytes from the remote file.
 
@@ -141,13 +151,22 @@ class S3Downloader(Downloader):
 
             if not os.path.exists(local_filepath):
                 # Issue: https://github.com/boto/boto3/issues/3113
-                self._client.client.download_file(
-                    obj.netloc,
-                    obj.path.lstrip("/"),
-                    local_filepath,
-                    ExtraArgs=extra_args,
-                    Config=TransferConfig(use_threads=False),
-                )
+                # Download to a temp path then atomically replace so co-workers never observe a
+                # partial final file.
+                tmp_path = self._temp_download_path(local_filepath)
+                try:
+                    self._client.client.download_file(
+                        obj.netloc,
+                        obj.path.lstrip("/"),
+                        tmp_path,
+                        ExtraArgs=extra_args,
+                        Config=TransferConfig(use_threads=False),
+                    )
+                    self._atomic_replace(tmp_path, local_filepath)
+                except Exception:
+                    with suppress(FileNotFoundError, PermissionError):
+                        os.remove(tmp_path)
+                    raise
 
     def download_bytes(self, remote_filepath: str, offset: int, length: int, local_chunkpath: str) -> bytes:
         obj = parse.urlparse(remote_filepath)
@@ -252,13 +271,20 @@ class R2Downloader(Downloader):
             if not os.path.exists(local_filepath):
                 # Issue: https://github.com/boto/boto3/issues/3113
                 t0 = time()
-                self._client.client.download_file(
-                    obj.netloc,
-                    obj.path.lstrip("/"),
-                    local_filepath,
-                    ExtraArgs=extra_args,
-                    Config=TransferConfig(use_threads=False),
-                )
+                tmp_path = self._temp_download_path(local_filepath)
+                try:
+                    self._client.client.download_file(
+                        obj.netloc,
+                        obj.path.lstrip("/"),
+                        tmp_path,
+                        ExtraArgs=extra_args,
+                        Config=TransferConfig(use_threads=False),
+                    )
+                    self._atomic_replace(tmp_path, local_filepath)
+                except Exception:
+                    with suppress(FileNotFoundError, PermissionError):
+                        os.remove(tmp_path)
+                    raise
                 if _DEBUG:
                     print("DOWNLOAD TIME", time() - t0)
 
@@ -372,7 +398,14 @@ class GCPDownloader(Downloader):
             client = storage.Client(**self._storage_options)
             bucket = client.bucket(bucket_name)
             blob = bucket.blob(key)
-            blob.download_to_filename(local_filepath)
+            tmp_path = self._temp_download_path(local_filepath)
+            try:
+                blob.download_to_filename(tmp_path)
+                self._atomic_replace(tmp_path, local_filepath)
+            except Exception:
+                with suppress(FileNotFoundError, PermissionError):
+                    os.remove(tmp_path)
+                raise
 
     def download_bytes(self, remote_filepath: str, offset: int, length: int, local_chunkpath: str) -> bytes:
         from google.cloud import storage
@@ -480,9 +513,16 @@ class AzureDownloader(Downloader):
 
             service = BlobServiceClient(**self._storage_options)
             blob_client = service.get_blob_client(container=obj.netloc, blob=obj.path.lstrip("/"))
-            with open(local_filepath, "wb") as download_file:
-                blob_data = blob_client.download_blob()
-                blob_data.readinto(download_file)
+            tmp_path = self._temp_download_path(local_filepath)
+            try:
+                with open(tmp_path, "wb") as download_file:
+                    blob_data = blob_client.download_blob()
+                    blob_data.readinto(download_file)
+                self._atomic_replace(tmp_path, local_filepath)
+            except Exception:
+                with suppress(FileNotFoundError, PermissionError):
+                    os.remove(tmp_path)
+                raise
 
     def download_fileobj(self, remote_filepath: str, fileobj: Any) -> None:
         """Download a file from Azure Blob Storage directly to a file-like object."""

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -17,10 +17,12 @@ import os
 import struct
 from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
+from collections.abc import Callable
 from copy import deepcopy
 from datetime import datetime
 from io import BytesIO, FileIO
 from multiprocessing import Queue
+from threading import Event
 from time import sleep, time
 from typing import Any
 
@@ -161,6 +163,8 @@ class BaseItemLoader(ABC):
         self._shift_idx = len(self._data_format) * 4  # each item takes 4 bytes
         self.region_of_interest = region_of_interest
         self._force_download_queue = force_download_queue
+        # Optional provider of per-chunk readiness Events from PrepareChunksThread.
+        self._chunk_ready_provider: Callable[[int], Event] | None = getattr(self, "_chunk_ready_provider", None)
 
         # setup the serializers on restart
         for data_format in self._data_format:
@@ -192,6 +196,55 @@ class BaseItemLoader(ABC):
         co-worker may delete/replace while it is mapped can crash with SIGSEGV (see issues #459,
         #756), so only non-shared chunks are mapped.
         """
+
+    def set_chunk_ready_provider(self, provider: Callable[[int], Event] | None) -> None:
+        """Install a provider of per-chunk readiness Events from the prefetch thread."""
+        self._chunk_ready_provider = provider
+
+    def _wait_until_chunk_ready(self, chunk_index: int, chunk_filepath: str, filesize_bytes: int) -> None:
+        """Block until ``chunk_filepath`` exists and is at least ``filesize_bytes``.
+
+        Prefers the in-process readiness Event (set by ``PrepareChunksThread`` after download /
+        decompress) and falls back to a short filesystem poll so co-worker downloads still work.
+
+        If a readiness Event is already set but the file is missing (e.g. the chunk was deleted
+        after a prior download), clear the Event and sleep so we do not busy-spin and starve the
+        prefetch thread under the GIL.
+        """
+        start_time = time()
+        requested_force_download = False
+
+        while True:
+            if os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes:
+                return
+
+            if self._chunk_ready_provider is not None:
+                event = self._chunk_ready_provider(chunk_index)
+                signaled = event.wait(timeout=0.1)
+                # Stale signal: chunk was ready once, then deleted / not yet re-published.
+                if signaled and not (
+                    os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes
+                ):
+                    event.clear()
+                    sleep(0.1)
+            else:
+                sleep(0.1)
+
+            if not requested_force_download and (time() - start_time) > _FORCE_DOWNLOAD_TIME:
+                if _DEBUG:
+                    print(f"[ItemLoader] Requested force download for {chunk_filepath} at {datetime.now().isoformat()}")
+                self.force_download(chunk_index)
+                requested_force_download = True
+
+            if (time() - start_time) > _MAX_WAIT_TIME:
+                raise FileNotFoundError(f"The {chunk_filepath} hasn't been found.")
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        # Prefetch-thread handles are process-local and reattached after worker spawn.
+        state["_chunk_ready_provider"] = None
+        state["_force_download_queue"] = None
+        return state
 
     @functools.lru_cache(maxsize=128)
     def _data_format_to_key(self, data_format: str) -> str:
@@ -333,24 +386,7 @@ class PyTreeLoader(BaseItemLoader):
 
         if chunk_filepath != self._chunk_filepath:
             start_time = time()
-            exists = os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes
-            requested_force_download = False
-
-            while not exists:
-                sleep(0.1)
-                exists = os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes
-
-                if not requested_force_download and (time() - start_time) > _FORCE_DOWNLOAD_TIME:
-                    if _DEBUG:
-                        print(
-                            f"[ItemLoader] Requested force download for {chunk_filepath} "
-                            f"at {datetime.now().isoformat()}"
-                        )
-                    self.force_download(chunk_index)
-                    requested_force_download = True
-
-                if (time() - start_time) > _MAX_WAIT_TIME:
-                    raise FileNotFoundError(f"The {chunk_filepath} hasn't been found.")
+            self._wait_until_chunk_ready(chunk_index, chunk_filepath, filesize_bytes)
 
             if _DEBUG and time() - start_time > 5:
                 print("WAIT TIME", time() - start_time)
@@ -566,8 +602,8 @@ class PyTreeLoader(BaseItemLoader):
         body = b"".join(data)
         return head + body, None
 
-    def __getstate__(self):
-        state = self.__dict__.copy()
+    def __getstate__(self) -> dict[str, Any]:
+        state = super().__getstate__()
         # File handle / memory-map are per-process and not picklable; lazily re-created on the
         # first read in the receiving process.
         state["_open_handle"] = None
@@ -684,22 +720,7 @@ class TokensLoader(BaseItemLoader):
             del self._chunk_filepaths[chunk_filepath]
 
         if chunk_filepath not in self._chunk_filepaths:
-            exists = os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size > filesize_bytes
-
-            start_time = time()
-            requested_force_download = False
-
-            while not exists:
-                sleep(0.1)
-                exists = os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes
-
-                if not requested_force_download and (time() - start_time) > _FORCE_DOWNLOAD_TIME:
-                    self.force_download(chunk_index)
-                    requested_force_download = True
-
-                if (time() - start_time) > _MAX_WAIT_TIME:
-                    raise FileNotFoundError(f"The {chunk_filepath} hasn't been found.")
-
+            self._wait_until_chunk_ready(chunk_index, chunk_filepath, filesize_bytes)
             self._chunk_filepaths[chunk_filepath] = True
 
         self._load_chunk(chunk_index, chunk_filepath)

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -18,7 +18,7 @@ import warnings
 from contextlib import suppress
 from datetime import datetime
 from queue import Empty, Queue
-from threading import Event, Thread
+from threading import Event, Lock, Thread
 from typing import Any
 
 import numpy as np
@@ -77,6 +77,10 @@ class PrepareChunksThread(Thread):
         # TODO: Find a real fix to this problem
         self._force_download_queue: Queue = Queue()
 
+        # Per-chunk readiness signals for the in-process item-loader wait loop.
+        self._chunk_ready: dict[int, Event] = {}
+        self._chunk_ready_lock = Lock()
+
         self._rank = rank
 
         # Check whether a dataset slice fits on the node
@@ -87,6 +91,26 @@ class PrepareChunksThread(Thread):
             print(f"Delete chunks when used: {self._delete_chunks_when_processed}")
 
         self._has_exited = False
+
+    def get_ready_event(self, chunk_index: int) -> Event:
+        """Return (creating if needed) the readiness event for ``chunk_index``."""
+        with self._chunk_ready_lock:
+            event = self._chunk_ready.get(chunk_index)
+            if event is None:
+                event = Event()
+                self._chunk_ready[chunk_index] = event
+            return event
+
+    def mark_chunk_ready(self, chunk_index: int) -> None:
+        """Signal that ``chunk_index`` is fully downloaded (and decompressed if needed)."""
+        self.get_ready_event(chunk_index).set()
+
+    def clear_chunk_ready(self, chunk_index: int) -> None:
+        """Clear readiness after a chunk is deleted so waiters block for the next download."""
+        with self._chunk_ready_lock:
+            event = self._chunk_ready.get(chunk_index)
+            if event is not None:
+                event.clear()
 
     def download(self, chunk_indexes: list[int]) -> None:
         """Receive the list of the chunk indices to download for the current epoch."""
@@ -171,6 +195,7 @@ class PrepareChunksThread(Thread):
         except (FileNotFoundError, PermissionError) as e:
             logger.debug(f"_apply_delete({chunk_index}): could not remove data file: {e}")
 
+        self.clear_chunk_ready(chunk_index)
         self._cleanup_download_locks(chunk_filepath, chunk_index)
 
     def stop(self) -> None:
@@ -180,13 +205,10 @@ class PrepareChunksThread(Thread):
     def force_stop(self) -> None:
         self._force_stop_event.set()
 
-    def _maybe_delete_chunks(self) -> None:
-        reached_pre_download = self._pre_download_counter == self._max_pre_download
-
-        # we have already pre-downloaded some chunks, we just need to wait for them to be processed.
-        chunk_index = _get_from_queue(
-            self._to_delete_queue, timeout=_LONG_DEFAULT_TIMEOUT if reached_pre_download else _DEFAULT_TIMEOUT
-        )
+    def _maybe_delete_chunks(self, timeout: float = _DEFAULT_TIMEOUT) -> None:
+        # When the prefetch buffer is full we still use a short timeout so force-download
+        # requests are not starved behind a multi-second delete-queue wait.
+        chunk_index = _get_from_queue(self._to_delete_queue, timeout=timeout)
 
         if chunk_index is None:
             return
@@ -214,8 +236,8 @@ class PrepareChunksThread(Thread):
         chunk_filepath, _, _ = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
         self._item_loader.pre_load_chunk(chunk_index, chunk_filepath)
 
-    def _force_download(self) -> None:
-        chunk_index = _get_from_queue(self._force_download_queue)
+    def _force_download(self, timeout: float = _DEFAULT_TIMEOUT) -> None:
+        chunk_index = _get_from_queue(self._force_download_queue, timeout=timeout)
         if chunk_index is None:
             return
 
@@ -227,6 +249,7 @@ class PrepareChunksThread(Thread):
                 # request was processed, so double check that it still needs
                 # downloading before we delete it.
                 if os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes:
+                    self.mark_chunk_ready(chunk_index)
                     return
 
                 # force apply deletion before redownload
@@ -238,6 +261,7 @@ class PrepareChunksThread(Thread):
                     )
 
             self._config.download_chunk_from_index(chunk_index, skip_lock=True)
+            self.mark_chunk_ready(chunk_index)
         except Timeout:
             # Another worker is actively downloading this chunk. Defer to them.
             return
@@ -256,18 +280,27 @@ class PrepareChunksThread(Thread):
                 self._has_exited = True
                 return
 
-            self._force_download()
+            can_download_more = self._pre_download_counter < self._max_pre_download
+            # Non-blocking force/delete polls while download work can still proceed, so we do not
+            # pay ~0.2s of empty-queue sleep per chunk. When the prefetch buffer is full, keep a
+            # short timeout so force-download requests are not blocked behind a long delete wait.
+            side_timeout = 0.0 if can_download_more else _DEFAULT_TIMEOUT
 
-            if self._pre_download_counter < self._max_pre_download:
+            self._force_download(timeout=side_timeout)
+
+            if can_download_more:
                 chunk_index = _get_from_queue(self._to_download_queue)
                 if chunk_index == _END_TOKEN:
                     if self._max_cache_size:
-                        self._maybe_delete_chunks()
+                        self._maybe_delete_chunks(timeout=_DEFAULT_TIMEOUT)
                     self._has_exited = True
                     return
 
                 if chunk_index is not None:
                     self._config.download_chunk_from_index(chunk_index)
+                    chunk_filepath, _, filesize_bytes = self._config[ChunkedIndex(index=-1, chunk_index=chunk_index)]
+                    if os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes:
+                        self.mark_chunk_ready(chunk_index)
 
                     # Preload item if possible to gain some time but only
                     # if this is one of the pre-downloaded chunk
@@ -278,7 +311,7 @@ class PrepareChunksThread(Thread):
                     self._pre_download_counter += 1
 
             if self._max_cache_size:
-                self._maybe_delete_chunks()
+                self._maybe_delete_chunks(timeout=side_timeout)
 
 
 # The BinaryReader operates as the inverse of the data optimization process:
@@ -428,8 +461,9 @@ class BinaryReader:
                     self._max_pre_download,
                     self._rank,
                 )
-                # Attach the force download queue
+                # Attach the force download queue and readiness signals used by the item loader wait loop.
                 self._item_loader._force_download_queue = self._prepare_thread._force_download_queue  # type: ignore
+                self._item_loader.set_chunk_ready_provider(self._prepare_thread.get_ready_event)
                 self._prepare_thread.start()
                 if index.chunk_indexes:
                     self._prepare_thread.download(index.chunk_indexes)

--- a/tests/streaming/test_download_reader_overlap.py
+++ b/tests/streaming/test_download_reader_overlap.py
@@ -1,0 +1,258 @@
+"""Tests for PrepareChunksThread ↔ ItemLoader handoff optimizations."""
+
+from __future__ import annotations
+
+import os
+import threading
+from time import perf_counter, sleep
+from unittest.mock import MagicMock
+
+import pytest
+
+from litdata.constants import _ZSTD_AVAILABLE
+from litdata.streaming import Cache
+from litdata.streaming.config import ChunksConfig
+from litdata.streaming.dataset import StreamingDataset
+from litdata.streaming.downloader import S3Downloader
+from litdata.streaming.item_loader import PyTreeLoader
+from litdata.streaming.reader import _DEFAULT_TIMEOUT, PrepareChunksThread
+from litdata.utilities.env import _DistributedEnv
+
+
+def test_prefetch_side_polls_are_nonblocking_when_download_work_available(monkeypatch, tmpdir):
+    """Force/delete polls must use timeout=0 while the prefetch buffer can still accept downloads."""
+    cache_dir = str(tmpdir / "cache")
+    os.makedirs(cache_dir)
+    config = MagicMock(spec=ChunksConfig)
+    config.num_bytes = 1024
+    config._cache_dir = cache_dir
+    config.download_chunk_from_index = MagicMock()
+    item_loader = MagicMock()
+    env = _DistributedEnv(1, 0, 1)
+
+    thread = PrepareChunksThread(config, item_loader, env, max_cache_size=10_000, max_pre_download=2)
+    observed: list[tuple[str, float]] = []
+
+    def fake_force(timeout: float = _DEFAULT_TIMEOUT) -> None:
+        observed.append(("force", timeout))
+
+    def fake_delete(timeout: float = _DEFAULT_TIMEOUT) -> None:
+        observed.append(("delete", timeout))
+        # Stop after first loop body so the test does not spin forever.
+        thread._force_stop_event.set()
+
+    monkeypatch.setattr(thread, "_force_download", fake_force)
+    monkeypatch.setattr(thread, "_maybe_delete_chunks", fake_delete)
+    # Keep download queue empty so `_get_from_queue` returns quickly with default timeout,
+    # but counter is still below max so side polls should be non-blocking.
+    thread.run()
+
+    assert ("force", 0.0) in observed
+    assert ("delete", 0.0) in observed
+
+
+def test_prefetch_side_polls_use_short_timeout_when_buffer_full(monkeypatch, tmpdir):
+    cache_dir = str(tmpdir / "cache")
+    os.makedirs(cache_dir)
+    config = MagicMock(spec=ChunksConfig)
+    config.num_bytes = 1024
+    config._cache_dir = cache_dir
+    item_loader = MagicMock()
+    env = _DistributedEnv(1, 0, 1)
+
+    thread = PrepareChunksThread(config, item_loader, env, max_cache_size=10_000, max_pre_download=2)
+    thread._pre_download_counter = 2  # buffer full
+    observed: list[tuple[str, float]] = []
+
+    def fake_force(timeout: float = _DEFAULT_TIMEOUT) -> None:
+        observed.append(("force", timeout))
+
+    def fake_delete(timeout: float = _DEFAULT_TIMEOUT) -> None:
+        observed.append(("delete", timeout))
+        thread._force_stop_event.set()
+
+    monkeypatch.setattr(thread, "_force_download", fake_force)
+    monkeypatch.setattr(thread, "_maybe_delete_chunks", fake_delete)
+    thread.run()
+
+    assert ("force", _DEFAULT_TIMEOUT) in observed
+    assert ("delete", _DEFAULT_TIMEOUT) in observed
+    assert all(timeout != 5 for _, timeout in observed)
+
+
+def test_item_loader_unblocks_on_ready_event(tmpdir):
+    """load_item_from_chunk should wake from the ready Event without a long busy-wait."""
+    cache = Cache(str(tmpdir), chunk_size=2)
+    for i in range(4):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    dataset = StreamingDataset(str(tmpdir))
+    _ = dataset[0]
+    loader = dataset.cache._reader._item_loader
+    assert isinstance(loader, PyTreeLoader)
+
+    from litdata.streaming.sampler import ChunkedIndex
+
+    chunk_filepath, begin, filesize = dataset.cache._reader.config[ChunkedIndex(2, chunk_index=1)]
+    # Hide the file and install a readiness Event that becomes ready shortly.
+    hidden = chunk_filepath + ".hidden"
+    os.rename(chunk_filepath, hidden)
+    ready = threading.Event()
+    loader.set_chunk_ready_provider(lambda _idx: ready)
+
+    def restore_and_signal() -> None:
+        sleep(0.05)
+        os.rename(hidden, chunk_filepath)
+        ready.set()
+
+    threading.Thread(target=restore_and_signal, daemon=True).start()
+    t0 = perf_counter()
+    item = loader.load_item_from_chunk(2, 1, chunk_filepath, begin, filesize)
+    elapsed = perf_counter() - t0
+    assert item == 2
+    # Should return well under the old 0.1s poll granularity * multiple iterations.
+    assert elapsed < 1.0
+
+
+def test_item_loader_clears_stale_ready_event(tmpdir):
+    """A readiness Event left set after deletion must not busy-spin the wait loop."""
+    cache = Cache(str(tmpdir), chunk_size=2)
+    for i in range(4):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    dataset = StreamingDataset(str(tmpdir))
+    _ = dataset[0]
+    loader = dataset.cache._reader._item_loader
+    assert isinstance(loader, PyTreeLoader)
+
+    from litdata.streaming.sampler import ChunkedIndex
+
+    chunk_filepath, begin, filesize = dataset.cache._reader.config[ChunkedIndex(2, chunk_index=1)]
+    hidden = chunk_filepath + ".hidden"
+    os.rename(chunk_filepath, hidden)
+
+    ready = threading.Event()
+    ready.set()  # stale: previously ready, file now missing
+    loader.set_chunk_ready_provider(lambda _idx: ready)
+
+    def restore_after_clear() -> None:
+        # Wait until the loader clears the stale signal, then restore + re-signal.
+        for _ in range(50):
+            if not ready.is_set():
+                break
+            sleep(0.02)
+        os.rename(hidden, chunk_filepath)
+        ready.set()
+
+    threading.Thread(target=restore_after_clear, daemon=True).start()
+    item = loader.load_item_from_chunk(2, 1, chunk_filepath, begin, filesize)
+    assert item == 2
+    assert ready.is_set()
+
+
+def test_s3_downloader_does_not_publish_partial_final_path(monkeypatch, tmpdir):
+    """Atomic rename means readers never see a truncated final path mid-download."""
+    from litdata.streaming import downloader as downloader_mod
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.client = self
+
+        def download_file(self, bucket, key, filename, ExtraArgs=None, Config=None):
+            # Simulate a slow write: create a partial file, pause, then finish.
+            with open(filename, "wb") as f:
+                f.write(b"partial")
+                f.flush()
+                sleep(0.05)
+                f.write(b"-complete")
+
+    monkeypatch.setattr(downloader_mod, "S3Client", FakeClient)
+    local_filepath = os.path.join(tmpdir, "chunk.bin")
+    seen_final_sizes: list[int] = []
+    stop = threading.Event()
+
+    def watcher() -> None:
+        while not stop.is_set():
+            if os.path.exists(local_filepath):
+                seen_final_sizes.append(os.stat(local_filepath).st_size)
+            sleep(0.005)
+
+    t = threading.Thread(target=watcher, daemon=True)
+    t.start()
+    try:
+        dl = S3Downloader("s3://bucket", str(tmpdir), [])
+        dl.download_file("s3://bucket/chunk.bin", local_filepath)
+    finally:
+        stop.set()
+        t.join(timeout=1)
+
+    assert os.path.exists(local_filepath)
+    with open(local_filepath, "rb") as f:
+        assert f.read() == b"partial-complete"
+    # Final path should only ever appear at the completed size (never "partial" alone).
+    assert all(size == len(b"partial-complete") for size in seen_final_sizes)
+
+
+@pytest.mark.skipif(not _ZSTD_AVAILABLE, reason="Requires: ['zstd']")
+def test_try_decompress_publishes_complete_bin(tmpdir):
+    """try_decompress must publish a .bin that satisfies chunk_bytes after atomic replace."""
+    import shutil
+
+    from litdata.streaming.serializers import _get_serializers
+
+    cache_dir = str(tmpdir / "cache")
+    os.makedirs(cache_dir)
+    cache = Cache(cache_dir, chunk_size=10, compression="zstd")
+    for i in range(10):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    compressed = [f for f in os.listdir(cache_dir) if f.endswith(".zstd.bin")][0]
+    compressed_path = os.path.join(cache_dir, compressed)
+    target_path = compressed_path.replace(".zstd.bin", ".bin")
+    backup_path = compressed_path + ".bak"
+    shutil.copy(compressed_path, backup_path)
+    if os.path.exists(target_path):
+        os.remove(target_path)
+
+    config = ChunksConfig.load(cache_dir, _get_serializers({}), None)
+    # try_decompress may delete the compressed source; restore from backup for a clean call.
+    if not os.path.exists(compressed_path):
+        shutil.copy(backup_path, compressed_path)
+    config.try_decompress(compressed_path)
+    assert os.path.exists(target_path)
+    chunk_index = config._get_chunk_index_from_filename(compressed)
+    assert os.stat(target_path).st_size >= int(config._chunks[chunk_index]["chunk_bytes"])
+
+
+def test_tokens_loader_accepts_exact_filesize(tmpdir):
+    """Exact-size chunk files must be considered ready (not strictly greater)."""
+    from litdata.streaming.item_loader import BaseItemLoader
+
+    class _Loader(BaseItemLoader):
+        def generate_intervals(self):
+            return []
+
+        def pre_load_chunk(self, chunk_index, chunk_filepath):
+            return None
+
+        def load_item_from_chunk(self, index, chunk_index, chunk_filepath, begin, filesize_bytes):
+            return None
+
+        def delete(self, chunk_index, chunk_filepath):
+            return None
+
+        def encode_data(self, data, sizes, flattened):
+            return b"", None
+
+    loader = _Loader()
+    path = os.path.join(tmpdir, "chunk.bin")
+    payload = b"\x00" * 16
+    with open(path, "wb") as f:
+        f.write(payload)
+    loader._wait_until_chunk_ready(0, path, filesize_bytes=len(payload))

--- a/tests/streaming/test_downloader.py
+++ b/tests/streaming/test_downloader.py
@@ -51,6 +51,14 @@ def test_get_downloader(tmpdir):
     unregister_downloader("dummy://")
 
 
+def _write_download_target(*args, **kwargs):
+    """Side effect for mocked cloud downloads that write to a local path argument."""
+    # boto: (bucket, key, filename, ...); gcp blob: (filename,)
+    path = args[2] if len(args) >= 3 else args[0]
+    with open(path, "wb") as f:
+        f.write(b"ok")
+
+
 @mock.patch("litdata.streaming.downloader.R2Client")
 def test_r2_downloader_fast(r2_client_mock, tmpdir):
     # Mock the R2Client
@@ -58,13 +66,16 @@ def test_r2_downloader_fast(r2_client_mock, tmpdir):
     r2_client_mock.return_value = r2_client_instance
 
     # Mock the download_file method to avoid credential errors
-    r2_client_instance.client.download_file = MagicMock()
+    r2_client_instance.client.download_file = MagicMock(side_effect=_write_download_target)
 
     downloader = R2Downloader("r2://random_bucket", str(tmpdir), [])
-    downloader.download_file("r2://random_bucket/a.txt", os.path.join(tmpdir, "a.txt"))
+    local_filepath = os.path.join(tmpdir, "a.txt")
+    downloader.download_file("r2://random_bucket/a.txt", local_filepath)
 
-    # Verify R2Client download_file was called
+    # Verify R2Client download_file was called and the final path was published atomically
     r2_client_instance.client.download_file.assert_called_once()
+    assert os.path.exists(local_filepath)
+    assert r2_client_instance.client.download_file.call_args.args[2].startswith(local_filepath + ".tmp.")
 
 
 @mock.patch("litdata.streaming.downloader.R2Client")
@@ -76,7 +87,7 @@ def test_r2_downloader_with_storage_options(r2_client_mock, tmpdir):
     r2_client_mock.return_value = r2_client_instance
 
     # Mock the download_file method to avoid credential errors
-    r2_client_instance.client.download_file = MagicMock()
+    r2_client_instance.client.download_file = MagicMock(side_effect=_write_download_target)
 
     # Initialize the R2Downloader with storage options
     downloader = R2Downloader("r2://random_bucket", str(tmpdir), [], storage_options)
@@ -143,7 +154,12 @@ def test_gcp_downloader(tmpdir, monkeypatch, google_mock):
     mock_client = MagicMock()
     mock_bucket = MagicMock()
     mock_blob = MagicMock()
-    mock_blob.download_to_filename = MagicMock()
+
+    def _write_ok(path: str) -> None:
+        with open(path, "wb") as f:
+            f.write(b"ok")
+
+    mock_blob.download_to_filename = MagicMock(side_effect=_write_ok)
 
     # Patch the storage client to return the mock client
     google_mock.cloud.storage.Client = MagicMock(return_value=mock_client)
@@ -162,7 +178,8 @@ def test_gcp_downloader(tmpdir, monkeypatch, google_mock):
     google_mock.cloud.storage.Client.assert_called_with(**storage_options)
     mock_client.bucket.assert_called_with("random_bucket")
     mock_bucket.blob.assert_called_with("a.txt")
-    mock_blob.download_to_filename.assert_called_with(local_filepath)
+    assert mock_blob.download_to_filename.call_args.args[0].startswith(local_filepath + ".tmp.")
+    assert os.path.exists(local_filepath)
 
 
 @mock.patch("litdata.streaming.downloader._AZURE_STORAGE_AVAILABLE", True)


### PR DESCRIPTION
## Summary
- Cut PrepareChunksThread force/delete queue sleeps when download work can proceed (no ~0.2s empty-queue wait per chunk).
- Notify ItemLoader via per-chunk ready Events instead of filesystem busy-wait; clear stale signals on delete.
- Publish cloud downloads atomically (temp + `os.replace`) and fix `try_decompress` completeness (stop treating item-count `chunk_size` as bytes); TokensLoader exact-size wait uses `>=`.

## Benchmarks
Local microbench (`scripts/bench_download_reader_overlap.py`) vs `main` (`cd343d0` / #849), same machine/venv, `local:` remote (no cloud):

| Metric | before (`main`) | after (this PR) |
|---|---|---|
| Prefetch force/delete poll timeout (work available) | 0.100s / 0.100s | 0.000s / 0.000s |
| ItemLoader wake after 50ms delayed publish (p50 / p95) | 103.4ms / 105.6ms | 54.3ms / 56.0ms |
| E2E cold-cache iterate 400 items / 100 chunks (p50) | 21.19s (~19 items/s) | 10.56s (~38 items/s) |

```bash
.venv/bin/python scripts/bench_download_reader_overlap.py --label after
# baseline: run the same script on a main checkout/worktree with --label before
```

## Test plan
- [x] `pytest tests/streaming/test_download_reader_overlap.py tests/streaming/test_downloader.py tests/streaming/test_reader.py tests/streaming/test_item_loader.py tests/streaming/test_shared_chunk_deletion.py`
- [ ] CI green
- [ ] Spot-check compressed remote streaming still decompresses and reads complete chunks


Made with [Cursor](https://cursor.com)