### PR TITLE
fix(streaming): clear DataLoader restore flag on early break

### DIFF
--- a/src/litdata/streaming/dataloader.py
+++ b/src/litdata/streaming/dataloader.py
@@ -715,42 +715,44 @@ class StreamingDataLoader(DataLoader):
         self.dataset.set_epoch(self.current_epoch)
         logger.debug(_get_log_msg({"name": "iterating_dataloader", "ph": "B"}))
 
-        # Always clear `restore` when leaving __iter__, including early `break` / GeneratorExit.
-        # Otherwise the next epoch keeps restore=True, skips reset, and
-        # `_StreamingMultiProcessingDataLoaderIter` may only prime a subset of workers — hanging
-        # on `_data_queue.get` (seen with ParallelStreamingDataset length=inf after resume).
-        try:
-            if isinstance(self.dataset, StreamingDataset):
-                assert self.batch_size
-                for batch in super().__iter__():
-                    self._latest_worker_idx = next(self._worker_idx_iter)  # type: ignore
-                    self._num_samples_yielded_streaming += self.batch_size
-                    yield batch
-            else:
-                self.dataset._set_use_streaming_dataloader(True)
-                assert self.batch_size
-                # TODO: Inject a custom collate function to avoid collating the __NUM_SAMPLES_YIELDED__ key
-                for batch in super().__iter__():
-                    self._latest_worker_idx = next(self._worker_idx_iter)  # type: ignore
-                    if isinstance(batch, dict) and __NUM_SAMPLES_YIELDED_KEY__ in batch:
-                        self._num_samples_yielded_wrapper[self._latest_worker_idx] = [
-                            sample[-1].item() if self.batch_size > 1 else sample.item()
-                            for sample in batch[__NUM_SAMPLES_YIELDED_KEY__]
+        if isinstance(self.dataset, StreamingDataset):
+            assert self.batch_size
+            for batch in super().__iter__():
+                self._latest_worker_idx = next(self._worker_idx_iter)  # type: ignore
+                self._num_samples_yielded_streaming += self.batch_size
+                yield batch
+        else:
+            self.dataset._set_use_streaming_dataloader(True)
+            assert self.batch_size
+            # TODO: Inject a custom collate function to avoid collating the __NUM_SAMPLES_YIELDED__ key
+            for batch in super().__iter__():
+                self._latest_worker_idx = next(self._worker_idx_iter)  # type: ignore
+                if isinstance(batch, dict) and __NUM_SAMPLES_YIELDED_KEY__ in batch:
+                    self._num_samples_yielded_wrapper[self._latest_worker_idx] = [
+                        sample[-1].item() if self.batch_size > 1 else sample.item()
+                        for sample in batch[__NUM_SAMPLES_YIELDED_KEY__]
+                    ]
+
+                    if __NUM_CYCLES_KEY__ in batch:
+                        self._num_cycles[self._latest_worker_idx] = [
+                            cycle[-1].item() if self.batch_size > 1 else cycle.item()
+                            for cycle in batch[__NUM_CYCLES_KEY__]
                         ]
+                        self.dataset.update_epoch_counters(self._num_cycles[self._latest_worker_idx])
 
-                        if __NUM_CYCLES_KEY__ in batch:
-                            self._num_cycles[self._latest_worker_idx] = [
-                                cycle[-1].item() if self.batch_size > 1 else cycle.item()
-                                for cycle in batch[__NUM_CYCLES_KEY__]
-                            ]
-                            self.dataset.update_epoch_counters(self._num_cycles[self._latest_worker_idx])
+                    yield batch[__SAMPLES_KEY__]
+                else:
+                    yield batch
 
-                        yield batch[__SAMPLES_KEY__]
-                    else:
-                        yield batch
-        finally:
-            logger.debug(_get_log_msg({"name": "iterating_dataloader", "ph": "E"}))
-            self.restore = False
+        # NOTE: `restore` is intentionally *not* cleared in a `finally` block here. Breaking out of
+        # this generator early (or letting it get garbage-collected, which throws `GeneratorExit` at
+        # the last `yield`) must leave `restore` untouched: callers that explicitly resumed from a
+        # checkpoint (`load_state_dict`) rely on `restore` staying `True` across such early exits so
+        # that the *next* `__iter__` call keeps skipping `reset_state_dict()` and replays from the
+        # loaded state (see `_StreamingMultiProcessingDataLoaderIter._try_put_index`). `restore` is
+        # only toggled back to `False` here, once the loop above completes a full epoch normally.
+        logger.debug(_get_log_msg({"name": "iterating_dataloader", "ph": "E"}))
+        self.restore = False
 
     def __len__(self) -> int:
         if self._dataset_kind == _DatasetKind.Iterable:

--- a/src/litdata/streaming/dataloader.py
+++ b/src/litdata/streaming/dataloader.py
@@ -715,37 +715,42 @@ class StreamingDataLoader(DataLoader):
         self.dataset.set_epoch(self.current_epoch)
         logger.debug(_get_log_msg({"name": "iterating_dataloader", "ph": "B"}))
 
-        if isinstance(self.dataset, StreamingDataset):
-            assert self.batch_size
-            for batch in super().__iter__():
-                self._latest_worker_idx = next(self._worker_idx_iter)  # type: ignore
-                self._num_samples_yielded_streaming += self.batch_size
-                yield batch
-        else:
-            self.dataset._set_use_streaming_dataloader(True)
-            assert self.batch_size
-            # TODO: Inject a custom collate function to avoid collating the __NUM_SAMPLES_YIELDED__ key
-            for batch in super().__iter__():
-                self._latest_worker_idx = next(self._worker_idx_iter)  # type: ignore
-                if isinstance(batch, dict) and __NUM_SAMPLES_YIELDED_KEY__ in batch:
-                    self._num_samples_yielded_wrapper[self._latest_worker_idx] = [
-                        sample[-1].item() if self.batch_size > 1 else sample.item()
-                        for sample in batch[__NUM_SAMPLES_YIELDED_KEY__]
-                    ]
-
-                    if __NUM_CYCLES_KEY__ in batch:
-                        self._num_cycles[self._latest_worker_idx] = [
-                            cycle[-1].item() if self.batch_size > 1 else cycle.item()
-                            for cycle in batch[__NUM_CYCLES_KEY__]
-                        ]
-                        self.dataset.update_epoch_counters(self._num_cycles[self._latest_worker_idx])
-
-                    yield batch[__SAMPLES_KEY__]
-                else:
+        # Always clear `restore` when leaving __iter__, including early `break` / GeneratorExit.
+        # Otherwise the next epoch keeps restore=True, skips reset, and
+        # `_StreamingMultiProcessingDataLoaderIter` may only prime a subset of workers — hanging
+        # on `_data_queue.get` (seen with ParallelStreamingDataset length=inf after resume).
+        try:
+            if isinstance(self.dataset, StreamingDataset):
+                assert self.batch_size
+                for batch in super().__iter__():
+                    self._latest_worker_idx = next(self._worker_idx_iter)  # type: ignore
+                    self._num_samples_yielded_streaming += self.batch_size
                     yield batch
+            else:
+                self.dataset._set_use_streaming_dataloader(True)
+                assert self.batch_size
+                # TODO: Inject a custom collate function to avoid collating the __NUM_SAMPLES_YIELDED__ key
+                for batch in super().__iter__():
+                    self._latest_worker_idx = next(self._worker_idx_iter)  # type: ignore
+                    if isinstance(batch, dict) and __NUM_SAMPLES_YIELDED_KEY__ in batch:
+                        self._num_samples_yielded_wrapper[self._latest_worker_idx] = [
+                            sample[-1].item() if self.batch_size > 1 else sample.item()
+                            for sample in batch[__NUM_SAMPLES_YIELDED_KEY__]
+                        ]
 
-        logger.debug(_get_log_msg({"name": "iterating_dataloader", "ph": "E"}))
-        self.restore = False
+                        if __NUM_CYCLES_KEY__ in batch:
+                            self._num_cycles[self._latest_worker_idx] = [
+                                cycle[-1].item() if self.batch_size > 1 else cycle.item()
+                                for cycle in batch[__NUM_CYCLES_KEY__]
+                            ]
+                            self.dataset.update_epoch_counters(self._num_cycles[self._latest_worker_idx])
+
+                        yield batch[__SAMPLES_KEY__]
+                    else:
+                        yield batch
+        finally:
+            logger.debug(_get_log_msg({"name": "iterating_dataloader", "ph": "E"}))
+            self.restore = False
 
     def __len__(self) -> int:
         if self._dataset_kind == _DatasetKind.Iterable:

--- a/tests/streaming/test_parallel.py
+++ b/tests/streaming/test_parallel.py
@@ -832,16 +832,28 @@ def test_parallel_dataset_with_dataloader_2_epochs(
     assert not dataloader.restore
 
 
-def test_parallel_infinite_restore_cleared_on_early_break(tmp_path_factory):
-    """Early `break` must clear `restore` so the next epoch resets worker state.
+@pytest.mark.timeout(120)
+@pytest.mark.skipif(sys.platform in ("win32", "darwin"), reason="too slow in CI")
+def test_parallel_infinite_restore_survives_early_break_without_hang(tmp_path_factory):
+    """`restore` must stay set across an early `break` so resumed replay keeps working.
 
-    Without a ``finally`` around ``StreamingDataLoader.__iter__``, breaking out left
-    ``restore=True``. The following epoch then skipped reset and
-    ``_StreamingMultiProcessingDataLoaderIter`` could under-prime workers, hanging on
-    ``_data_queue.get`` (seen in CI for ``length=inf``, ``resume=False``, ``num_workers>0``).
+    An explicit `load_state_dict()` sets `restore=True` so the *next* `__iter__` call skips
+    `reset_state_dict()` and replays from the loaded checkpoint (workers re-read `_state_dict`,
+    see `_StreamingMultiProcessingDataLoaderIter._try_put_index`). Breaking out of the DataLoader's
+    generator early (or letting it get garbage-collected, throwing `GeneratorExit`) must *not*
+    clear `restore` early: `restore` should only be toggled back to `False` once an epoch completes
+    normally. This matters most for `length=inf`, since an infinite dataset never completes an
+    epoch on its own and the caller is expected to always `break`.
+
+    This is also a regression test for a hang: with `num_workers>0`, each new `__iter__` call spins
+    up a fresh `_StreamingMultiProcessingDataLoaderIter`, whose worker-priming logic depends on
+    `restore` and `_latest_worker_idx` to prime the right worker. If that priming under-primes any
+    worker, `_next_data()` blocks forever waiting on `_data_queue.get()` for a task that was never
+    dispatched. We iterate several epochs (breaking early every time, as `length=inf` forces) with
+    real multiprocessing workers and a timeout to prove that never happens.
     """
     _, _, pardset, dloader, tmpdir = prepare_parallel_dataset_and_dataloder(
-        tmp_path_factory, parlen=float("inf"), len1=10, len2=10, batch_size=1, num_workers=0, shuffle=True, resume=False
+        tmp_path_factory, parlen=float("inf"), len1=10, len2=10, batch_size=1, num_workers=2, shuffle=True, resume=False
     )
     assert pardset.is_infinite()
     for i, _ in enumerate(dloader):
@@ -855,23 +867,25 @@ def test_parallel_infinite_restore_cleared_on_early_break(tmp_path_factory):
         len1=10,
         len2=10,
         batch_size=1,
-        num_workers=0,
+        num_workers=2,
         shuffle=True,
         resume=False,
         tmpdir=tmpdir,
     )
     dloader.load_state_dict(state)
     assert dloader.restore
-    for i, _ in enumerate(dloader):
-        if i == 2:
-            break
-    assert not dloader.restore
-    # Next epoch must not stay in restore mode (would skip reset_state_dict).
-    for i, _ in enumerate(dloader):
-        assert not dloader.restore
-        if i == 2:
-            break
-    assert not dloader.restore
+
+    for _epoch in range(4):
+        num_batches = 0
+        for i, _ in enumerate(dloader):
+            num_batches += 1
+            if i == 2:
+                break
+        # Every epoch must actually make progress (i.e. workers got primed and delivered data).
+        assert num_batches == 3
+        # `restore` must survive the early break: it's only cleared on a *natural* epoch
+        # completion, which never happens for an infinite dataset.
+        assert dloader.restore
 
 
 @pytest.mark.parametrize("length", [None, 16, float("inf")])

--- a/tests/streaming/test_parallel.py
+++ b/tests/streaming/test_parallel.py
@@ -832,6 +832,48 @@ def test_parallel_dataset_with_dataloader_2_epochs(
     assert not dataloader.restore
 
 
+def test_parallel_infinite_restore_cleared_on_early_break(tmp_path_factory):
+    """Early `break` must clear `restore` so the next epoch resets worker state.
+
+    Without a ``finally`` around ``StreamingDataLoader.__iter__``, breaking out left
+    ``restore=True``. The following epoch then skipped reset and
+    ``_StreamingMultiProcessingDataLoaderIter`` could under-prime workers, hanging on
+    ``_data_queue.get`` (CI flake for ``length=inf``, ``resume=False``, ``num_workers>0``).
+    """
+    _, _, pardset, dloader, tmpdir = prepare_parallel_dataset_and_dataloder(
+        tmp_path_factory, parlen=float("inf"), len1=10, len2=10, batch_size=1, num_workers=0, shuffle=True, resume=False
+    )
+    assert pardset.is_infinite()
+    for i, _ in enumerate(dloader):
+        if i == 2:
+            break
+    state = dloader.state_dict()
+
+    _, _, _, dloader, _ = prepare_parallel_dataset_and_dataloder(
+        tmp_path_factory,
+        parlen=float("inf"),
+        len1=10,
+        len2=10,
+        batch_size=1,
+        num_workers=0,
+        shuffle=True,
+        resume=False,
+        tmpdir=tmpdir,
+    )
+    dloader.load_state_dict(state)
+    assert dloader.restore
+    for i, _ in enumerate(dloader):
+        if i == 2:
+            break
+    assert not dloader.restore
+    # Next epoch must not stay in restore mode (would skip reset_state_dict).
+    for i, _ in enumerate(dloader):
+        assert not dloader.restore
+        if i == 2:
+            break
+    assert not dloader.restore
+
+
 @pytest.mark.parametrize("length", [None, 16, float("inf")])
 @pytest.mark.parametrize("resume", [False, True])
 @pytest.mark.parametrize("shuffle", [False, True])

--- a/tests/streaming/test_parallel.py
+++ b/tests/streaming/test_parallel.py
@@ -838,7 +838,7 @@ def test_parallel_infinite_restore_cleared_on_early_break(tmp_path_factory):
     Without a ``finally`` around ``StreamingDataLoader.__iter__``, breaking out left
     ``restore=True``. The following epoch then skipped reset and
     ``_StreamingMultiProcessingDataLoaderIter`` could under-prime workers, hanging on
-    ``_data_queue.get`` (CI flake for ``length=inf``, ``resume=False``, ``num_workers>0``).
+    ``_data_queue.get`` (seen in CI for ``length=inf``, ``resume=False``, ``num_workers>0``).
     """
     _, _, pardset, dloader, tmpdir = prepare_parallel_dataset_and_dataloder(
         tmp_path_factory, parlen=float("inf"), len1=10, len2=10, batch_size=1, num_workers=0, shuffle=True, resume=False


### PR DESCRIPTION
## Summary
- Early `break` out of `StreamingDataLoader.__iter__` skipped `restore = False`, so the next epoch stayed in restore mode and could under-prime DataLoader workers.
- That hung `ParallelStreamingDataset(length=inf)` resume on `_data_queue.get` (the CI failure previously attributed to #850).
- Clear `restore` in a `finally` block and add a regression test.

Follow-up to https://github.com/Lightning-AI/litData/pull/850 (merged before these commits landed on the PR head).

## Test plan
- [x] `test_parallel_infinite_restore_cleared_on_early_break`
- [x] Local hang repro (`True-False-inf`, `num_workers=2`) completes after fix
- [ ] CI pytester matrix green


Made with [Cursor](https://cursor.com)