### PR TITLE
Bump version to 0.2.65

### DIFF
--- a/src/litdata/__about__.py
+++ b/src/litdata/__about__.py
@@ -14,7 +14,7 @@
 
 import time
 
-__version__ = "0.2.64"
+__version__ = "0.2.65"
 __author__ = "Lightning AI et al."
 __author_email__ = "pytorch@lightning.ai"
 __license__ = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump package version from 0.2.64 → 0.2.65 in `src/litdata/__about__.py`.

## Test plan
- [ ] CI green
- [ ] Confirm release workflow tags/publishes 0.2.65 after merge


Made with [Cursor](https://cursor.com)