### PR TITLE
feat(simulator): LitData streaming simulator and web UI

### DIFF
--- a/.github/workflows/ci-litsim.yml
+++ b/.github/workflows/ci-litsim.yml
@@ -1,0 +1,27 @@
+name: litsim
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "simulator/**"
+      - ".github/workflows/ci-litsim.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "simulator/**"
+      - ".github/workflows/ci-litsim.yml"
+
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: simulator
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache-dependency-path: simulator/go.sum
+      - run: go test ./...

--- a/simulator/.gitignore
+++ b/simulator/.gitignore
@@ -1,0 +1,4 @@
+litsim.yaml
+*.html
+!web/static/
+!web/static/**

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -1,0 +1,29 @@
+# litsim
+
+Offline **LitData streaming simulator**. It does not train: it walks a dataset’s `index.json` (and optional chunk headers) and models download, S3 429s, cache, decompress, deserialize jitter, and device time.
+
+Config file is the source of truth. Generate it, edit knobs, `run` / `tune`, open the HTML playground, export YAML again.
+
+```bash
+cd simulator
+go run ./cmd/litsim init --index /path/to/dataset -c litsim.yaml
+# edit litsim.yaml
+go run ./cmd/litsim verify -c litsim.yaml
+go run ./cmd/litsim run   -c litsim.yaml -o report.html
+go run ./cmd/litsim tune  -c litsim.yaml -o tune.html
+```
+
+`-c` / `--config` is the YAML on every subcommand (`init` writes it). `-o` is the HTML report for `run` / `tune`.
+
+`--index` accepts the same strings as `StreamingDataset(input_dir=...)`. Path resolution shells out to [`resolve_path.py`](resolve_path.py) (`litdata.streaming.resolver._resolve_dir`). If Python/litdata is missing, a local `index.json` still works.
+
+Requires **Go 1.23+** (`go.mod` records `toolchain go1.26.6` when that toolchain is available).
+
+Mosaic Streaming’s simulator uses one constant `time_per_sample` (download wait + process). litsim splits **GET** (bandwidth, RTT, 429 token bucket), **decompress once per chunk**, **deserialize per sample** (optional lognormal jitter), then **device** `time_per_sample_s`. Set CPU costs to `0` to match Mosaic’s scalar.
+
+`litsim serve` starts a small website. Sliders `POST /api/run` and re-run the **Go** engine (not a JS clone).
+
+```bash
+go run ./cmd/litsim serve -c litsim.yaml --addr :8765
+# open http://127.0.0.1:8765/
+```

--- a/simulator/chunk/header.go
+++ b/simulator/chunk/header.go
@@ -1,0 +1,127 @@
+package chunk
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+)
+
+// LitData uncompressed chunk layout (little-endian uint32, matching numpy on x86):
+//
+//	num_items: u32
+//	offsets:   u32[num_items+1]
+//	item_data: bytes
+//
+// offsets[0] == 4 + 4*(num_items+1). Item i is [offsets[i], offsets[i+1]).
+
+func HeaderSize(numItems uint32) int {
+	return 4 + 4*int(numItems+1)
+}
+
+type Header struct {
+	NumItems uint32
+	Offsets  []uint32 // length NumItems+1
+}
+
+func (h Header) ItemSize(i int) int64 {
+	return int64(h.Offsets[i+1] - h.Offsets[i])
+}
+
+func (h Header) PayloadBytes() int64 {
+	if len(h.Offsets) == 0 {
+		return 0
+	}
+	return int64(h.Offsets[len(h.Offsets)-1] - h.Offsets[0])
+}
+
+func Encode(h Header) ([]byte, error) {
+	if err := h.Validate(); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, HeaderSize(h.NumItems))
+	binary.LittleEndian.PutUint32(buf[0:4], h.NumItems)
+	for i, off := range h.Offsets {
+		binary.LittleEndian.PutUint32(buf[4+4*i:8+4*i], off)
+	}
+	return buf, nil
+}
+
+func Parse(b []byte) (Header, error) {
+	if len(b) < 4 {
+		return Header{}, fmt.Errorf("header: need 4 bytes for num_items, got %d", len(b))
+	}
+	n := binary.LittleEndian.Uint32(b[:4])
+	need := HeaderSize(n)
+	if len(b) < need {
+		return Header{}, fmt.Errorf("header: need %d bytes for %d items, got %d", need, n, len(b))
+	}
+	h := Header{NumItems: n, Offsets: make([]uint32, n+1)}
+	for i := range h.Offsets {
+		h.Offsets[i] = binary.LittleEndian.Uint32(b[4+4*i : 8+4*i])
+	}
+	return h, h.Validate()
+}
+
+func (h Header) Validate() error {
+	if len(h.Offsets) != int(h.NumItems)+1 {
+		return fmt.Errorf("header: offsets len %d want %d", len(h.Offsets), h.NumItems+1)
+	}
+	want0 := uint32(HeaderSize(h.NumItems))
+	if h.Offsets[0] != want0 {
+		return fmt.Errorf("header: offsets[0]=%d want %d", h.Offsets[0], want0)
+	}
+	for i := 1; i < len(h.Offsets); i++ {
+		if h.Offsets[i] < h.Offsets[i-1] {
+			return fmt.Errorf("header: offsets not monotonic at %d (%d < %d)", i, h.Offsets[i], h.Offsets[i-1])
+		}
+	}
+	return nil
+}
+
+// ReadFromFile reads exactly the header (using expected item count when > 0).
+func ReadFromFile(path string, expectedItems int) (Header, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Header{}, err
+	}
+	defer f.Close()
+	if expectedItems > 0 {
+		need := HeaderSize(uint32(expectedItems))
+		buf := make([]byte, need)
+		if _, err := io.ReadFull(f, buf); err != nil {
+			return Header{}, fmt.Errorf("%s: %w", path, err)
+		}
+		h, err := Parse(buf)
+		if err != nil {
+			return Header{}, fmt.Errorf("%s: %w", path, err)
+		}
+		if int(h.NumItems) != expectedItems {
+			return Header{}, fmt.Errorf("%s: num_items %d != index chunk_size %d", path, h.NumItems, expectedItems)
+		}
+		return h, nil
+	}
+	var nb [4]byte
+	if _, err := io.ReadFull(f, nb[:]); err != nil {
+		return Header{}, err
+	}
+	n := binary.LittleEndian.Uint32(nb[:])
+	rest := make([]byte, 4*int(n+1))
+	if _, err := io.ReadFull(f, rest); err != nil {
+		return Header{}, err
+	}
+	buf := append(nb[:], rest...)
+	return Parse(buf)
+}
+
+// NewPacked builds a header for itemSizes (payload lengths only).
+func NewPacked(itemSizes []int) Header {
+	n := uint32(len(itemSizes))
+	start := uint32(HeaderSize(n))
+	h := Header{NumItems: n, Offsets: make([]uint32, n+1)}
+	h.Offsets[0] = start
+	for i, sz := range itemSizes {
+		h.Offsets[i+1] = h.Offsets[i] + uint32(sz)
+	}
+	return h
+}

--- a/simulator/chunk/header_test.go
+++ b/simulator/chunk/header_test.go
@@ -1,0 +1,60 @@
+package chunk
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRoundTrip(t *testing.T) {
+	h := NewPacked([]int{10, 20, 15})
+	if h.NumItems != 3 {
+		t.Fatalf("num_items %d", h.NumItems)
+	}
+	if h.Offsets[0] != 20 { // 4 + 4*4
+		t.Fatalf("offsets[0]=%d", h.Offsets[0])
+	}
+	if h.PayloadBytes() != 45 {
+		t.Fatalf("payload %d", h.PayloadBytes())
+	}
+	b, err := Encode(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := Parse(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.NumItems != 3 || got.ItemSize(1) != 20 {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestValidateRejectsBadOffset0(t *testing.T) {
+	h := NewPacked([]int{4})
+	h.Offsets[0] = 0
+	if err := h.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestReadFromFile(t *testing.T) {
+	h := NewPacked([]int{3, 5})
+	hdr, err := Encode(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	dir := t.TempDir()
+	p := filepath.Join(dir, "chunk-0-0.bin")
+	if err := os.WriteFile(p, append(hdr, payload...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadFromFile(p, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ItemSize(0) != 3 || got.ItemSize(1) != 5 {
+		t.Fatalf("%+v", got)
+	}
+}

--- a/simulator/cmd/litsim/main.go
+++ b/simulator/cmd/litsim/main.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/Lightning-AI/litData/simulator/config"
+	"github.com/Lightning-AI/litData/simulator/index"
+	"github.com/Lightning-AI/litData/simulator/report"
+	"github.com/Lightning-AI/litData/simulator/resolve"
+	"github.com/Lightning-AI/litData/simulator/sim"
+	"github.com/Lightning-AI/litData/simulator/tune"
+	"github.com/Lightning-AI/litData/simulator/verify"
+	"github.com/Lightning-AI/litData/simulator/web"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	cmd := os.Args[1]
+	args := os.Args[2:]
+	var err error
+	switch cmd {
+	case "init":
+		err = cmdInit(args)
+	case "verify":
+		err = cmdVerify(args)
+	case "run":
+		err = cmdRun(args)
+	case "tune":
+		err = cmdTune(args)
+	case "serve":
+		err = cmdServe(args)
+	default:
+		usage()
+		os.Exit(2)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `litsim — LitData streaming simulator
+
+  litsim init   --index PATH -c litsim.yaml
+  litsim verify -c litsim.yaml
+  litsim run    -c litsim.yaml -o report.html
+  litsim tune   -c litsim.yaml -o tune.html
+  litsim serve  -c litsim.yaml [--addr :8765]
+`)
+}
+
+func cmdInit(args []string) error {
+	fs := flag.NewFlagSet("init", flag.ExitOnError)
+	indexPath := fs.String("index", "", "dataset directory or index.json (same as StreamingDataset)")
+	cfgPath := fs.String("c", "", "config YAML to write")
+	fs.StringVar(cfgPath, "config", "", "config YAML to write")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *indexPath == "" || *cfgPath == "" {
+		return fmt.Errorf("init requires --index and -c")
+	}
+	res, err := resolve.Path(*indexPath)
+	if err != nil {
+		return err
+	}
+	local := resolve.IndexJSONPath(res, *indexPath)
+	idx, err := index.Load(local)
+	if err != nil {
+		return err
+	}
+	if err := config.WriteInit(*cfgPath, *indexPath, res, idx); err != nil {
+		return err
+	}
+	fmt.Printf("wrote %s (%d chunks, %d items)\n", *cfgPath, len(idx.Chunks), idx.TotalItems())
+	return nil
+}
+
+func loadCfg(path string) (*config.File, *index.Index, error) {
+	f, err := config.Load(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	user := f.Dataset.Index
+	res := f.Dataset.Resolved
+	if res.IndexJSON == "" && user != "" {
+		r, err := resolve.Path(user)
+		if err == nil {
+			res = r
+			f.Dataset.Resolved = r
+		}
+	}
+	local := resolve.IndexJSONPath(res, user)
+	idx, err := index.Load(local)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, idx, nil
+}
+
+func cmdVerify(args []string) error {
+	fs := flag.NewFlagSet("verify", flag.ExitOnError)
+	cfgPath := fs.String("c", "", "config")
+	fs.StringVar(cfgPath, "config", "", "config")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *cfgPath == "" {
+		return fmt.Errorf("verify requires -c")
+	}
+	f, idx, err := loadCfg(*cfgPath)
+	if err != nil {
+		return err
+	}
+	rep := verify.Chunks(idx, f.ChunksDir())
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(map[string]any{"checked": rep.Checked, "failed": rep.Failed, "errors": rep.Errors})
+	if rep.Failed > 0 {
+		return fmt.Errorf("verify: %d failed", rep.Failed)
+	}
+	return nil
+}
+
+func cmdRun(args []string) error {
+	fs := flag.NewFlagSet("run", flag.ExitOnError)
+	cfgPath := fs.String("c", "", "config")
+	fs.StringVar(cfgPath, "config", "", "config")
+	out := fs.String("o", "litsim-report.html", "HTML report")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *cfgPath == "" {
+		return fmt.Errorf("run requires -c")
+	}
+	f, idx, err := loadCfg(*cfgPath)
+	if err != nil {
+		return err
+	}
+	res := sim.Run(idx, sim.FromFile(f))
+	if err := report.Write(*out, idx, f, res, nil); err != nil {
+		return err
+	}
+	fmt.Println(report.FormatResult(res))
+	fmt.Println("wrote", *out)
+	return nil
+}
+
+func cmdTune(args []string) error {
+	fs := flag.NewFlagSet("tune", flag.ExitOnError)
+	cfgPath := fs.String("c", "", "config")
+	fs.StringVar(cfgPath, "config", "", "config")
+	out := fs.String("o", "litsim-tune.html", "HTML report")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *cfgPath == "" {
+		return fmt.Errorf("tune requires -c")
+	}
+	f, idx, err := loadCfg(*cfgPath)
+	if err != nil {
+		return err
+	}
+	dir := f.ChunksDir()
+	rep := verify.Chunks(idx, dir)
+	cands := tune.SearchFile(idx, rep.Headers, f)
+	best := sim.Result{}
+	if len(cands) > 0 {
+		best = cands[0].Result
+	}
+	if err := report.Write(*out, idx, f, best, cands); err != nil {
+		return err
+	}
+	fmt.Printf("%d trials; best %s\n", len(cands), report.FormatResult(best))
+	if abs, err := filepath.Abs(*out); err == nil {
+		fmt.Println("wrote", abs)
+	} else {
+		fmt.Println("wrote", *out)
+	}
+	return nil
+}
+
+func cmdServe(args []string) error {
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	cfgPath := fs.String("c", "", "config")
+	fs.StringVar(cfgPath, "config", "", "config")
+	addr := fs.String("addr", ":8765", "listen address")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *cfgPath == "" {
+		return fmt.Errorf("serve requires -c")
+	}
+	f, idx, err := loadCfg(*cfgPath)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("litsim %d chunks / %d items — http://127.0.0.1%s/\n", len(idx.Chunks), idx.TotalItems(), *addr)
+	return http.ListenAndServe(*addr, web.New(f, idx).Handler())
+}

--- a/simulator/config/config.go
+++ b/simulator/config/config.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type File struct {
+	Dataset   Dataset   `yaml:"dataset"`
+	Cluster   Cluster   `yaml:"cluster"`
+	Cache     Cache     `yaml:"cache"`
+	Optimize  Optimize  `yaml:"optimize"`
+	Network   Network   `yaml:"network"`
+	RateLimit RateLimit `yaml:"rate_limit"`
+	Tuner     Tuner     `yaml:"tuner"`
+}
+
+type Dataset struct {
+	Index       string   `yaml:"index"`
+	ChunksDir   string   `yaml:"chunks_dir"`
+	Compression string   `yaml:"compression"`
+	Resolved    Resolved `yaml:"resolved"`
+}
+
+type Resolved struct {
+	Path             string `yaml:"path"`
+	URL              string `yaml:"url"`
+	DataConnectionID string `yaml:"data_connection_id"`
+	IndexJSON        string `yaml:"index_json"`
+}
+
+type Cluster struct {
+	Nodes          int        `yaml:"nodes"`
+	DevicesPerNode int        `yaml:"devices_per_node"`
+	Epochs         int        `yaml:"epochs"`
+	Shuffle        bool       `yaml:"shuffle"`
+	Seed           int64      `yaml:"seed"`
+	TimePerSampleS float64    `yaml:"time_per_sample_s"`
+	StartupS       float64    `yaml:"startup_s"`
+	CPU            CPU        `yaml:"cpu"`
+	Dataloader     Dataloader `yaml:"dataloader"`
+}
+
+type CPU struct {
+	DecompressNsPerByte    float64 `yaml:"decompress_ns_per_byte"`
+	DeserializeUsPerSample float64 `yaml:"deserialize_us_per_sample"`
+	DecompressWorkers      int     `yaml:"decompress_workers"`
+	Jitter                 string  `yaml:"jitter"` // none | lognormal
+	JitterSigma            float64 `yaml:"jitter_sigma"`
+	CalibrateFile          string  `yaml:"calibrate_file"`
+}
+
+type Dataloader struct {
+	NumWorkers        int  `yaml:"num_workers"`
+	BatchSize         int  `yaml:"batch_size"`
+	PrefetchFactor    int  `yaml:"prefetch_factor"`
+	PersistentWorkers bool `yaml:"persistent_workers"`
+	DropLast          bool `yaml:"drop_last"`
+}
+
+type Cache struct {
+	MaxBytes       ByteSize `yaml:"max_bytes"`
+	MaxPreDownload int      `yaml:"max_pre_download"`
+	KeepCompressed bool     `yaml:"keep_compressed"`
+}
+
+type Optimize struct {
+	ChunkBytes ByteSize `yaml:"chunk_bytes"`
+	UseHeaders bool     `yaml:"use_headers"`
+}
+
+type Network struct {
+	Local             bool      `yaml:"local"`
+	BandwidthBps      Bandwidth `yaml:"bandwidth_bps"`
+	RTTMs             float64   `yaml:"rtt_ms"`
+	MaxConcurrentGets int       `yaml:"max_concurrent_gets"`
+	ExtraLatencyMs    float64   `yaml:"extra_latency_ms"`
+	JitterMs          float64   `yaml:"jitter_ms"`
+}
+
+type RateLimit struct {
+	Enabled        bool    `yaml:"enabled"`
+	RequestsPerSec float64 `yaml:"requests_per_sec"`
+	Burst          int     `yaml:"burst"`
+	RetryAfterS    float64 `yaml:"retry_after_s"`
+	MaxRetries     int     `yaml:"max_retries"`
+	Backoff        string  `yaml:"backoff"` // none | exponential
+	BackoffBaseS   float64 `yaml:"backoff_base_s"`
+	BytesPerSec    int64   `yaml:"bytes_per_sec"`
+}
+
+type Tuner struct {
+	Metric    string              `yaml:"metric"`
+	MaxTrials int                 `yaml:"max_trials"`
+	Search    map[string][]string `yaml:"search"`
+}
+
+func Load(path string) (*File, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var f File
+	if err := yaml.Unmarshal(b, &f); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	f.applyDefaults()
+	return &f, nil
+}
+
+func (f *File) applyDefaults() {
+	if f.Cluster.Nodes < 1 {
+		f.Cluster.Nodes = 1
+	}
+	if f.Cluster.DevicesPerNode < 1 {
+		f.Cluster.DevicesPerNode = 1
+	}
+	if f.Cluster.Epochs < 1 {
+		f.Cluster.Epochs = 1
+	}
+	if f.Cluster.Dataloader.BatchSize < 1 {
+		f.Cluster.Dataloader.BatchSize = 1
+	}
+	if f.Cluster.Dataloader.PrefetchFactor < 1 {
+		f.Cluster.Dataloader.PrefetchFactor = 2
+	}
+	if f.Cache.MaxPreDownload < 1 {
+		f.Cache.MaxPreDownload = 2
+	}
+	if f.Network.MaxConcurrentGets < 1 {
+		f.Network.MaxConcurrentGets = 8
+	}
+	if f.Tuner.MaxTrials < 1 {
+		f.Tuner.MaxTrials = 64
+	}
+	if f.Tuner.Metric == "" {
+		f.Tuner.Metric = "samples_per_sec"
+	}
+	if f.Cluster.CPU.Jitter == "" {
+		f.Cluster.CPU.Jitter = "lognormal"
+	}
+	if f.Cluster.CPU.DecompressWorkers < 1 {
+		f.Cluster.CPU.DecompressWorkers = 4
+	}
+}
+
+func (f *File) ChunksDir() string {
+	if f.Dataset.ChunksDir != "" {
+		return f.Dataset.ChunksDir
+	}
+	p := f.Dataset.Resolved.Path
+	if p == "" {
+		p = f.Dataset.Index
+	}
+	if strings.HasSuffix(p, "index.json") {
+		return filepath.Dir(p)
+	}
+	return p
+}

--- a/simulator/config/config_test.go
+++ b/simulator/config/config_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadHumanSizes(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "litsim.yaml")
+	body := `
+dataset:
+  index: /tmp/ds
+cluster:
+  dataloader:
+    num_workers: 4
+    batch_size: 128
+    prefetch_factor: 2
+cache:
+  max_bytes: 8GiB
+  max_pre_download: 4
+network:
+  bandwidth_bps: 1Gbps
+  rtt_ms: 20
+rate_limit:
+  enabled: true
+  requests_per_sec: 500
+tuner:
+  metric: samples_per_sec
+  search:
+    cache.max_pre_download: ["2", "4"]
+`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := Load(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Cache.MaxBytes.Int64() != 8<<30 {
+		t.Fatalf("max_bytes %d", f.Cache.MaxBytes)
+	}
+	if f.Network.BandwidthBps.Int64() != 1_000_000_000/8 {
+		t.Fatalf("bw %d", f.Network.BandwidthBps)
+	}
+	if f.Cluster.Dataloader.PrefetchFactor != 2 {
+		t.Fatalf("prefetch %d", f.Cluster.Dataloader.PrefetchFactor)
+	}
+}

--- a/simulator/config/init.go
+++ b/simulator/config/init.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Lightning-AI/litData/simulator/index"
+)
+
+func WriteInit(path string, indexPath string, res Resolved, idx *index.Index) error {
+	comp := "none"
+	for _, c := range idx.Chunks {
+		if c.Compressed() {
+			comp = "zstd"
+			break
+		}
+	}
+	bs := 256
+	if n := idx.TotalItems(); n > 0 && n < bs {
+		bs = n
+		if bs > 64 {
+			bs = 64
+		}
+	}
+	body := fmt.Sprintf(initTemplate,
+		indexPath,
+		comp,
+		res.Path, res.URL, res.DataConnectionID, res.IndexJSON,
+		len(idx.Chunks), idx.TotalItems(), idx.TotalBytes(),
+		bs,
+	)
+	return os.WriteFile(path, []byte(body), 0o644)
+}
+
+const initTemplate = `dataset:
+  # Same strings as StreamingDataset(input_dir=...).
+  index: %s
+  chunks_dir: null                     # default: directory that contains index.json
+  compression: %s                      # inferred from filenames
+  resolved:
+    path: %q
+    url: %q
+    data_connection_id: %q
+    index_json: %q
+  # index.json: %d chunks, %d items, %d bytes
+
+cluster:
+  nodes: 1
+  devices_per_node: 8                  # GPUs/ranks per node
+  epochs: 1
+  shuffle: true
+  seed: 42
+  time_per_sample_s: 0                 # GPU train time/sample; 0 = dataloader-only
+  startup_s: 0                         # worker bring-up; fit from two epoch lengths: T0 = t - n*tau
+  cpu:
+    decompress_ns_per_byte: 0
+    deserialize_us_per_sample: 200     # wall tau * num_workers * 1e6; jitter none to match a bench
+    decompress_workers: 4
+    jitter: none                       # lognormal adds scatter; use none when matching a measurement
+    jitter_sigma: 0.35
+  dataloader:
+    num_workers: 4
+    batch_size: %d
+    prefetch_factor: 2                 # batches queued per worker (PyTorch)
+    persistent_workers: false
+    drop_last: true
+
+cache:
+  max_bytes: 8GiB
+  max_pre_download: 4                  # chunks ahead per worker (not batches)
+  keep_compressed: false
+
+optimize:
+  chunk_bytes: 64MiB                   # hypothetical pack for tuner (does not rewrite data)
+  use_headers: true
+
+network:
+  local: false                         # true = files already on node (skip GET/429/RTT)
+  bandwidth_bps: 1Gbps                 # per node (ignored when local: true)
+  rtt_ms: 20
+  max_concurrent_gets: 16
+  extra_latency_ms: 0
+  jitter_ms: 0
+
+rate_limit:
+  enabled: true
+  requests_per_sec: 3500               # cluster-wide token bucket
+  burst: 1000
+  retry_after_s: 1.0
+  max_retries: 8
+  backoff: exponential                 # none | exponential
+  backoff_base_s: 0.2
+  bytes_per_sec: 0                     # 0 = unlimited aggregate
+
+tuner:
+  metric: samples_per_sec              # samples_per_sec | stall_frac | time_to_first_batch
+  max_trials: 64
+  search:
+    optimize.chunk_bytes: [16MiB, 32MiB, 64MiB, 128MiB]
+    cache.max_pre_download: [2, 4, 8]
+    cache.max_bytes: [4GiB, 8GiB, 16GiB]
+    cluster.dataloader.num_workers: [2, 4, 8]
+    cluster.dataloader.prefetch_factor: [2, 4]
+    cluster.dataloader.batch_size: [64, 128, 256]
+    network.max_concurrent_gets: [8, 16, 32]
+    rate_limit.requests_per_sec: [500, 1500, 3500]
+`

--- a/simulator/config/size.go
+++ b/simulator/config/size.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/Lightning-AI/litData/simulator/units"
+	"gopkg.in/yaml.v3"
+)
+
+// ByteSize unmarshals 64MiB / 8GiB / integer bytes.
+type ByteSize int64
+
+func (b ByteSize) Int64() int64 { return int64(b) }
+
+func (b *ByteSize) UnmarshalYAML(n *yaml.Node) error {
+	if n.Kind != yaml.ScalarNode {
+		return fmt.Errorf("byte size: want scalar")
+	}
+	if n.Tag == "!!int" || n.Tag == "!!float" {
+		v, err := strconv.ParseInt(n.Value, 10, 64)
+		if err != nil {
+			f, err2 := strconv.ParseFloat(n.Value, 64)
+			if err2 != nil {
+				return err
+			}
+			*b = ByteSize(int64(f))
+			return nil
+		}
+		*b = ByteSize(v)
+		return nil
+	}
+	v, err := units.ParseBytes(n.Value)
+	if err != nil {
+		return err
+	}
+	*b = ByteSize(v)
+	return nil
+}
+
+func (b ByteSize) MarshalYAML() (any, error) {
+	return units.FormatBytes(int64(b)), nil
+}
+
+// Bandwidth unmarshals 1Gbps / 100MBps / integer bytes/s.
+type Bandwidth int64
+
+func (b Bandwidth) Int64() int64 { return int64(b) }
+
+func (b *Bandwidth) UnmarshalYAML(n *yaml.Node) error {
+	if n.Kind != yaml.ScalarNode {
+		return fmt.Errorf("bandwidth: want scalar")
+	}
+	if n.Tag == "!!int" {
+		v, err := strconv.ParseInt(n.Value, 10, 64)
+		if err != nil {
+			return err
+		}
+		*b = Bandwidth(v)
+		return nil
+	}
+	v, err := units.ParseBandwidth(n.Value)
+	if err != nil {
+		return err
+	}
+	*b = Bandwidth(v)
+	return nil
+}

--- a/simulator/go.mod
+++ b/simulator/go.mod
@@ -1,0 +1,5 @@
+module github.com/Lightning-AI/litData/simulator
+
+go 1.23.0
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/simulator/go.sum
+++ b/simulator/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/simulator/imagenet-spec.yaml
+++ b/simulator/imagenet-spec.yaml
@@ -1,8 +1,8 @@
 dataset:
   # Same strings as StreamingDataset(input_dir=...).
   index: /tmp/imagenet_spec
-  chunks_dir: null                     # default: directory that contains index.json
-  compression: none                      # inferred from filenames
+  chunks_dir: null # default: directory that contains index.json
+  compression: none # inferred from filenames
   resolved:
     path: "/tmp/imagenet_spec"
     url: ""
@@ -12,36 +12,36 @@ dataset:
 
 cluster:
   nodes: 1
-  devices_per_node: 8                  # GPUs/ranks per node
+  devices_per_node: 8 # GPUs/ranks per node
   epochs: 1
   shuffle: true
   seed: 42
-  time_per_sample_s: 0.001             # device/GPU time per sample once tensors are ready
+  time_per_sample_s: 0.001 # device/GPU time per sample once tensors are ready
   cpu:
-    decompress_ns_per_byte: 2.0        # 0 = skip (Mosaic-compatible: all process in time_per_sample_s)
-    deserialize_us_per_sample: 1500     # JPEG decode-ish; calibrate from Litracer
+    decompress_ns_per_byte: 2.0 # 0 = skip (Mosaic-compatible: all process in time_per_sample_s)
+    deserialize_us_per_sample: 1500 # JPEG decode-ish; calibrate from Litracer
     decompress_workers: 4
-    jitter: lognormal                  # none | lognormal
-    jitter_sigma: 0.35                 # log-space std; p90/p50 ≈ exp(1.28*sigma)
+    jitter: lognormal # none | lognormal
+    jitter_sigma: 0.35 # log-space std; p90/p50 ≈ exp(1.28*sigma)
     calibrate_file: null
   dataloader:
     num_workers: 8
     batch_size: 256
-    prefetch_factor: 2                 # batches queued per worker (PyTorch)
+    prefetch_factor: 2 # batches queued per worker (PyTorch)
     persistent_workers: false
     drop_last: true
 
 cache:
-  max_bytes: 200GiB                    # stream_imagenet.py default max_cache_size
-  max_pre_download: 4                  # chunks ahead per worker (not batches)
+  max_bytes: 200GiB # stream_imagenet.py default max_cache_size
+  max_pre_download: 4 # chunks ahead per worker (not batches)
   keep_compressed: false
 
 optimize:
-  chunk_bytes: 64MiB                   # hypothetical pack for tuner (does not rewrite data)
+  chunk_bytes: 64MiB # hypothetical pack for tuner (does not rewrite data)
   use_headers: true
 
 network:
-  bandwidth_bps: 1Gbps                 # per node
+  bandwidth_bps: 1Gbps # per node
   rtt_ms: 20
   max_concurrent_gets: 16
   extra_latency_ms: 0
@@ -49,16 +49,16 @@ network:
 
 rate_limit:
   enabled: true
-  requests_per_sec: 3500               # cluster-wide token bucket
+  requests_per_sec: 3500 # cluster-wide token bucket
   burst: 1000
   retry_after_s: 1.0
   max_retries: 8
-  backoff: exponential                 # none | exponential
+  backoff: exponential # none | exponential
   backoff_base_s: 0.2
-  bytes_per_sec: 0                     # 0 = unlimited aggregate
+  bytes_per_sec: 0 # 0 = unlimited aggregate
 
 tuner:
-  metric: samples_per_sec              # samples_per_sec | stall_frac | time_to_first_batch
+  metric: samples_per_sec # samples_per_sec | stall_frac | time_to_first_batch
   max_trials: 64
   search:
     optimize.chunk_bytes: [16MiB, 32MiB, 64MiB, 128MiB]

--- a/simulator/imagenet-spec.yaml
+++ b/simulator/imagenet-spec.yaml
@@ -1,0 +1,71 @@
+dataset:
+  # Same strings as StreamingDataset(input_dir=...).
+  index: /tmp/imagenet_spec
+  chunks_dir: null                     # default: directory that contains index.json
+  compression: none                      # inferred from filenames
+  resolved:
+    path: "/tmp/imagenet_spec"
+    url: ""
+    data_connection_id: ""
+    index_json: "/tmp/imagenet_spec/index.json"
+  # index.json: 2347 chunks, 1281167 items, 157429800960 bytes
+
+cluster:
+  nodes: 1
+  devices_per_node: 8                  # GPUs/ranks per node
+  epochs: 1
+  shuffle: true
+  seed: 42
+  time_per_sample_s: 0.001             # device/GPU time per sample once tensors are ready
+  cpu:
+    decompress_ns_per_byte: 2.0        # 0 = skip (Mosaic-compatible: all process in time_per_sample_s)
+    deserialize_us_per_sample: 1500     # JPEG decode-ish; calibrate from Litracer
+    decompress_workers: 4
+    jitter: lognormal                  # none | lognormal
+    jitter_sigma: 0.35                 # log-space std; p90/p50 ≈ exp(1.28*sigma)
+    calibrate_file: null
+  dataloader:
+    num_workers: 8
+    batch_size: 256
+    prefetch_factor: 2                 # batches queued per worker (PyTorch)
+    persistent_workers: false
+    drop_last: true
+
+cache:
+  max_bytes: 200GiB                    # stream_imagenet.py default max_cache_size
+  max_pre_download: 4                  # chunks ahead per worker (not batches)
+  keep_compressed: false
+
+optimize:
+  chunk_bytes: 64MiB                   # hypothetical pack for tuner (does not rewrite data)
+  use_headers: true
+
+network:
+  bandwidth_bps: 1Gbps                 # per node
+  rtt_ms: 20
+  max_concurrent_gets: 16
+  extra_latency_ms: 0
+  jitter_ms: 0
+
+rate_limit:
+  enabled: true
+  requests_per_sec: 3500               # cluster-wide token bucket
+  burst: 1000
+  retry_after_s: 1.0
+  max_retries: 8
+  backoff: exponential                 # none | exponential
+  backoff_base_s: 0.2
+  bytes_per_sec: 0                     # 0 = unlimited aggregate
+
+tuner:
+  metric: samples_per_sec              # samples_per_sec | stall_frac | time_to_first_batch
+  max_trials: 64
+  search:
+    optimize.chunk_bytes: [16MiB, 32MiB, 64MiB, 128MiB]
+    cache.max_pre_download: [2, 4, 8]
+    cache.max_bytes: [4GiB, 8GiB, 16GiB]
+    cluster.dataloader.num_workers: [2, 4, 8]
+    cluster.dataloader.prefetch_factor: [2, 4]
+    cluster.dataloader.batch_size: [64, 128, 256]
+    network.max_concurrent_gets: [8, 16, 32]
+    rate_limit.requests_per_sec: [500, 1500, 3500]

--- a/simulator/index/index.go
+++ b/simulator/index/index.go
@@ -1,0 +1,73 @@
+package index
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Chunk is one entry from LitData index.json.
+type Chunk struct {
+	Filename   string `json:"filename"`
+	ChunkBytes int64  `json:"chunk_bytes"`
+	ChunkSize  int    `json:"chunk_size"`
+}
+
+// Index is the merged LitData index (chunks + config).
+type Index struct {
+	Chunks []Chunk         `json:"chunks"`
+	Config json.RawMessage `json:"config"`
+}
+
+func Load(path string) (*Index, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var idx Index
+	if err := json.Unmarshal(b, &idx); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if len(idx.Chunks) == 0 {
+		return nil, fmt.Errorf("%s: no chunks", path)
+	}
+	return &idx, nil
+}
+
+func (c Chunk) Compressed() bool {
+	return strings.Contains(c.Filename, ".zstd.") || strings.HasSuffix(c.Filename, ".zstd.bin")
+}
+
+func (idx *Index) TotalItems() int {
+	n := 0
+	for _, c := range idx.Chunks {
+		n += c.ChunkSize
+	}
+	return n
+}
+
+func (idx *Index) TotalBytes() int64 {
+	var n int64
+	for _, c := range idx.Chunks {
+		n += c.ChunkBytes
+	}
+	return n
+}
+
+// MeanItemBytes is chunk_bytes / chunk_size averaged over chunks with items.
+// For compressed files this is compressed bytes per item (download cost).
+func (idx *Index) MeanItemBytes() float64 {
+	var b int64
+	var n int
+	for _, c := range idx.Chunks {
+		if c.ChunkSize > 0 {
+			b += c.ChunkBytes
+			n += c.ChunkSize
+		}
+	}
+	if n == 0 {
+		return 0
+	}
+	return float64(b) / float64(n)
+}

--- a/simulator/report/report.go
+++ b/simulator/report/report.go
@@ -1,0 +1,258 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Lightning-AI/litData/simulator/config"
+	"github.com/Lightning-AI/litData/simulator/index"
+	"github.com/Lightning-AI/litData/simulator/sim"
+	"github.com/Lightning-AI/litData/simulator/tune"
+)
+
+type Payload struct {
+	Chunks [][2]int64       `json:"chunks"` // [bytes, items]
+	Config map[string]any   `json:"config"`
+	Result sim.Result       `json:"result"`
+	Trials []tune.Candidate `json:"trials,omitempty"`
+}
+
+func Write(path string, idx *index.Index, file *config.File, res sim.Result, trials []tune.Candidate) error {
+	chunks := make([][2]int64, len(idx.Chunks))
+	for i, c := range idx.Chunks {
+		chunks[i] = [2]int64{c.ChunkBytes, int64(c.ChunkSize)}
+	}
+	cfg := map[string]any{
+		"num_workers":               file.Cluster.Dataloader.NumWorkers,
+		"batch_size":                file.Cluster.Dataloader.BatchSize,
+		"prefetch_factor":           file.Cluster.Dataloader.PrefetchFactor,
+		"drop_last":                 file.Cluster.Dataloader.DropLast,
+		"max_pre_download":          file.Cache.MaxPreDownload,
+		"max_bytes":                 file.Cache.MaxBytes.Int64(),
+		"bandwidth_bps":             file.Network.BandwidthBps.Int64(),
+		"rtt_ms":                    file.Network.RTTMs,
+		"max_concurrent_gets":       file.Network.MaxConcurrentGets,
+		"time_per_sample_s":         file.Cluster.TimePerSampleS,
+		"decompress_ns_per_byte":    file.Cluster.CPU.DecompressNsPerByte,
+		"deserialize_us_per_sample": file.Cluster.CPU.DeserializeUsPerSample,
+		"jitter_sigma":              file.Cluster.CPU.JitterSigma,
+		"cpu_jitter":                file.Cluster.CPU.Jitter,
+		"rate_limit_enabled":        file.RateLimit.Enabled,
+		"requests_per_sec":          file.RateLimit.RequestsPerSec,
+		"burst":                     file.RateLimit.Burst,
+		"seed":                      file.Cluster.Seed,
+		"shuffle":                   file.Cluster.Shuffle,
+		"epochs":                    file.Cluster.Epochs,
+		"index":                     file.Dataset.Index,
+	}
+	raw, err := json.Marshal(Payload{Chunks: chunks, Config: cfg, Result: res, Trials: trials})
+	if err != nil {
+		return err
+	}
+	body := strings.Replace(htmlPage, "__PAYLOAD__", string(raw), 1)
+	return os.WriteFile(path, []byte(body), 0o644)
+}
+
+func FormatResult(r sim.Result) string {
+	return fmt.Sprintf(
+		"samples/s=%.1f stall=%.2fs (%.1f%%) ttfb=%.3fs downloaded=%d peak_cache=%d 429s=%d",
+		r.SamplesPerSec, r.StallS, 100*r.StallFrac(), r.TimeToFirstBatchS, r.DownloadedBytes, r.PeakCacheBytes, r.HTTP429Count,
+	)
+}
+
+const htmlPage = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><title>litsim</title>
+<style>
+body{font-family:ui-sans-serif,system-ui,sans-serif;margin:0;display:flex;height:100vh;background:#111;color:#eee}
+#side{width:320px;overflow:auto;padding:16px;border-right:1px solid #333;background:#1a1a1a}
+#main{flex:1;overflow:auto;padding:16px}
+label{display:block;margin:10px 0 4px;font-size:12px;color:#aaa}
+input,select{width:100%;background:#222;color:#eee;border:1px solid #444;padding:6px;border-radius:4px}
+button{margin-top:12px;padding:8px 12px;background:#3b82f6;color:#fff;border:0;border-radius:6px;cursor:pointer}
+.stat{display:inline-block;margin:8px 16px 8px 0}
+table{border-collapse:collapse;width:100%;font-size:13px}
+td,th{border-bottom:1px solid #333;padding:6px;text-align:left}
+canvas{width:100%;max-height:180px;background:#0d0d0d;margin:12px 0}
+</style></head><body>
+<aside id="side">
+<h2>litsim</h2>
+<label>num_workers</label><input id="num_workers" type="number">
+<label>batch_size</label><input id="batch_size" type="number">
+<label>prefetch_factor</label><input id="prefetch_factor" type="number">
+<label>max_pre_download</label><input id="max_pre_download" type="number">
+<label>bandwidth_bps</label><input id="bandwidth_bps" type="number">
+<label>rtt_ms</label><input id="rtt_ms" type="number">
+<label>max_concurrent_gets</label><input id="max_concurrent_gets" type="number">
+<label>requests_per_sec</label><input id="requests_per_sec" type="number">
+<label>time_per_sample_s</label><input id="time_per_sample_s" type="number" step="0.0001">
+<label>decompress_ns_per_byte</label><input id="decompress_ns_per_byte" type="number" step="0.1">
+<label>deserialize_us_per_sample</label><input id="deserialize_us_per_sample" type="number">
+<label>jitter_sigma</label><input id="jitter_sigma" type="number" step="0.05">
+<button onclick="replay()">Replay sim</button>
+<button onclick="exportYaml()">Export YAML</button>
+</aside>
+<main id="main">
+<div id="stats"></div>
+<canvas id="chart" height="160"></canvas>
+<h3>Tune trials</h3>
+<div id="trials"></div>
+</main>
+<script>
+const DATA = __PAYLOAD__;
+function fill() {
+  const c = DATA.config;
+  for (const k of Object.keys(c)) {
+    const el = document.getElementById(k);
+    if (el) el.value = c[k];
+  }
+  show(DATA.result);
+  draw(DATA.result.Steps || []);
+  trials(DATA.trials || []);
+}
+function readCfg() {
+  const g = id => document.getElementById(id);
+  return {
+    num_workers: +g('num_workers').value,
+    batch_size: +g('batch_size').value,
+    prefetch_factor: +g('prefetch_factor').value,
+    max_pre_download: +g('max_pre_download').value,
+    bandwidth_bps: +g('bandwidth_bps').value,
+    rtt_ms: +g('rtt_ms').value,
+    max_concurrent_gets: +g('max_concurrent_gets').value,
+    requests_per_sec: +g('requests_per_sec').value,
+    time_per_sample_s: +g('time_per_sample_s').value,
+    decompress_ns_per_byte: +g('decompress_ns_per_byte').value,
+    deserialize_us_per_sample: +g('deserialize_us_per_sample').value,
+    jitter_sigma: +g('jitter_sigma').value,
+  };
+}
+function mulberry32(a){return function(){a|=0;a=a+0x6D2B79F5|0;let t=Math.imul(a^a>>>15,1|a);t=t+Math.imul(t^t>>>7,61|t)^t;return((t^t>>>14)>>>0)/4294967296}}
+function randn(r){let u=1-r(),v=r();return Math.sqrt(-2*Math.log(u))*Math.cos(2*Math.PI*v)}
+function runSim(chunks, cfg) {
+  const readers = Math.max(1, cfg.num_workers|0);
+  const bs = Math.max(1, cfg.batch_size|0);
+  let stream = [];
+  for (let i=0;i<chunks.length;i++) {
+    const n = chunks[i][1];
+    for (let k=0;k<n;k++) stream.push(i);
+  }
+  const rng = mulberry32(42);
+  let now=0, tokens=1000, lastFill=0, n429=0, downloaded=0, samples=0, stall=0, first=true, ttfb=0;
+  const cache = new Set();
+  const rps = cfg.requests_per_sec || 3500;
+  function refill(){ tokens = Math.min(1000, tokens + (now-lastFill)*rps); lastFill=now; }
+  function getOne(id) {
+    refill();
+    let retries=0;
+    while (tokens < 1) {
+      n429++; now += 1; stall += 1; retries++; if (retries>8) break;
+      refill();
+    }
+    tokens -= 1;
+    const rtt = (cfg.rtt_ms||20)/1000;
+    const bw = Math.max(1, cfg.bandwidth_bps||1e8);
+    const bytes = chunks[id][0];
+    now += rtt + bytes/bw;
+    cache.add(id);
+    downloaded += bytes;
+  }
+  for (let start=0; start<stream.length; start+=bs) {
+    const end = Math.min(stream.length, start+bs);
+    const need = new Set();
+    for (let i=start;i<end;i++) need.add(stream[i]);
+    const t0=now;
+    for (const id of need) if (!cache.has(id)) getOne(id);
+    stall += now-t0;
+    if (first) { ttfb = now-t0; first=false; }
+    let dec=0;
+    for (const id of need) {
+      let m = 1;
+      if ((cfg.jitter_sigma||0)>0) m = Math.exp(randn(rng)*cfg.jitter_sigma);
+      dec += chunks[id][0]*(cfg.decompress_ns_per_byte||0)*1e-9*m;
+    }
+    now += dec / Math.max(1, readers);
+    const n = end-start;
+    now += n*(cfg.deserialize_us_per_sample||0)*1e-6 / readers;
+    now += n*(cfg.time_per_sample_s||0);
+    samples += n;
+    const pre = cfg.max_pre_download * readers;
+    let seen=new Set(), got=0;
+    for (let i=end;i<stream.length && got<pre;i++) {
+      const id=stream[i];
+      if (seen.has(id)||cache.has(id)) continue;
+      seen.add(id); getOne(id); got++;
+    }
+  }
+  const sps = samples/Math.max(now,1e-9);
+  return {Samples:samples, TotalS:now, StallS:stall, SamplesPerSec:sps, TimeToFirstBatchS:ttfb, DownloadedBytes:downloaded, HTTP429Count:n429, PeakCacheBytes:0, Steps:[]};
+}
+function replay() {
+  const r = runSim(DATA.chunks, readCfg());
+  show(r);
+}
+function show(r) {
+  document.getElementById('stats').innerHTML =
+    '<span class="stat"><b>'+(r.SamplesPerSec||0).toFixed(1)+'</b> samples/s</span>'+
+    '<span class="stat">stall '+(r.StallS||0).toFixed(2)+'s</span>'+
+    '<span class="stat">ttfb '+(r.TimeToFirstBatchS||0).toFixed(3)+'s</span>'+
+    '<span class="stat">429s '+(r.HTTP429Count||0)+'</span>'+
+    '<span class="stat">downloaded '+(r.DownloadedBytes||0)+'</span>';
+}
+function draw(steps) {
+  const c = document.getElementById('chart');
+  const ctx = c.getContext('2d');
+  c.width = c.clientWidth; c.height = 160;
+  ctx.clearRect(0,0,c.width,c.height);
+  if (!steps.length) return;
+  const ys = steps.map(s => s.SamplesPerSec||0);
+  const max = Math.max(...ys, 1);
+  ctx.strokeStyle='#3b82f6'; ctx.beginPath();
+  steps.forEach((s,i) => {
+    const x = i/(steps.length-1||1)*c.width;
+    const y = c.height - (s.SamplesPerSec||0)/max*c.height;
+    i?ctx.lineTo(x,y):ctx.moveTo(x,y);
+  });
+  ctx.stroke();
+}
+function trials(rows) {
+  if (!rows.length) { document.getElementById('trials').textContent='(none)'; return; }
+  let h='<table><tr><th>overrides</th><th>samples/s</th><th>stall</th><th>429</th></tr>';
+  for (const t of rows.slice(0,32)) {
+    h += '<tr><td>'+JSON.stringify(t.Overrides||{})+'</td><td>'+(t.Result.SamplesPerSec||0).toFixed(1)+
+         '</td><td>'+(t.Result.StallS||0).toFixed(2)+'</td><td>'+(t.Result.HTTP429Count||0)+'</td></tr>';
+  }
+  document.getElementById('trials').innerHTML=h+'</table>';
+}
+function exportYaml() {
+  const c = readCfg();
+  const y = [
+    'cluster:',
+    '  time_per_sample_s: '+c.time_per_sample_s,
+    '  cpu:',
+    '    decompress_ns_per_byte: '+c.decompress_ns_per_byte,
+    '    deserialize_us_per_sample: '+c.deserialize_us_per_sample,
+    '    jitter_sigma: '+c.jitter_sigma,
+    '  dataloader:',
+    '    num_workers: '+c.num_workers,
+    '    batch_size: '+c.batch_size,
+    '    prefetch_factor: '+c.prefetch_factor,
+    'cache:',
+    '  max_pre_download: '+c.max_pre_download,
+    'network:',
+    '  bandwidth_bps: '+c.bandwidth_bps,
+    '  rtt_ms: '+c.rtt_ms,
+    '  max_concurrent_gets: '+c.max_concurrent_gets,
+    'rate_limit:',
+    '  requests_per_sec: '+c.requests_per_sec,
+  ].join('\n');
+  const blob = new Blob([y], {type:'text/yaml'});
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'litsim.yaml';
+  a.click();
+}
+fill();
+</script></body></html>
+`

--- a/simulator/resolve/resolve.go
+++ b/simulator/resolve/resolve.go
@@ -1,0 +1,104 @@
+package resolve
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/Lightning-AI/litData/simulator/config"
+)
+
+type Result struct {
+	Path             string `json:"path"`
+	URL              string `json:"url"`
+	DataConnectionID string `json:"data_connection_id"`
+	IndexJSON        string `json:"index_json"`
+	Error            string `json:"error"`
+}
+
+func scriptPath() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return ""
+	}
+	// resolve/resolve.go -> simulator/resolve_path.py
+	return filepath.Join(filepath.Dir(file), "..", "resolve_path.py")
+}
+
+func Path(user string) (config.Resolved, error) {
+	script := scriptPath()
+	py := os.Getenv("PYTHON")
+	if py == "" {
+		py = "python3"
+	}
+	cmd := exec.Command(py, script, user)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		local, ferr := fallbackLocal(user)
+		if ferr == nil {
+			return local, nil
+		}
+		return config.Resolved{}, fmt.Errorf(
+			"resolver failed (%v): %s\nInstall litdata (PYTHONPATH=src) or pass a local index.json. %v",
+			err, strings.TrimSpace(string(out)), ferr,
+		)
+	}
+	var r Result
+	if err := json.Unmarshal(out, &r); err != nil {
+		return config.Resolved{}, fmt.Errorf("resolver JSON: %w (%s)", err, out)
+	}
+	if r.Error != "" {
+		return config.Resolved{}, fmt.Errorf("%s", r.Error)
+	}
+	return config.Resolved{
+		Path:             r.Path,
+		URL:              r.URL,
+		DataConnectionID: r.DataConnectionID,
+		IndexJSON:        r.IndexJSON,
+	}, nil
+}
+
+func fallbackLocal(user string) (config.Resolved, error) {
+	p := user
+	if strings.HasSuffix(p, "index.json") {
+		if _, err := os.Stat(p); err != nil {
+			return config.Resolved{}, err
+		}
+		return config.Resolved{Path: filepath.Dir(p), IndexJSON: p}, nil
+	}
+	idx := filepath.Join(p, "index.json")
+	if _, err := os.Stat(idx); err != nil {
+		return config.Resolved{}, err
+	}
+	abs, _ := filepath.Abs(p)
+	return config.Resolved{Path: abs, IndexJSON: idx}, nil
+}
+
+func IndexJSONPath(res config.Resolved, user string) string {
+	if res.IndexJSON != "" {
+		// Prefer a readable local file.
+		if !strings.Contains(res.IndexJSON, "://") {
+			return res.IndexJSON
+		}
+	}
+	if res.Path != "" {
+		if strings.HasSuffix(res.Path, "index.json") {
+			return res.Path
+		}
+		cand := filepath.Join(res.Path, "index.json")
+		if _, err := os.Stat(cand); err == nil {
+			return cand
+		}
+	}
+	if strings.HasSuffix(user, "index.json") && !strings.Contains(user, "://") {
+		return user
+	}
+	if !strings.Contains(user, "://") {
+		return filepath.Join(user, "index.json")
+	}
+	return res.IndexJSON
+}

--- a/simulator/resolve_path.py
+++ b/simulator/resolve_path.py
@@ -3,6 +3,7 @@
 
 Prints JSON: path, url, data_connection_id, index_json.
 """
+
 from __future__ import annotations
 
 import json
@@ -19,14 +20,7 @@ try:
     from litdata.streaming.resolver import _resolve_dir
 except ImportError as e:
     print(
-        json.dumps(
-            {
-                "error": (
-                    "litdata resolver unavailable; install litdata or set PYTHONPATH to src. "
-                    f"{e}"
-                )
-            }
-        ),
+        json.dumps({"error": (f"litdata resolver unavailable; install litdata or set PYTHONPATH to src. {e}")}),
         file=sys.stderr,
     )
     sys.exit(2)

--- a/simulator/resolve_path.py
+++ b/simulator/resolve_path.py
@@ -44,6 +44,7 @@ def _index_json(path: str | None, url: str | None, user: str) -> str:
 
 
 def main() -> None:
+    """Print JSON for the resolved dataset directory and index.json path."""
     if len(sys.argv) != 2:
         print("usage: resolve_path.py <dataset-path-or-index.json>", file=sys.stderr)
         sys.exit(1)

--- a/simulator/resolve_path.py
+++ b/simulator/resolve_path.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Resolve a StreamingDataset-style path via litdata.streaming.resolver._resolve_dir.
+
+Prints JSON: path, url, data_connection_id, index_json.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SRC = _ROOT / "src"
+if _SRC.is_dir():
+    sys.path.insert(0, str(_SRC))
+
+try:
+    from litdata.streaming.resolver import _resolve_dir
+except ImportError as e:
+    print(
+        json.dumps(
+            {
+                "error": (
+                    "litdata resolver unavailable; install litdata or set PYTHONPATH to src. "
+                    f"{e}"
+                )
+            }
+        ),
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def _index_json(path: str | None, url: str | None, user: str) -> str:
+    u = user.rstrip("/")
+    if u.endswith("index.json"):
+        return u
+    if path:
+        p = path.rstrip("/")
+        if p.endswith("index.json"):
+            return p
+        return os.path.join(p, "index.json")
+    if url:
+        base = url.rstrip("/")
+        if base.endswith("index.json"):
+            return base
+        return base + "/index.json"
+    return u + "/index.json"
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("usage: resolve_path.py <dataset-path-or-index.json>", file=sys.stderr)
+        sys.exit(1)
+    user = sys.argv[1]
+    d = _resolve_dir(user)
+    out = {
+        "path": d.path,
+        "url": d.url,
+        "data_connection_id": d.data_connection_id,
+        "index_json": _index_json(d.path, d.url, user),
+    }
+    print(json.dumps(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/simulator/sim/sim.go
+++ b/simulator/sim/sim.go
@@ -1,0 +1,587 @@
+package sim
+
+import (
+	"math"
+	"math/rand"
+
+	"github.com/Lightning-AI/litData/simulator/config"
+	"github.com/Lightning-AI/litData/simulator/index"
+)
+
+type Config struct {
+	Workers            int
+	BatchSize          int
+	PrefetchFactor     int
+	DropLast           bool
+	PersistentWorkers  bool
+	MaxPreDownload     int
+	CacheBytes         int64
+	BandwidthBps       int64
+	TimePerSampleS     float64
+	Shuffle            bool
+	Seed               int64
+	Epochs             int
+	RTTMs              float64
+	ExtraLatencyMs     float64
+	JitterMs           float64
+	MaxConcurrentGets  int
+	RateLimitEnabled   bool
+	RequestsPerSec     float64
+	Burst              int
+	RetryAfterS        float64
+	MaxRetries         int
+	BackoffExponential bool
+	BackoffBaseS       float64
+	BytesPerSec        int64
+	DecompressNsPerB   float64
+	DeserializeUs      float64
+	DecompressWorkers  int
+	CPUJitter          string
+	JitterSigma        float64
+	AssumeResident     bool    // local files: GETs are free (page cache / already on disk)
+	StartupS           float64 // worker process bring-up
+}
+
+type Result struct {
+	Samples           int     `json:"samples"`
+	Batches           int     `json:"batches"`
+	StallS            float64 `json:"stall_s"`
+	ComputeS          float64 `json:"compute_s"`
+	CPUDecompressS    float64 `json:"cpu_decompress_s"`
+	CPUDeserializeS   float64 `json:"cpu_deserialize_s"`
+	TotalS            float64 `json:"total_s"`
+	DownloadedBytes   int64   `json:"downloaded_bytes"`
+	PeakCacheBytes    int64   `json:"peak_cache_bytes"`
+	TimeToFirstBatchS float64 `json:"time_to_first_batch_s"`
+	SamplesPerSec     float64 `json:"samples_per_sec"`
+	MinCacheBytes     int64   `json:"min_cache_bytes"`
+	StalledBatches    int     `json:"stalled_batches"`
+	HTTP429Count      int     `json:"http_429_count"`
+	BackoffS          float64 `json:"backoff_s"`
+	Failed            bool    `json:"failed"`
+	FailReason        string  `json:"fail_reason"`
+	Steps             []Step  `json:"steps"`
+}
+
+type Step struct {
+	N             int     `json:"n"`
+	T             float64 `json:"t"`
+	SamplesPerSec float64 `json:"samples_per_sec"`
+	Downloaded    int64   `json:"downloaded"`
+	InFlight      int     `json:"in_flight"`
+	HTTP429       int     `json:"http_429"`
+}
+
+type chunkRef struct {
+	id    int
+	bytes int64
+	items int
+}
+
+type sampleLoc struct{ chunk int }
+
+func DefaultConfig() Config {
+	return Config{
+		Workers:           4,
+		BatchSize:         64,
+		PrefetchFactor:    2,
+		MaxPreDownload:    4,
+		CacheBytes:        8 << 30,
+		BandwidthBps:      1_000_000_000 / 8,
+		TimePerSampleS:    0.001,
+		Shuffle:           true,
+		Seed:              42,
+		Epochs:            1,
+		RTTMs:             20,
+		MaxConcurrentGets: 16,
+		RequestsPerSec:    3500,
+		Burst:             1000,
+		RetryAfterS:       1,
+		MaxRetries:        8,
+		BackoffBaseS:      0.2,
+		DecompressWorkers: 4,
+		CPUJitter:         "none",
+	}
+}
+
+func FromFile(f *config.File) Config {
+	c := DefaultConfig()
+	dl := f.Cluster.Dataloader
+	c.Workers = dl.NumWorkers
+	c.BatchSize = dl.BatchSize
+	c.PrefetchFactor = dl.PrefetchFactor
+	c.DropLast = dl.DropLast
+	c.PersistentWorkers = dl.PersistentWorkers
+	c.MaxPreDownload = f.Cache.MaxPreDownload
+	c.CacheBytes = f.Cache.MaxBytes.Int64()
+	c.BandwidthBps = f.Network.BandwidthBps.Int64()
+	c.TimePerSampleS = f.Cluster.TimePerSampleS
+	c.Shuffle = f.Cluster.Shuffle
+	c.Seed = f.Cluster.Seed
+	c.Epochs = f.Cluster.Epochs
+	c.RTTMs = f.Network.RTTMs
+	c.ExtraLatencyMs = f.Network.ExtraLatencyMs
+	c.JitterMs = f.Network.JitterMs
+	c.MaxConcurrentGets = f.Network.MaxConcurrentGets
+	c.RateLimitEnabled = f.RateLimit.Enabled
+	c.RequestsPerSec = f.RateLimit.RequestsPerSec
+	c.Burst = f.RateLimit.Burst
+	c.RetryAfterS = f.RateLimit.RetryAfterS
+	c.MaxRetries = f.RateLimit.MaxRetries
+	c.BackoffExponential = f.RateLimit.Backoff == "exponential"
+	c.BackoffBaseS = f.RateLimit.BackoffBaseS
+	c.BytesPerSec = f.RateLimit.BytesPerSec
+	cpu := f.Cluster.CPU
+	c.DecompressNsPerB = cpu.DecompressNsPerByte
+	c.DeserializeUs = cpu.DeserializeUsPerSample
+	c.DecompressWorkers = cpu.DecompressWorkers
+	c.CPUJitter = cpu.Jitter
+	c.JitterSigma = cpu.JitterSigma
+	c.StartupS = f.Cluster.StartupS
+	c.AssumeResident = f.Network.Local
+	return c
+}
+
+func Run(idx *index.Index, cfg Config) Result {
+	if cfg.Workers < 0 {
+		cfg.Workers = 0
+	}
+	readers := cfg.Workers
+	if readers < 1 {
+		readers = 1
+	}
+	if cfg.BatchSize < 1 {
+		cfg.BatchSize = 1
+	}
+	if cfg.Epochs < 1 {
+		cfg.Epochs = 1
+	}
+	if cfg.BandwidthBps < 1 {
+		cfg.BandwidthBps = 1
+	}
+	if cfg.MaxPreDownload < 1 {
+		cfg.MaxPreDownload = 1
+	}
+	if cfg.MaxConcurrentGets < 1 {
+		cfg.MaxConcurrentGets = 8
+	}
+	if cfg.DecompressWorkers < 1 {
+		cfg.DecompressWorkers = 1
+	}
+	if cfg.PrefetchFactor < 1 {
+		cfg.PrefetchFactor = 2
+	}
+
+	chunks := make([]chunkRef, len(idx.Chunks))
+	for i, c := range idx.Chunks {
+		chunks[i] = chunkRef{id: i, bytes: c.ChunkBytes, items: c.ChunkSize}
+	}
+
+	order := make([]int, len(chunks))
+	for i := range order {
+		order[i] = i
+	}
+
+	rng := rand.New(rand.NewSource(cfg.Seed))
+	net := newNet(cfg, rng)
+
+	var totalStall, totalCompute, ttfb, cpuDec, cpuDeser float64
+	var downloaded, peak int64
+	var batches, stalledBatches, samples int
+	first := true
+	var steps []Step
+	inflated := map[int]bool{}
+
+	for epoch := 0; epoch < cfg.Epochs; epoch++ {
+		ord := append([]int(nil), order...)
+		if cfg.Shuffle {
+			erng := rand.New(rand.NewSource(cfg.Seed + int64(epoch)))
+			erng.Shuffle(len(ord), func(i, j int) { ord[i], ord[j] = ord[j], ord[i] })
+		}
+
+		var stream []sampleLoc
+		for _, id := range ord {
+			if chunks[id].items > 0 {
+				for i := 0; i < chunks[id].items; i++ {
+					stream = append(stream, sampleLoc{chunk: id})
+				}
+			}
+		}
+
+		cache := newLRU(cfg.CacheBytes)
+		if cfg.AssumeResident {
+			for _, ch := range chunks {
+				if ch.items > 0 {
+					cache.add(ch.id, ch.bytes)
+				}
+			}
+		}
+		if epoch == 0 || !cfg.PersistentWorkers {
+			net.now += cfg.StartupS
+		}
+
+		lookSamples := cfg.PrefetchFactor * cfg.BatchSize * readers
+		preChunks := cfg.MaxPreDownload * readers
+
+		for start := 0; start < len(stream); start += cfg.BatchSize {
+			end := start + cfg.BatchSize
+			if end > len(stream) {
+				if cfg.DropLast {
+					break
+				}
+				end = len(stream)
+			}
+			n := end - start
+			needIDs := uniqueChunks(stream[start:end])
+			aheadLimit := preChunks
+			if look := uniqueChunks(stream[end:min(len(stream), end+lookSamples)]); len(look) > aheadLimit {
+				aheadLimit = len(look)
+			}
+			ahead := upcomingChunks(stream, end, aheadLimit)
+
+			var waitBytes int64
+			toGet := []int{}
+			for _, id := range needIDs {
+				if cache.has(id) {
+					cache.touch(id)
+					continue
+				}
+				waitBytes += chunks[id].bytes
+				toGet = append(toGet, id)
+			}
+
+			stall0 := net.now
+			ok := net.downloadAll(toGet, chunks, cache)
+			if !ok {
+				return Result{Failed: true, FailReason: "GET retries exhausted", HTTP429Count: net.n429, BackoffS: net.backoffS}
+			}
+			stall := net.now - stall0
+			for _, id := range toGet {
+				downloaded += chunks[id].bytes
+			}
+
+			// Decompress newly local needed chunks once.
+			var decS float64
+			pendingDec := 0
+			for _, id := range needIDs {
+				if inflated[id] {
+					continue
+				}
+				inflated[id] = true
+				dt := float64(chunks[id].bytes) * cfg.DecompressNsPerB * 1e-9
+				dt *= cpuMul(rng, cfg)
+				decS += dt
+				pendingDec++
+			}
+			if pendingDec > 0 && cfg.DecompressWorkers > 0 {
+				decS = decS / float64(min(cfg.DecompressWorkers, pendingDec))
+			}
+			cpuDec += decS
+
+			deser := float64(n) * cfg.DeserializeUs * 1e-6
+			deser *= cpuMul(rng, cfg)
+			deser /= float64(readers)
+			cpuDeser += deser
+
+			compute := float64(n) * cfg.TimePerSampleS
+			totalCompute += compute
+			// DataLoader workers overlap the GPU: wall is max(CPU, device), not the sum.
+			work := math.Max(decS+deser, compute)
+
+			// Prefetch during the overlapped work window.
+			budgetT := work
+			preGet := []int{}
+			for _, id := range ahead {
+				if cache.has(id) {
+					continue
+				}
+				preGet = append(preGet, id)
+				if len(preGet) >= preChunks {
+					break
+				}
+			}
+			if len(preGet) > 0 {
+				t0 := net.now
+				net.downloadAll(preGet, chunks, cache)
+				dt := net.now - t0
+				if dt > budgetT {
+					stall += dt - budgetT
+					net.now = t0 + dt
+				} else {
+					net.now = t0 + budgetT
+				}
+				for _, id := range preGet {
+					if cache.has(id) {
+						downloaded += chunks[id].bytes
+					}
+				}
+			} else {
+				net.now += work
+			}
+
+			if cache.used > peak {
+				peak = cache.used
+			}
+
+			totalStall += stall
+			if waitBytes > 0 || stall > 1e-9 {
+				stalledBatches++
+			}
+			if first {
+				ttfb = stall + decS + deser
+				first = false
+			}
+			batches++
+			samples += n
+			elapsed := net.now
+			sps := 0.0
+			if elapsed > 0 {
+				sps = float64(samples) / elapsed
+			}
+			if batches%max(1, batches/200+1) == 0 || batches <= 32 {
+				steps = append(steps, Step{
+					N: batches, T: elapsed, SamplesPerSec: sps,
+					Downloaded: downloaded, HTTP429: net.n429,
+				})
+			}
+		}
+	}
+
+	total := net.now
+	sps := 0.0
+	if total > 0 {
+		sps = float64(samples) / total
+	}
+	return Result{
+		Samples:           samples,
+		Batches:           batches,
+		StallS:            totalStall,
+		ComputeS:          totalCompute,
+		CPUDecompressS:    cpuDec,
+		CPUDeserializeS:   cpuDeser,
+		TotalS:            total,
+		DownloadedBytes:   downloaded,
+		PeakCacheBytes:    peak,
+		TimeToFirstBatchS: ttfb,
+		SamplesPerSec:     sps,
+		MinCacheBytes:     peak,
+		StalledBatches:    stalledBatches,
+		HTTP429Count:      net.n429,
+		BackoffS:          net.backoffS,
+		Steps:             steps,
+	}
+}
+
+func cpuMul(rng *rand.Rand, cfg Config) float64 {
+	if cfg.CPUJitter != "lognormal" || cfg.JitterSigma <= 0 {
+		return 1
+	}
+	return math.Exp(rng.NormFloat64() * cfg.JitterSigma)
+}
+
+func uniqueChunks(stream []sampleLoc) []int {
+	seen := map[int]struct{}{}
+	var out []int
+	for _, s := range stream {
+		if _, ok := seen[s.chunk]; ok {
+			continue
+		}
+		seen[s.chunk] = struct{}{}
+		out = append(out, s.chunk)
+	}
+	return out
+}
+
+func upcomingChunks(stream []sampleLoc, from, limit int) []int {
+	seen := map[int]struct{}{}
+	var out []int
+	for i := from; i < len(stream) && len(out) < limit; i++ {
+		id := stream[i].chunk
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+type netSim struct {
+	cfg      Config
+	rng      *rand.Rand
+	now      float64
+	tokens   float64
+	lastFill float64
+	n429     int
+	backoffS float64
+}
+
+func newNet(cfg Config, rng *rand.Rand) *netSim {
+	burst := float64(cfg.Burst)
+	if burst < 1 {
+		burst = 1
+	}
+	return &netSim{cfg: cfg, rng: rng, tokens: burst, lastFill: 0}
+}
+
+func (n *netSim) refill() {
+	if !n.cfg.RateLimitEnabled || n.cfg.RequestsPerSec <= 0 {
+		n.tokens = 1e9
+		return
+	}
+	dt := n.now - n.lastFill
+	if dt < 0 {
+		dt = 0
+	}
+	n.tokens += dt * n.cfg.RequestsPerSec
+	burst := float64(n.cfg.Burst)
+	if burst < 1 {
+		burst = 1
+	}
+	if n.tokens > burst {
+		n.tokens = burst
+	}
+	n.lastFill = n.now
+}
+
+func (n *netSim) takeToken() bool {
+	n.refill()
+	if n.tokens >= 1 {
+		n.tokens -= 1
+		return true
+	}
+	return false
+}
+
+func (n *netSim) downloadAll(ids []int, chunks []chunkRef, cache *lru) bool {
+	var pending []int
+	for _, id := range ids {
+		if cache.has(id) {
+			continue
+		}
+		pending = append(pending, id)
+	}
+	if len(pending) == 0 {
+		return true
+	}
+	conc := n.cfg.MaxConcurrentGets
+	for i := 0; i < len(pending); i += conc {
+		j := min(len(pending), i+conc)
+		wave := pending[i:j]
+		var waveBytes int64
+		for _, id := range wave {
+			retries := 0
+			for {
+				if n.takeToken() {
+					break
+				}
+				n.n429++
+				wait := n.cfg.RetryAfterS
+				if wait <= 0 {
+					wait = 1
+				}
+				if n.cfg.BackoffExponential {
+					base := n.cfg.BackoffBaseS
+					if base <= 0 {
+						base = 0.2
+					}
+					wait = base * math.Pow(2, float64(retries))
+				}
+				n.now += wait
+				n.backoffS += wait
+				retries++
+				if n.cfg.MaxRetries > 0 && retries > n.cfg.MaxRetries {
+					return false
+				}
+			}
+			if !cache.has(id) {
+				cache.add(id, chunks[id].bytes)
+			}
+			waveBytes += chunks[id].bytes
+		}
+		rtt := (n.cfg.RTTMs + n.cfg.ExtraLatencyMs) / 1000
+		if n.cfg.JitterMs > 0 {
+			rtt += math.Abs(n.rng.NormFloat64()) * n.cfg.JitterMs / 1000
+		}
+		bw := float64(n.cfg.BandwidthBps)
+		share := bw / float64(len(wave))
+		if n.cfg.BytesPerSec > 0 {
+			cap := float64(n.cfg.BytesPerSec) / float64(len(wave))
+			if cap < share {
+				share = cap
+			}
+		}
+		xfer := float64(waveBytes) / float64(len(wave)) / share
+		n.now += rtt + xfer
+	}
+	return true
+}
+
+type lru struct {
+	cap  int64
+	used int64
+	tick int
+	at   map[int]int
+	sz   map[int]int64
+}
+
+func newLRU(cap int64) *lru {
+	if cap <= 0 {
+		cap = math.MaxInt64 / 4
+	}
+	return &lru{cap: cap, at: map[int]int{}, sz: map[int]int64{}}
+}
+
+func (l *lru) has(id int) bool {
+	_, ok := l.at[id]
+	return ok
+}
+
+func (l *lru) touch(id int) {
+	l.tick++
+	l.at[id] = l.tick
+}
+
+func (l *lru) add(id int, sz int64) {
+	if l.has(id) {
+		l.touch(id)
+		return
+	}
+	for l.used+sz > l.cap && len(l.sz) > 0 {
+		l.evict()
+	}
+	l.tick++
+	l.at[id] = l.tick
+	l.sz[id] = sz
+	l.used += sz
+}
+
+func (l *lru) evict() {
+	oldest, oid := int(^uint(0)>>1), -1
+	for id, t := range l.at {
+		if t < oldest {
+			oldest, oid = t, id
+		}
+	}
+	if oid < 0 {
+		return
+	}
+	l.used -= l.sz[oid]
+	delete(l.at, oid)
+	delete(l.sz, oid)
+}
+
+func (r Result) Score() float64 {
+	if r.Failed || r.TotalS <= 0 {
+		return 0
+	}
+	stallFrac := r.StallS / r.TotalS
+	return r.SamplesPerSec * (1.0 - 0.5*stallFrac)
+}
+
+func (r Result) StallFrac() float64 {
+	if r.TotalS <= 0 {
+		return 0
+	}
+	return r.StallS / r.TotalS
+}

--- a/simulator/sim/sim_test.go
+++ b/simulator/sim/sim_test.go
@@ -1,0 +1,77 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/Lightning-AI/litData/simulator/index"
+)
+
+func tinyIndex(chunks int, items, bytes int) *index.Index {
+	idx := &index.Index{}
+	for i := 0; i < chunks; i++ {
+		idx.Chunks = append(idx.Chunks, index.Chunk{
+			Filename:   "chunk.bin",
+			ChunkBytes: int64(bytes),
+			ChunkSize:  items,
+		})
+	}
+	return idx
+}
+
+func TestRunCompletes(t *testing.T) {
+	idx := tinyIndex(20, 10, 1_000_000)
+	cfg := DefaultConfig()
+	cfg.BatchSize = 8
+	cfg.Workers = 2
+	cfg.MaxPreDownload = 4
+	cfg.BandwidthBps = 10_000_000
+	cfg.TimePerSampleS = 0.0001
+	cfg.CacheBytes = 50_000_000
+	r := Run(idx, cfg)
+	if r.Samples != 200 {
+		t.Fatalf("samples %d", r.Samples)
+	}
+	if r.TotalS <= 0 || r.SamplesPerSec <= 0 {
+		t.Fatalf("%+v", r)
+	}
+}
+
+func TestMoreBandwidthLessStall(t *testing.T) {
+	idx := tinyIndex(30, 8, 8_000_000)
+	slow := DefaultConfig()
+	slow.BandwidthBps = 1_000_000
+	slow.TimePerSampleS = 0.00001
+	slow.MaxPreDownload = 1
+	slow.CacheBytes = 20_000_000
+	fast := slow
+	fast.BandwidthBps = 1_000_000_000
+	a, b := Run(idx, slow), Run(idx, fast)
+	if b.StallS >= a.StallS {
+		t.Fatalf("expected less stall with more bandwidth: %.3f vs %.3f", b.StallS, a.StallS)
+	}
+}
+
+func TestLocalWarmMatchesLinearCPU(t *testing.T) {
+	idx := tinyIndex(24, 341, 50_000_000)
+	cfg := DefaultConfig()
+	cfg.AssumeResident = true
+	cfg.RateLimitEnabled = false
+	cfg.RTTMs = 0
+	cfg.TimePerSampleS = 0
+	cfg.DecompressNsPerB = 0
+	cfg.DeserializeUs = 318.9
+	cfg.CPUJitter = "none"
+	cfg.StartupS = 0.0442
+	cfg.Workers = 8
+	cfg.BatchSize = 256
+	cfg.DropLast = false
+	cfg.PersistentWorkers = true
+	cfg.Shuffle = false
+	r := Run(idx, cfg)
+	want := 22096.0
+	errPct := math.Abs(r.SamplesPerSec-want) / want * 100
+	if errPct > 1 {
+		t.Fatalf("sps %.1f want %.1f (%.2f%% err) samples=%d total=%.4f", r.SamplesPerSec, want, errPct, r.Samples, r.TotalS)
+	}
+}

--- a/simulator/tune/tune.go
+++ b/simulator/tune/tune.go
@@ -1,0 +1,289 @@
+package tune
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strconv"
+
+	"github.com/Lightning-AI/litData/simulator/chunk"
+	"github.com/Lightning-AI/litData/simulator/config"
+	"github.com/Lightning-AI/litData/simulator/index"
+	"github.com/Lightning-AI/litData/simulator/sim"
+	"github.com/Lightning-AI/litData/simulator/units"
+)
+
+type Candidate struct {
+	TargetChunkBytes int64             `json:"target_chunk_bytes"`
+	ItemsPerChunk    int               `json:"items_per_chunk"`
+	MaxPreDownload   int               `json:"max_pre_download"`
+	Workers          int               `json:"workers"`
+	CacheBytes       int64             `json:"cache_bytes"`
+	Overrides        map[string]string `json:"overrides"`
+	Result           sim.Result        `json:"result"`
+	Note             string            `json:"note"`
+}
+
+type Grid struct {
+	ChunkBytes     []int64
+	MaxPreDownload []int
+	Workers        []int
+	CacheBytes     []int64
+	Sim            sim.Config
+}
+
+func DefaultGrid() Grid {
+	return Grid{
+		ChunkBytes:     []int64{8 << 20, 32 << 20, 64 << 20, 128 << 20, 256 << 20},
+		MaxPreDownload: []int{2, 4, 8, 16},
+		Workers:        []int{2, 4, 8},
+		Sim:            sim.DefaultConfig(),
+	}
+}
+
+func ItemBytes(idx *index.Index, headers []chunk.Header) []int64 {
+	if len(headers) == len(idx.Chunks) {
+		var out []int64
+		for _, h := range headers {
+			for i := 0; i < int(h.NumItems); i++ {
+				out = append(out, h.ItemSize(i))
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	mean := idx.MeanItemBytes()
+	n := idx.TotalItems()
+	out := make([]int64, n)
+	for i := range out {
+		out[i] = int64(mean)
+		if out[i] < 1 {
+			out[i] = 1
+		}
+	}
+	return out
+}
+
+func Pack(itemBytes []int64, targetBytes int64) []index.Chunk {
+	if targetBytes < 1 {
+		targetBytes = 1
+	}
+	var chunks []index.Chunk
+	var cur index.Chunk
+	for _, sz := range itemBytes {
+		if cur.ChunkSize > 0 && cur.ChunkBytes+sz > targetBytes {
+			chunks = append(chunks, cur)
+			cur = index.Chunk{}
+		}
+		cur.ChunkBytes += sz
+		cur.ChunkSize++
+		cur.Filename = "packed.bin"
+	}
+	if cur.ChunkSize > 0 {
+		chunks = append(chunks, cur)
+	}
+	return chunks
+}
+
+func Search(idx *index.Index, headers []chunk.Header, grid Grid) []Candidate {
+	items := ItemBytes(idx, headers)
+	g := grid
+	if len(g.CacheBytes) == 0 {
+		meanChunk := int64(idx.MeanItemBytes() * 64)
+		if meanChunk < 1<<20 {
+			meanChunk = 64 << 20
+		}
+		g.CacheBytes = []int64{meanChunk * 8, meanChunk * 16, meanChunk * 32}
+	}
+	var out []Candidate
+	base := g.Sim
+	for _, cb := range g.ChunkBytes {
+		packed := Pack(items, cb)
+		hyp := &index.Index{Chunks: packed, Config: idx.Config}
+		for _, pre := range g.MaxPreDownload {
+			for _, w := range g.Workers {
+				for _, cache := range g.CacheBytes {
+					cfg := base
+					cfg.MaxPreDownload = pre
+					cfg.Workers = w
+					cfg.CacheBytes = cache
+					r := sim.Run(hyp, cfg)
+					out = append(out, Candidate{
+						TargetChunkBytes: cb,
+						ItemsPerChunk:    avgItems(packed),
+						MaxPreDownload:   pre,
+						Workers:          w,
+						CacheBytes:       cache,
+						Result:           r,
+						Note:             fmt.Sprintf("%d packed chunks", len(packed)),
+					})
+				}
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Result.Score() > out[j].Result.Score()
+	})
+	return out
+}
+
+func SearchFile(idx *index.Index, headers []chunk.Header, file *config.File) []Candidate {
+	return SearchFileOn(idx, headers, file, nil)
+}
+
+// SearchFileOn is SearchFile with a callback after each trial (i is 1-based).
+func SearchFileOn(idx *index.Index, headers []chunk.Header, file *config.File, on func(i, n int, c Candidate)) []Candidate {
+	axes := file.Tuner.Search
+	if len(axes) == 0 {
+		cfg := sim.FromFile(file)
+		r := sim.Run(idx, cfg)
+		c := Candidate{Result: r, Note: "no search axes"}
+		if on != nil {
+			on(1, 1, c)
+		}
+		return []Candidate{c}
+	}
+	keys := make([]string, 0, len(axes))
+	for k := range axes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	combos := []map[string]string{{}}
+	for _, k := range keys {
+		vals := axes[k]
+		var next []map[string]string
+		for _, c := range combos {
+			for _, v := range vals {
+				m := copyMap(c)
+				m[k] = v
+				next = append(next, m)
+			}
+		}
+		combos = next
+	}
+	maxT := file.Tuner.MaxTrials
+	if maxT < 1 {
+		maxT = 64
+	}
+	if len(combos) > maxT {
+		rng := rand.New(rand.NewSource(file.Cluster.Seed))
+		rng.Shuffle(len(combos), func(i, j int) { combos[i], combos[j] = combos[j], combos[i] })
+		combos = combos[:maxT]
+	}
+
+	items := ItemBytes(idx, headers)
+	useHeaders := file.Optimize.UseHeaders && len(headers) == len(idx.Chunks)
+	_ = useHeaders
+
+	var out []Candidate
+	for _, ov := range combos {
+		f := *file
+		f.Cluster = file.Cluster
+		f.Cache = file.Cache
+		f.Network = file.Network
+		f.RateLimit = file.RateLimit
+		f.Optimize = file.Optimize
+		applyOverrides(&f, ov)
+		hyp := idx
+		note := ""
+		if cb, ok := ov["optimize.chunk_bytes"]; ok {
+			tb, err := units.ParseBytes(cb)
+			if err == nil {
+				packed := Pack(items, tb)
+				hyp = &index.Index{Chunks: packed, Config: idx.Config}
+				note = fmt.Sprintf("%d packed chunks @ %s", len(packed), cb)
+			}
+		}
+		r := sim.Run(hyp, sim.FromFile(&f))
+		c := Candidate{
+			TargetChunkBytes: f.Optimize.ChunkBytes.Int64(),
+			MaxPreDownload:   f.Cache.MaxPreDownload,
+			Workers:          f.Cluster.Dataloader.NumWorkers,
+			CacheBytes:       f.Cache.MaxBytes.Int64(),
+			Overrides:        ov,
+			Result:           r,
+			Note:             note,
+		}
+		out = append(out, c)
+		if on != nil {
+			on(len(out), len(combos), c)
+		}
+	}
+	metric := file.Tuner.Metric
+	sort.Slice(out, func(i, j int) bool {
+		return better(out[i].Result, out[j].Result, metric)
+	})
+	return out
+}
+
+func better(a, b sim.Result, metric string) bool {
+	if a.Failed != b.Failed {
+		return !a.Failed
+	}
+	switch metric {
+	case "stall_frac":
+		if a.StallFrac() != b.StallFrac() {
+			return a.StallFrac() < b.StallFrac()
+		}
+	case "time_to_first_batch":
+		if a.TimeToFirstBatchS != b.TimeToFirstBatchS {
+			return a.TimeToFirstBatchS < b.TimeToFirstBatchS
+		}
+	default:
+		if a.SamplesPerSec != b.SamplesPerSec {
+			return a.SamplesPerSec > b.SamplesPerSec
+		}
+	}
+	if a.StallFrac() != b.StallFrac() {
+		return a.StallFrac() < b.StallFrac()
+	}
+	if a.HTTP429Count != b.HTTP429Count {
+		return a.HTTP429Count < b.HTTP429Count
+	}
+	return a.PeakCacheBytes < b.PeakCacheBytes
+}
+
+func applyOverrides(f *config.File, ov map[string]string) {
+	for k, v := range ov {
+		switch k {
+		case "optimize.chunk_bytes":
+			n, _ := units.ParseBytes(v)
+			f.Optimize.ChunkBytes = config.ByteSize(n)
+		case "cache.max_pre_download":
+			f.Cache.MaxPreDownload, _ = strconv.Atoi(v)
+		case "cache.max_bytes":
+			n, _ := units.ParseBytes(v)
+			f.Cache.MaxBytes = config.ByteSize(n)
+		case "cluster.dataloader.num_workers":
+			f.Cluster.Dataloader.NumWorkers, _ = strconv.Atoi(v)
+		case "cluster.dataloader.prefetch_factor":
+			f.Cluster.Dataloader.PrefetchFactor, _ = strconv.Atoi(v)
+		case "cluster.dataloader.batch_size":
+			f.Cluster.Dataloader.BatchSize, _ = strconv.Atoi(v)
+		case "network.max_concurrent_gets":
+			f.Network.MaxConcurrentGets, _ = strconv.Atoi(v)
+		case "rate_limit.requests_per_sec":
+			f.RateLimit.RequestsPerSec, _ = strconv.ParseFloat(v, 64)
+		}
+	}
+}
+
+func copyMap(m map[string]string) map[string]string {
+	o := make(map[string]string, len(m)+1)
+	for k, v := range m {
+		o[k] = v
+	}
+	return o
+}
+
+func avgItems(chunks []index.Chunk) int {
+	if len(chunks) == 0 {
+		return 0
+	}
+	n := 0
+	for _, c := range chunks {
+		n += c.ChunkSize
+	}
+	return n / len(chunks)
+}

--- a/simulator/tune/tune_test.go
+++ b/simulator/tune/tune_test.go
@@ -1,0 +1,48 @@
+package tune
+
+import (
+	"testing"
+
+	"github.com/Lightning-AI/litData/simulator/index"
+	"github.com/Lightning-AI/litData/simulator/sim"
+)
+
+func TestPackRespectsTarget(t *testing.T) {
+	items := make([]int64, 100)
+	for i := range items {
+		items[i] = 1000
+	}
+	chunks := Pack(items, 10_000)
+	for _, c := range chunks[:len(chunks)-1] {
+		if c.ChunkBytes > 10_000 {
+			t.Fatalf("chunk %d bytes", c.ChunkBytes)
+		}
+		if c.ChunkBytes+1000 <= 10_000 && c.ChunkSize < 10 {
+			t.Fatalf("underpacked %+v", c)
+		}
+	}
+}
+
+func TestSearchRanksSomething(t *testing.T) {
+	idx := &index.Index{}
+	for i := 0; i < 40; i++ {
+		idx.Chunks = append(idx.Chunks, index.Chunk{Filename: "c.bin", ChunkBytes: 2_000_000, ChunkSize: 20})
+	}
+	g := Grid{
+		ChunkBytes:     []int64{1 << 20, 8 << 20},
+		MaxPreDownload: []int{2, 8},
+		Workers:        []int{4},
+		CacheBytes:     []int64{32 << 20},
+		Sim:            sim.DefaultConfig(),
+	}
+	g.Sim.BandwidthBps = 50_000_000
+	g.Sim.TimePerSampleS = 0.0002
+	g.Sim.BatchSize = 16
+	cands := Search(idx, nil, g)
+	if len(cands) != 4 {
+		t.Fatalf("len %d", len(cands))
+	}
+	if cands[0].Result.Score() < cands[len(cands)-1].Result.Score() {
+		t.Fatal("not sorted")
+	}
+}

--- a/simulator/units/units.go
+++ b/simulator/units/units.go
@@ -1,0 +1,68 @@
+package units
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func ParseBytes(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty size")
+	}
+	mult := int64(1)
+	upper := strings.ToUpper(s)
+	switch {
+	case strings.HasSuffix(upper, "KB"):
+		mult, s = 1000, s[:len(s)-2]
+	case strings.HasSuffix(upper, "MB"):
+		mult, s = 1000*1000, s[:len(s)-2]
+	case strings.HasSuffix(upper, "GB"):
+		mult, s = 1000*1000*1000, s[:len(s)-2]
+	case strings.HasSuffix(upper, "KIB"):
+		mult, s = 1024, s[:len(s)-3]
+	case strings.HasSuffix(upper, "MIB"):
+		mult, s = 1<<20, s[:len(s)-3]
+	case strings.HasSuffix(upper, "GIB"):
+		mult, s = 1<<30, s[:len(s)-3]
+	}
+	v, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil {
+		return 0, err
+	}
+	return int64(v * float64(mult)), nil
+}
+
+func ParseBandwidth(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	upper := strings.ToUpper(s)
+	if strings.HasSuffix(upper, "GBPS") {
+		v, err := strconv.ParseFloat(s[:len(s)-4], 64)
+		if err != nil {
+			return 0, err
+		}
+		return int64(v * 1e9 / 8), nil
+	}
+	if strings.HasSuffix(upper, "MBPS") {
+		v, err := strconv.ParseFloat(s[:len(s)-4], 64)
+		if err != nil {
+			return 0, err
+		}
+		return int64(v * 1e6 / 8), nil
+	}
+	return ParseBytes(s) // bytes/s
+}
+
+func FormatBytes(n int64) string {
+	switch {
+	case n >= 1_000_000_000:
+		return fmt.Sprintf("%.2fGB", float64(n)/1e9)
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.2fMB", float64(n)/1e6)
+	case n >= 1000:
+		return fmt.Sprintf("%.2fKB", float64(n)/1e3)
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}

--- a/simulator/verify/verify.go
+++ b/simulator/verify/verify.go
@@ -1,0 +1,51 @@
+package verify
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Lightning-AI/litData/simulator/chunk"
+	"github.com/Lightning-AI/litData/simulator/index"
+)
+
+type Report struct {
+	Checked int
+	Failed  int
+	Headers []chunk.Header
+	Errors  []string
+}
+
+// Chunks reads each uncompressed chunk header (num_items + offset table) and
+// checks it against index.json. Compressed (.zstd) objects cannot expose the
+// inner header via a range GET; those are size-checked only.
+func Chunks(idx *index.Index, dir string) Report {
+	var r Report
+	r.Headers = make([]chunk.Header, len(idx.Chunks))
+	for i, c := range idx.Chunks {
+		r.Checked++
+		p := filepath.Join(dir, c.Filename)
+		st, err := os.Stat(p)
+		if err != nil {
+			r.Failed++
+			r.Errors = append(r.Errors, fmt.Sprintf("%s: %v", c.Filename, err))
+			continue
+		}
+		if st.Size() != c.ChunkBytes && c.ChunkBytes > 0 {
+			r.Failed++
+			r.Errors = append(r.Errors, fmt.Sprintf("%s: size %d != index chunk_bytes %d", c.Filename, st.Size(), c.ChunkBytes))
+			continue
+		}
+		if c.Compressed() {
+			continue
+		}
+		h, err := chunk.ReadFromFile(p, c.ChunkSize)
+		if err != nil {
+			r.Failed++
+			r.Errors = append(r.Errors, err.Error())
+			continue
+		}
+		r.Headers[i] = h
+	}
+	return r
+}

--- a/simulator/web/embed.go
+++ b/simulator/web/embed.go
@@ -1,0 +1,6 @@
+package web
+
+import "embed"
+
+//go:embed static/*
+var Static embed.FS

--- a/simulator/web/knobs.go
+++ b/simulator/web/knobs.go
@@ -1,0 +1,94 @@
+package web
+
+import (
+	"github.com/Lightning-AI/litData/simulator/config"
+)
+
+// Knobs are the interactive sliders (JSON from the browser).
+type Knobs struct {
+	NumWorkers             int     `json:"num_workers"`
+	BatchSize              int     `json:"batch_size"`
+	PrefetchFactor         int     `json:"prefetch_factor"`
+	MaxPreDownload         int     `json:"max_pre_download"`
+	MaxBytes               int64   `json:"max_bytes"`
+	BandwidthBps           int64   `json:"bandwidth_bps"`
+	RTTMs                  float64 `json:"rtt_ms"`
+	MaxConcurrentGets      int     `json:"max_concurrent_gets"`
+	RequestsPerSec         float64 `json:"requests_per_sec"`
+	RateLimitEnabled       *bool   `json:"rate_limit_enabled"`
+	TimePerSampleS         float64 `json:"time_per_sample_s"`
+	DecompressNsPerByte    float64 `json:"decompress_ns_per_byte"`
+	DeserializeUsPerSample float64 `json:"deserialize_us_per_sample"`
+	JitterSigma            float64 `json:"jitter_sigma"`
+	DropLast               *bool   `json:"drop_last"`
+}
+
+func ApplyKnobs(f *config.File, k Knobs) {
+	if k.NumWorkers >= 0 {
+		f.Cluster.Dataloader.NumWorkers = k.NumWorkers
+	}
+	if k.BatchSize > 0 {
+		f.Cluster.Dataloader.BatchSize = k.BatchSize
+	}
+	if k.PrefetchFactor > 0 {
+		f.Cluster.Dataloader.PrefetchFactor = k.PrefetchFactor
+	}
+	if k.MaxPreDownload > 0 {
+		f.Cache.MaxPreDownload = k.MaxPreDownload
+	}
+	if k.MaxBytes > 0 {
+		f.Cache.MaxBytes = config.ByteSize(k.MaxBytes)
+	}
+	if k.BandwidthBps > 0 {
+		f.Network.BandwidthBps = config.Bandwidth(k.BandwidthBps)
+	}
+	if k.RTTMs >= 0 {
+		f.Network.RTTMs = k.RTTMs
+	}
+	if k.MaxConcurrentGets > 0 {
+		f.Network.MaxConcurrentGets = k.MaxConcurrentGets
+	}
+	if k.RequestsPerSec > 0 {
+		f.RateLimit.RequestsPerSec = k.RequestsPerSec
+	}
+	if k.RateLimitEnabled != nil {
+		f.RateLimit.Enabled = *k.RateLimitEnabled
+	}
+	if k.TimePerSampleS >= 0 {
+		f.Cluster.TimePerSampleS = k.TimePerSampleS
+	}
+	if k.DecompressNsPerByte >= 0 {
+		f.Cluster.CPU.DecompressNsPerByte = k.DecompressNsPerByte
+	}
+	if k.DeserializeUsPerSample >= 0 {
+		f.Cluster.CPU.DeserializeUsPerSample = k.DeserializeUsPerSample
+	}
+	if k.JitterSigma >= 0 {
+		f.Cluster.CPU.JitterSigma = k.JitterSigma
+	}
+	if k.DropLast != nil {
+		f.Cluster.Dataloader.DropLast = *k.DropLast
+	}
+}
+
+func KnobsFromFile(f *config.File) Knobs {
+	en := f.RateLimit.Enabled
+	dl := f.Cluster.Dataloader.DropLast
+	return Knobs{
+		NumWorkers:             f.Cluster.Dataloader.NumWorkers,
+		BatchSize:              f.Cluster.Dataloader.BatchSize,
+		PrefetchFactor:         f.Cluster.Dataloader.PrefetchFactor,
+		MaxPreDownload:         f.Cache.MaxPreDownload,
+		MaxBytes:               f.Cache.MaxBytes.Int64(),
+		BandwidthBps:           f.Network.BandwidthBps.Int64(),
+		RTTMs:                  f.Network.RTTMs,
+		MaxConcurrentGets:      f.Network.MaxConcurrentGets,
+		RequestsPerSec:         f.RateLimit.RequestsPerSec,
+		RateLimitEnabled:       &en,
+		TimePerSampleS:         f.Cluster.TimePerSampleS,
+		DecompressNsPerByte:    f.Cluster.CPU.DecompressNsPerByte,
+		DeserializeUsPerSample: f.Cluster.CPU.DeserializeUsPerSample,
+		JitterSigma:            f.Cluster.CPU.JitterSigma,
+		DropLast:               &dl,
+	}
+}

--- a/simulator/web/server.go
+++ b/simulator/web/server.go
@@ -1,0 +1,265 @@
+package web
+
+import (
+	"encoding/json"
+	"io/fs"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/Lightning-AI/litData/simulator/config"
+	"github.com/Lightning-AI/litData/simulator/index"
+	"github.com/Lightning-AI/litData/simulator/sim"
+	"github.com/Lightning-AI/litData/simulator/tune"
+)
+
+type RunRecord struct {
+	ID     int        `json:"id"`
+	At     time.Time  `json:"at"`
+	Source string     `json:"source"`
+	Knobs  Knobs      `json:"knobs"`
+	Result sim.Result `json:"result"`
+	Note   string     `json:"note,omitempty"`
+}
+
+type Server struct {
+	mu      sync.Mutex
+	file    *config.File
+	idx     *index.Index
+	meta    map[string]any
+	history []RunRecord
+	nextID  int
+}
+
+func New(file *config.File, idx *index.Index) *Server {
+	return &Server{
+		file: file,
+		idx:  idx,
+		meta: map[string]any{
+			"index":       file.Dataset.Index,
+			"chunks":      len(idx.Chunks),
+			"items":       idx.TotalItems(),
+			"bytes":       idx.TotalBytes(),
+			"compression": file.Dataset.Compression,
+		},
+	}
+}
+
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	static, err := fs.Sub(Static, "static")
+	if err != nil {
+		panic(err)
+	}
+	mux.HandleFunc("GET /api/state", s.getState)
+	mux.HandleFunc("GET /api/history", s.getHistory)
+	mux.HandleFunc("POST /api/run", s.postRun)
+	mux.HandleFunc("POST /api/search", s.postSearch)
+	mux.HandleFunc("POST /api/history/clear", s.clearHistory)
+	mux.Handle("/", http.FileServer(http.FS(static)))
+	return withLog(mux)
+}
+
+func withLog(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t0 := time.Now()
+		next.ServeHTTP(w, r)
+		log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(t0).Truncate(time.Millisecond))
+	})
+}
+
+func thinSteps(st []sim.Step, n int) []sim.Step {
+	if len(st) <= n || n < 2 {
+		return st
+	}
+	out := make([]sim.Step, n)
+	last := len(st) - 1
+	for i := 0; i < n; i++ {
+		out[i] = st[i*last/(n-1)]
+	}
+	return out
+}
+
+func (s *Server) append(source string, k Knobs, res sim.Result, note string) RunRecord {
+	res.Steps = thinSteps(res.Steps, 96)
+	s.nextID++
+	rec := RunRecord{ID: s.nextID, At: time.Now().UTC(), Source: source, Knobs: k, Result: res, Note: note}
+	s.history = append(s.history, rec)
+	if len(s.history) > 250 {
+		s.history = s.history[len(s.history)-250:]
+	}
+	return rec
+}
+
+func (s *Server) getState(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t0 := time.Now()
+	res := sim.Run(s.idx, sim.FromFile(s.file))
+	k := KnobsFromFile(s.file)
+	rec := RunRecord{ID: 0, Source: "init", Knobs: k, Result: res}
+	if len(s.history) == 0 {
+		rec = s.append("init", k, res, "load")
+	}
+	writeJSON(w, map[string]any{
+		"meta":    s.meta,
+		"knobs":   k,
+		"result":  res,
+		"sim_ms":  time.Since(t0).Milliseconds(),
+		"run":     rec,
+		"history": s.history,
+	})
+}
+
+func (s *Server) getHistory(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	writeJSON(w, map[string]any{"history": s.history})
+}
+
+func (s *Server) clearHistory(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.history = nil
+	writeJSON(w, map[string]any{"history": s.history})
+}
+
+func (s *Server) postRun(w http.ResponseWriter, r *http.Request) {
+	var k Knobs
+	if err := json.NewDecoder(r.Body).Decode(&k); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ApplyKnobs(s.file, k)
+	t0 := time.Now()
+	res := sim.Run(s.idx, sim.FromFile(s.file))
+	kn := KnobsFromFile(s.file)
+	rec := s.append("slider", kn, res, "")
+	writeJSON(w, map[string]any{
+		"meta":    s.meta,
+		"knobs":   kn,
+		"result":  res,
+		"sim_ms":  time.Since(t0).Milliseconds(),
+		"run":     rec,
+		"history": s.history,
+	})
+}
+
+func (s *Server) postSearch(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Knobs     Knobs `json:"knobs"`
+		MaxTrials int   `json:"max_trials"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if body.MaxTrials < 1 {
+		body.MaxTrials = 32
+	}
+	s.mu.Lock()
+	ApplyKnobs(s.file, body.Knobs)
+	f := *s.file
+	s.mu.Unlock()
+	f.Tuner.MaxTrials = body.MaxTrials
+	f.Tuner.Metric = "samples_per_sec"
+	if len(f.Tuner.Search) == 0 {
+		f.Tuner.Search = map[string][]string{
+			"cluster.dataloader.num_workers":     {"2", "4", "8", "16"},
+			"cluster.dataloader.prefetch_factor": {"2", "4"},
+			"cache.max_pre_download":             {"2", "4", "8"},
+			"network.max_concurrent_gets":        {"8", "16", "32"},
+		}
+	}
+	flusher, _ := w.(http.Flusher)
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	enc := json.NewEncoder(w)
+	t0 := time.Now()
+	cands := tune.SearchFileOn(s.idx, nil, &f, func(i, n int, c tune.Candidate) {
+		s.mu.Lock()
+		kk := KnobsFromFile(s.file)
+		ApplySearchOverride(&kk, c.Overrides)
+		rec := s.append("search", kk, c.Result, c.Note)
+		s.mu.Unlock()
+		_ = enc.Encode(map[string]any{
+			"type": "trial", "i": i, "n": n, "run": rec, "sim_ms": time.Since(t0).Milliseconds(),
+		})
+		if flusher != nil {
+			flusher.Flush()
+		}
+	})
+	best := sim.Result{}
+	s.mu.Lock()
+	if len(cands) > 0 {
+		best = cands[0].Result
+		applyBestFile(s.file, cands[0].Overrides)
+	}
+	out := map[string]any{
+		"type":    "done",
+		"meta":    s.meta,
+		"knobs":   KnobsFromFile(s.file),
+		"result":  best,
+		"trials":  len(cands),
+		"sim_ms":  time.Since(t0).Milliseconds(),
+		"history": s.history,
+	}
+	s.mu.Unlock()
+	_ = enc.Encode(out)
+}
+
+func applyBestFile(f *config.File, ov map[string]string) {
+	// reuse tune via a tiny copy: SearchFile already ranked; applyOverrides is unexported.
+	// Duplicate the few keys we search.
+	for k, v := range ov {
+		switch k {
+		case "cluster.dataloader.num_workers":
+			n := atoi(v)
+			f.Cluster.Dataloader.NumWorkers = n
+		case "cluster.dataloader.prefetch_factor":
+			f.Cluster.Dataloader.PrefetchFactor = atoi(v)
+		case "cluster.dataloader.batch_size":
+			f.Cluster.Dataloader.BatchSize = atoi(v)
+		case "cache.max_pre_download":
+			f.Cache.MaxPreDownload = atoi(v)
+		case "network.max_concurrent_gets":
+			f.Network.MaxConcurrentGets = atoi(v)
+		}
+	}
+}
+
+func atoi(s string) int {
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			continue
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}
+
+func ApplySearchOverride(k *Knobs, ov map[string]string) {
+	for key, v := range ov {
+		switch key {
+		case "cluster.dataloader.num_workers":
+			k.NumWorkers = atoi(v)
+		case "cluster.dataloader.prefetch_factor":
+			k.PrefetchFactor = atoi(v)
+		case "cluster.dataloader.batch_size":
+			k.BatchSize = atoi(v)
+		case "cache.max_pre_download":
+			k.MaxPreDownload = atoi(v)
+		case "network.max_concurrent_gets":
+			k.MaxConcurrentGets = atoi(v)
+		}
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/simulator/web/static/app.js
+++ b/simulator/web/static/app.js
@@ -1,0 +1,427 @@
+const ids = [
+  "num_workers", "batch_size", "prefetch_factor", "max_pre_download",
+  "bandwidth_bps", "rtt_ms", "max_concurrent_gets", "requests_per_sec",
+  "time_per_sample_s", "decompress_ns_per_byte", "deserialize_us_per_sample", "jitter_sigma",
+];
+
+function el(id) { return document.getElementById(id); }
+
+function fmtBw(bps) {
+  const gbps = (bps * 8) / 1e9;
+  if (gbps >= 1) return gbps.toFixed(2) + " Gbps";
+  return ((bps * 8) / 1e6).toFixed(0) + " Mbps";
+}
+
+function readKnobs() {
+  const k = {};
+  for (const id of ids) k[id] = +el(id).value;
+  k.rate_limit_enabled = el("rate_limit_enabled").checked;
+  return k;
+}
+
+function paintVals() {
+  for (const id of ids) {
+    const input = el(id);
+    const span = input.parentElement.querySelector("[data-val]");
+    if (!span) continue;
+    if (id === "bandwidth_bps") span.textContent = fmtBw(+input.value);
+    else if (id === "time_per_sample_s") span.textContent = (+input.value).toFixed(4);
+    else span.textContent = input.value;
+  }
+}
+
+function setKnobs(k) {
+  for (const id of ids) {
+    if (k[id] == null) continue;
+    const input = el(id);
+    const v = +k[id];
+    if (v > +input.max) input.max = v;
+    input.value = v;
+  }
+  if (typeof k.rate_limit_enabled === "boolean") {
+    el("rate_limit_enabled").checked = k.rate_limit_enabled;
+  }
+  paintVals();
+}
+
+function formatBytes(n) {
+  if (n >= 1e12) return (n / 1e12).toFixed(2) + " TB";
+  if (n >= 1e9) return (n / 1e9).toFixed(2) + " GB";
+  if (n >= 1e6) return (n / 1e6).toFixed(1) + " MB";
+  return n + " B";
+}
+
+let historyCache = [];
+let currentId = null;
+let hoverId = null;
+
+function runColor(id, bestId) {
+  if (id === bestId) return "#e4dcff";
+  const hues = [255, 270, 230, 285, 245, 210, 300, 220];
+  const h = hues[id % hues.length];
+  const l = 62 + (id % 3) * 6;
+  return `hsl(${h} 55% ${l}%)`;
+}
+
+function runScore(r) {
+  const res = r.result || {};
+  if (res.failed || !(res.total_s > 0)) return 0;
+  const stallFrac = (res.stall_s || 0) / res.total_s;
+  return (res.samples_per_sec || 0) * (1 - 0.5 * stallFrac);
+}
+
+function ranked(history) {
+  return history.slice().sort((a, b) => {
+    const ds = runScore(b) - runScore(a);
+    if (ds) return ds;
+    const ar = a.result || {}, br = b.result || {};
+    const d429 = (ar.http_429_count || 0) - (br.http_429_count || 0);
+    if (d429) return d429;
+    return (a.id || 0) - (b.id || 0);
+  });
+}
+
+function bestIdOf(history) {
+  const rows = ranked(history);
+  return rows.length ? rows[0].id : null;
+}
+
+function show(state) {
+  const r = state.result || {};
+  const m = state.meta || {};
+  el("meta").textContent = `${m.index || ""} · ${m.chunks || 0} chunks · ${(m.items || 0).toLocaleString()} items`;
+  if (state.sim_ms != null) el("simms").textContent = `engine ${state.sim_ms} ms`;
+  paintStats(r);
+  if (state.history) historyCache = state.history;
+  if (state.run && state.run.id) currentId = state.run.id;
+  renderHistory(historyCache, currentId);
+}
+
+function paintStats(r) {
+  const stallPct = r.total_s > 0 ? (100 * r.stall_s / r.total_s) : 0;
+  el("stats").innerHTML = [
+    ["samples/s", (r.samples_per_sec || 0).toFixed(1)],
+    ["stall", `${(r.stall_s || 0).toFixed(2)}s (${stallPct.toFixed(1)}%)`],
+    ["ttfb", `${(r.time_to_first_batch_s || 0).toFixed(3)}s`],
+    ["429s", r.http_429_count || 0],
+    ["downloaded", formatBytes(r.downloaded_bytes || 0)],
+    ["peak cache", formatBytes(r.peak_cache_bytes || 0)],
+  ].map(([l, v]) => `<div class="stat"><b>${v}</b><span>${l}</span></div>`).join("");
+}
+
+function fitCanvas(c) {
+  const box = c.parentElement;
+  const dpr = devicePixelRatio || 1;
+  const cssW = Math.max(1, box.clientWidth);
+  const cssH = Math.max(1, box.clientHeight);
+  const w = Math.round(cssW * dpr);
+  const h = Math.round(cssH * dpr);
+  if (c.width !== w) c.width = w;
+  if (c.height !== h) c.height = h;
+  return { w, h, dpr, cssW, cssH };
+}
+
+function drawCurves(history) {
+  const c = el("chart");
+  const ctx = c.getContext("2d");
+  const { w, h, dpr } = fitCanvas(c);
+  ctx.clearRect(0, 0, w, h);
+  const bestId = bestIdOf(history);
+  let maxT = 1, maxY = 1;
+  for (const rec of history) {
+    for (const s of (rec.result && rec.result.steps) || []) {
+      if (s.t > maxT) maxT = s.t;
+      if (s.samples_per_sec > maxY) maxY = s.samples_per_sec;
+    }
+  }
+  const padL = 8 * dpr, padR = 8 * dpr, padT = 8 * dpr, padB = 8 * dpr;
+  const xOf = t => padL + (t / maxT) * (w - padL - padR);
+  const yOf = v => h - padB - (v / maxY) * (h - padT - padB);
+
+  ctx.lineWidth = 1 * dpr;
+  ctx.strokeStyle = "rgba(201,184,255,0.12)";
+  ctx.beginPath();
+  ctx.moveTo(padL, yOf(maxY * 0.5));
+  ctx.lineTo(w - padR, yOf(maxY * 0.5));
+  ctx.stroke();
+
+  history.forEach(rec => {
+    const steps = (rec.result && rec.result.steps) || [];
+    if (steps.length < 2) return;
+    const hi = hoverId == null || hoverId === rec.id;
+    const isCur = rec.id === currentId;
+    ctx.globalAlpha = hoverId == null ? (isCur ? 1 : 0.55) : (hi ? 1 : 0.12);
+    ctx.strokeStyle = runColor(rec.id, bestId);
+    ctx.lineWidth = (hi && hoverId != null ? 3 : isCur || rec.id === bestId ? 2.4 : 1.4) * dpr;
+    ctx.beginPath();
+    steps.forEach((s, i) => {
+      const x = xOf(s.t || 0);
+      const y = yOf(s.samples_per_sec || 0);
+      i ? ctx.lineTo(x, y) : ctx.moveTo(x, y);
+    });
+    ctx.stroke();
+  });
+  ctx.globalAlpha = 1;
+  c._layout = { w, h, maxT, maxY, dpr, padL, padR, padT, padB, xOf, yOf };
+}
+
+function nearestRun(mx, my, history) {
+  const lay = el("chart")._layout;
+  if (!lay) return null;
+  const x = mx * lay.dpr, y = my * lay.dpr;
+  let best = null, bestD = 18 * lay.dpr;
+  for (const rec of history) {
+    for (const s of (rec.result && rec.result.steps) || []) {
+      const dx = lay.xOf(s.t || 0) - x;
+      const dy = lay.yOf(s.samples_per_sec || 0) - y;
+      const d = Math.hypot(dx, dy);
+      if (d < bestD) { bestD = d; best = { rec, s }; }
+    }
+  }
+  return best;
+}
+
+function tipHTML(hit) {
+  const r = hit.rec.result || {};
+  const k = hit.rec.knobs || {};
+  const s = hit.s || {};
+  const stallPct = r.total_s > 0 ? (100 * r.stall_s / r.total_s) : 0;
+  const rank = ranked(historyCache).findIndex(x => x.id === hit.rec.id) + 1;
+  return `<b>rank ${rank} · run ${hit.rec.id} ${hit.rec.source || ""}</b><br>
+    <span class="k">at</span> ${(s.t || 0).toFixed(2)}s · ${(s.samples_per_sec || 0).toFixed(1)} samples/s<br>
+    <span class="k">epoch</span> ${(r.samples_per_sec || 0).toFixed(1)} sps · stall ${stallPct.toFixed(1)}% · ttfb ${(r.time_to_first_batch_s || 0).toFixed(2)}s · 429 ${r.http_429_count || 0}<br>
+    <span class="k">knobs</span> w=${k.num_workers} batch=${k.batch_size} pref=${k.prefetch_factor} pre-dl=${k.max_pre_download} conc=${k.max_concurrent_gets}`;
+}
+
+function bindChartHover() {
+  const c = el("chart");
+  const tip = el("tip");
+  const wrap = c.parentElement;
+  c.onmousemove = ev => {
+    const rect = c.getBoundingClientRect();
+    const hit = nearestRun(ev.clientX - rect.left, ev.clientY - rect.top, historyCache);
+    if (!hit) {
+      tip.hidden = true;
+      if (hoverId != null) { hoverId = null; drawCurves(historyCache); highlightRow(null); }
+      return;
+    }
+    const changed = hoverId !== hit.rec.id;
+    hoverId = hit.rec.id;
+    if (changed) { drawCurves(historyCache); highlightRow(hit.rec.id); }
+    tip.hidden = false;
+    tip.innerHTML = tipHTML(hit);
+    const x = ev.clientX - wrap.getBoundingClientRect().left + 12;
+    const y = ev.clientY - wrap.getBoundingClientRect().top + 12;
+    tip.style.left = Math.min(x, wrap.clientWidth - 290) + "px";
+    tip.style.top = Math.min(y, wrap.clientHeight - 90) + "px";
+  };
+  c.onmouseleave = () => {
+    tip.hidden = true;
+    hoverId = null;
+    drawCurves(historyCache);
+    highlightRow(null);
+  };
+}
+
+function highlightRow(id) {
+  el("hist").querySelectorAll("tbody tr").forEach(tr => {
+    tr.classList.toggle("hovering", id != null && String(id) === tr.dataset.id);
+  });
+}
+
+function drawHistoryBars(history) {
+  const c = el("histchart");
+  const ctx = c.getContext("2d");
+  const { w, h, dpr } = fitCanvas(c);
+  ctx.clearRect(0, 0, w, h);
+  const rows = ranked(history);
+  if (!rows.length) return;
+  const ys = rows.map(runScore);
+  const max = Math.max(...ys, 1);
+  const bestI = bestIdOf(history);
+  const barW = Math.max(2, w / rows.length - 2);
+  rows.forEach((r, i) => {
+    const v = runScore(r);
+    const bh = v / max * (h - 6);
+    ctx.fillStyle = runColor(r.id, bestI);
+    ctx.globalAlpha = hoverId == null || hoverId === r.id ? (i === 0 ? 1 : 0.75) : 0.15;
+    ctx.fillRect(i * (w / rows.length) + 1, h - bh, barW, bh);
+  });
+  ctx.globalAlpha = 1;
+}
+
+function renderHistory(history, curId) {
+  currentId = curId;
+  historyCache = history;
+  const tb = el("hist").querySelector("tbody");
+  const rows = ranked(history);
+  tb.innerHTML = rows.map((r, i) => {
+    const res = r.result || {};
+    const k = r.knobs || {};
+    const sps = res.samples_per_sec || 0;
+    const stallPct = res.total_s > 0 ? (100 * res.stall_s / res.total_s) : 0;
+    const cls = [
+      i === 0 && rows.length ? "best" : "",
+      r.id === curId ? "current" : "",
+    ].filter(Boolean).join(" ");
+    return `<tr data-id="${r.id}" class="${cls}">
+      <td>${i + 1}</td>
+      <td>${r.id}</td>
+      <td>${r.source || ""}</td>
+      <td>${sps.toFixed(1)}</td>
+      <td>${stallPct.toFixed(1)}%</td>
+      <td>${(res.time_to_first_batch_s || 0).toFixed(2)}s</td>
+      <td>${res.http_429_count || 0}</td>
+      <td>${k.num_workers ?? ""}</td>
+      <td>${k.batch_size ?? ""}</td>
+      <td>${k.prefetch_factor ?? ""}</td>
+      <td>${k.max_pre_download ?? ""}</td>
+      <td>${k.max_concurrent_gets ?? ""}</td>
+    </tr>`;
+  }).join("");
+  drawCurves(history);
+  drawHistoryBars(history);
+  tb.querySelectorAll("tr").forEach(tr => {
+    tr.addEventListener("mouseenter", () => {
+      hoverId = +tr.dataset.id;
+      drawCurves(historyCache);
+      drawHistoryBars(historyCache);
+    });
+    tr.addEventListener("mouseleave", () => {
+      hoverId = null;
+      drawCurves(historyCache);
+      drawHistoryBars(historyCache);
+    });
+    tr.addEventListener("click", () => {
+      const rec = history.find(x => String(x.id) === tr.dataset.id);
+      if (!rec) return;
+      setKnobs(rec.knobs);
+      schedule();
+    });
+  });
+}
+
+let timer = null;
+let seq = 0;
+function setStatus(s, busy) {
+  const n = el("status");
+  n.textContent = s;
+  n.className = "status" + (busy ? " busy" : "");
+}
+
+function schedule() {
+  paintVals();
+  setStatus("queued…", true);
+  clearTimeout(timer);
+  timer = setTimeout(run, 80);
+}
+
+async function run() {
+  const my = ++seq;
+  setStatus("simulating…", true);
+  const knobs = readKnobs();
+  try {
+    const res = await fetch("/api/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(knobs),
+    });
+    const data = await res.json();
+    if (my !== seq) return;
+    show(data);
+    setStatus("idle", false);
+  } catch (e) {
+    if (my !== seq) return;
+    setStatus("error", false);
+  }
+}
+
+async function search() {
+  const my = ++seq;
+  setStatus("auto-search…", true);
+  try {
+    const res = await fetch("/api/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ knobs: readKnobs(), max_trials: 32 }),
+    });
+    const reader = res.body.getReader();
+    const dec = new TextDecoder();
+    let buf = "";
+    while (true) {
+      const { value, done } = await reader.read();
+      if (my !== seq) return;
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+      const lines = buf.split("\n");
+      buf = lines.pop();
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        const msg = JSON.parse(line);
+        if (msg.type === "trial" && msg.run) {
+          historyCache = historyCache.concat([msg.run]);
+          currentId = msg.run.id;
+          paintStats(msg.run.result || {});
+          renderHistory(historyCache, currentId);
+          setStatus(`auto-search ${msg.i}/${msg.n} · ${(msg.run.result.samples_per_sec || 0).toFixed(0)} sps`, true);
+        } else if (msg.type === "done") {
+          if (msg.knobs) setKnobs(msg.knobs);
+          show(msg);
+          setStatus(`search done · ${msg.trials || historyCache.length} trials`, false);
+        }
+      }
+    }
+  } catch (e) {
+    if (my !== seq) return;
+    setStatus("search error", false);
+  }
+}
+
+document.querySelectorAll("aside input").forEach(n => {
+  n.addEventListener("input", schedule);
+  n.addEventListener("change", schedule);
+});
+
+document.querySelectorAll("[data-preset]").forEach(btn => {
+  btn.addEventListener("click", () => {
+    const p = btn.dataset.preset;
+    if (p === "s3") {
+      el("bandwidth_bps").value = 125000000;
+      el("rtt_ms").value = 20;
+      el("rate_limit_enabled").checked = true;
+      el("max_concurrent_gets").value = 16;
+    } else if (p === "s3fast") {
+      el("bandwidth_bps").value = 1250000000;
+      el("rtt_ms").value = 8;
+      el("rate_limit_enabled").checked = true;
+      el("max_concurrent_gets").value = 32;
+    } else if (p === "vast") {
+      el("bandwidth_bps").value = 5000000000;
+      el("rtt_ms").value = 1;
+      el("rate_limit_enabled").checked = false;
+      el("max_concurrent_gets").value = 64;
+    } else if (p === "gpu") {
+      el("time_per_sample_s").value = 0.001;
+    }
+    schedule();
+  });
+});
+
+el("search").addEventListener("click", search);
+el("clear").addEventListener("click", async () => {
+  await fetch("/api/history/clear", { method: "POST" });
+  historyCache = [];
+  hoverId = null;
+  renderHistory([], null);
+});
+
+bindChartHover();
+window.addEventListener("resize", () => drawCurves(historyCache));
+
+(async function init() {
+  const res = await fetch("/api/state");
+  const state = await res.json();
+  setKnobs(state.knobs);
+  show(state);
+  setStatus("idle", false);
+})();

--- a/simulator/web/static/bolt.svg
+++ b/simulator/web/static/bolt.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 48" fill="none">
+  <path d="M18.6 0 4 26.4h10.2L8.8 48 28 18.8H16.6L18.6 0Z" fill="#C9B8FF"/>
+</svg>

--- a/simulator/web/static/index.html
+++ b/simulator/web/static/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>LitData Simulator · Lightning.AI</title>
+  <link rel="icon" type="image/svg+xml" href="/bolt.svg" />
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <header class="top">
+    <a class="brand" href="https://lightning.ai/" target="_blank" rel="noopener">
+      <img class="bolt" src="/bolt.svg" alt="" />
+      <span class="brand-copy">
+        <span class="product">LitData Simulator</span>
+        <span class="org">Lightning.AI</span>
+      </span>
+    </a>
+    <div class="meta" id="meta">loading…</div>
+    <div class="status" id="status"></div>
+    <div class="simms" id="simms"></div>
+  </header>
+  <div class="layout">
+    <aside>
+      <p class="hint">Remote storage is the default: object-store GETs, RTT, and 429s. Compaction (chunks vs per-sample files) is what Vast and S3 both reward. Changing a knob re-runs the Go engine; History keeps every run.</p>
+      <div class="presets">
+        <button type="button" data-preset="s3">S3 1 Gbps</button>
+        <button type="button" data-preset="s3fast">S3 10 Gbps</button>
+        <button type="button" data-preset="vast">Vast POSIX</button>
+        <button type="button" data-preset="gpu">+ 1 ms GPU</button>
+      </div>
+      <button type="button" class="primary" id="search">Auto-search best knobs</button>
+      <label>num_workers <input id="num_workers" type="range" min="0" max="32" step="1"><span data-val></span></label>
+      <label>batch_size <input id="batch_size" type="range" min="8" max="512" step="8"><span data-val></span></label>
+      <label>prefetch_factor <input id="prefetch_factor" type="range" min="1" max="8" step="1"><span data-val></span></label>
+      <label>max_pre_download <input id="max_pre_download" type="range" min="1" max="32" step="1"><span data-val></span></label>
+      <label>bandwidth_bps <input id="bandwidth_bps" type="range" min="12500000" max="5000000000" step="12500000"><span data-val></span></label>
+      <label>rtt_ms <input id="rtt_ms" type="range" min="0" max="200" step="1"><span data-val></span></label>
+      <label>max_concurrent_gets <input id="max_concurrent_gets" type="range" min="1" max="64" step="1"><span data-val></span></label>
+      <label>requests_per_sec <input id="requests_per_sec" type="range" min="50" max="8000" step="50"><span data-val></span></label>
+      <label>time_per_sample_s <input id="time_per_sample_s" type="range" min="0" max="0.005" step="0.0001"><span data-val></span></label>
+      <label>decompress_ns_per_byte <input id="decompress_ns_per_byte" type="range" min="0" max="20" step="0.1"><span data-val></span></label>
+      <label>deserialize_us_per_sample <input id="deserialize_us_per_sample" type="range" min="0" max="8000" step="50"><span data-val></span></label>
+      <label>jitter_sigma <input id="jitter_sigma" type="range" min="0" max="1" step="0.05"><span data-val></span></label>
+      <label class="check"><input id="rate_limit_enabled" type="checkbox"> rate limit (429s)</label>
+    </aside>
+    <main>
+      <section class="stats" id="stats"></section>
+      <div class="chart-wrap">
+        <canvas id="chart"></canvas>
+        <div id="tip" class="tip" hidden></div>
+      </div>
+      <p class="caption">Every run is a curve. History is ranked by samples/s with a stall penalty (same score as the tuner). Hover for details; click a row to restore that spec.</p>
+      <div class="hist-head">
+        <h2>History</h2>
+        <button type="button" id="clear">Clear</button>
+      </div>
+      <div class="hist-bars"><canvas id="histchart"></canvas></div>
+      <div class="table-wrap">
+        <table id="hist">
+          <thead>
+            <tr>
+              <th>rank</th><th>run</th><th>source</th><th>samples/s</th><th>stall</th><th>ttfb</th><th>429</th>
+              <th>workers</th><th>batch</th><th>prefetch</th><th>pre-dl</th><th>conc</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </main>
+  </div>
+  <footer class="foot">
+    <span>Built for <a href="https://lightning.ai/" target="_blank" rel="noopener">Lightning.AI</a></span>
+    <span class="sep">·</span>
+    <span>LitData streaming</span>
+  </footer>
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/simulator/web/static/style.css
+++ b/simulator/web/static/style.css
@@ -1,0 +1,124 @@
+:root {
+  --bg: #0c0a12;
+  --panel: #14111c;
+  --line: rgba(201, 184, 255, 0.12);
+  --text: #f3f0fa;
+  --muted: #9b94ad;
+  --accent: #c9b8ff;
+  --accent-deep: #8f7cf0;
+  --best: #e4dcff;
+}
+* { box-sizing: border-box; }
+html, body {
+  margin: 0; height: 100%;
+  background: var(--bg); color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+body {
+  background-image:
+    radial-gradient(1100px 520px at 0% -20%, rgba(143, 124, 240, 0.22), transparent 55%),
+    radial-gradient(800px 420px at 100% 0%, rgba(201, 184, 255, 0.10), transparent 50%);
+}
+.top {
+  display: flex; align-items: center; gap: 18px;
+  padding: 12px 22px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(20, 17, 28, 0.88);
+  backdrop-filter: blur(12px);
+}
+.brand {
+  display: flex; align-items: center; gap: 10px;
+  text-decoration: none; color: inherit; flex-shrink: 0;
+}
+.bolt { width: 18px; height: 27px; display: block; }
+.brand-copy { display: flex; flex-direction: column; line-height: 1.15; }
+.product { font-weight: 700; letter-spacing: -0.02em; font-size: 15px; }
+.org {
+  font-size: 11px; font-weight: 600; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--accent);
+}
+.meta, .simms, .status { color: var(--muted); font-size: 13px; }
+.simms { margin-left: auto; font-variant-numeric: tabular-nums; }
+.status.busy { color: var(--accent); }
+.layout { display: flex; height: calc(100% - 86px); min-height: 0; }
+aside {
+  width: 340px; flex-shrink: 0; overflow: auto; padding: 16px 18px;
+  border-right: 1px solid var(--line); background: var(--panel);
+}
+main { flex: 1; min-width: 0; padding: 20px 24px; overflow: auto; }
+.hint { font-size: 12px; color: var(--muted); margin: 0 0 12px; line-height: 1.45; }
+.presets { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 12px; }
+.presets button, #clear {
+  background: transparent; color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 999px; padding: 6px 12px; cursor: pointer; font-size: 12px;
+}
+.presets button:hover, #clear:hover { border-color: var(--accent); color: var(--accent); }
+.primary {
+  width: 100%; margin-bottom: 14px; padding: 10px 12px;
+  background: linear-gradient(180deg, #b7a6ff 0%, #8f7cf0 100%);
+  color: #1a1428;
+  border: none; border-radius: 999px;
+  cursor: pointer; font-size: 13px; font-weight: 700;
+}
+.primary:hover { filter: brightness(1.05); }
+label {
+  display: grid; grid-template-columns: 1fr 72px; gap: 6px 8px; align-items: center;
+  font-size: 12px; color: var(--muted); margin: 10px 0;
+}
+label input[type=range] { grid-column: 1 / -1; width: 100%; accent-color: var(--accent-deep); }
+label span[data-val] { text-align: right; color: var(--text); font-variant-numeric: tabular-nums; }
+.check { display: flex; gap: 8px; align-items: center; grid-template-columns: none; }
+.check input { accent-color: var(--accent-deep); }
+.stats { display: flex; flex-wrap: wrap; gap: 16px 28px; margin-bottom: 8px; }
+.stat b { display: block; font-size: 28px; font-weight: 650; letter-spacing: -0.03em; }
+.stat span { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; }
+canvas {
+  width: 100%; height: 100%;
+  max-width: 100%;
+  background: #100e16;
+  border: 1px solid var(--line); border-radius: 12px;
+  display: block;
+}
+.chart-wrap {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+  height: 260px;
+}
+.hist-bars {
+  width: 100%;
+  min-width: 0;
+  height: 140px;
+}
+.tip {
+  position: absolute; pointer-events: none; z-index: 2;
+  background: rgba(20, 17, 28, 0.94);
+  border: 1px solid var(--line); border-radius: 10px;
+  padding: 8px 10px; font-size: 12px; line-height: 1.45;
+  color: var(--text); max-width: 280px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.35);
+}
+.tip b { color: var(--accent); }
+.tip .k { color: var(--muted); }
+.caption { color: var(--muted); font-size: 12px; }
+.hist-head { display: flex; align-items: baseline; justify-content: space-between; margin: 20px 0 8px; }
+.hist-head h2 { margin: 0; font-size: 16px; letter-spacing: -0.02em; }
+.table-wrap { overflow: auto; margin-top: 10px; max-height: 360px; }
+table { width: 100%; border-collapse: collapse; font-size: 12px; }
+th, td { text-align: left; padding: 8px; border-bottom: 1px solid var(--line); white-space: nowrap; }
+th { color: var(--muted); font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; font-size: 11px; }
+tbody tr { cursor: pointer; }
+tbody tr:hover { background: rgba(201, 184, 255, 0.08); }
+tbody tr.best { color: var(--best); }
+tbody tr.hovering { background: rgba(201, 184, 255, 0.12); }
+tbody tr.current { outline: 1px solid var(--accent); outline-offset: -1px; }
+.foot {
+  height: 36px; display: flex; align-items: center; gap: 8px;
+  padding: 0 22px; border-top: 1px solid var(--line);
+  font-size: 12px; color: var(--muted); background: var(--panel);
+}
+.foot a { color: var(--accent); text-decoration: none; font-weight: 600; }
+.foot a:hover { text-decoration: underline; }
+.sep { opacity: 0.4; }
+code { font-size: 11px; }


### PR DESCRIPTION
## Summary
- Adds `simulator/` (`litsim`): Go engine that walks a LitData `index.json` and models **remote** GETs, RTT, 429 rate limits, LRU cache, decompress/deserialize, and device time (CPU and GPU overlap via max, not sum).
- CLI: `init` / `verify` / `run` / `tune` / `serve`. Paths resolve through the same `_resolve_dir` as `StreamingDataset`.
- Web UI (`litsim serve`): Lightning.AI-styled playground, background re-runs, overlaid throughput curves with hover details, ranked history, and streaming auto-search.

Left out of this PR: `scripts/trace_dataloader.py` (local tracing WIP).

## Test plan
- [ ] `cd simulator && go test ./...` (CI: `.github/workflows/ci-litsim.yml`, Go 1.23)
- [ ] `go run ./cmd/litsim init --index <dataset> -c litsim.yaml && go run ./cmd/litsim verify|run -c litsim.yaml`
- [ ] `go run ./cmd/litsim serve -c litsim.yaml --addr :8765` — sliders re-run, history ranks, auto-search streams curves, charts stay a fixed size


Made with [Cursor](https://cursor.com)