### PR TITLE
Faster pytree flatten and bool deserialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -2141,7 +2141,9 @@ for batch in StreamingDataLoader(dataset, batch_size=64, num_workers=8):
 | `LITDATA_ASYNC_CHUNK_PREFETCH=1` | Force on |
 | `LITDATA_ASYNC_CHUNK_PREFETCH=0` | Force off |
 
-When async is on, LitData raises `max_pre_download` to at least **4** so `asyncio.gather` has enough in-flight downloads (override with `LITDATA_ASYNC_MIN_PRE_DOWNLOAD`; set `0` to disable the floor). Peak disk ≈ `num_workers × max_pre_download × chunk_size` — size `max_cache_size` accordingly.
+When async is on, LitData raises `max_pre_download` to at least **4** so `asyncio.gather` has enough in-flight downloads (override with `LITDATA_ASYNC_MIN_PRE_DOWNLOAD`; set `0` to disable the floor). Concurrent GETs are capped by `LITDATA_ASYNC_DOWNLOAD_CONCURRENCY` (default **8**). The prepare thread drains the prefetch queue up to that gather width whenever a cache slot is free. Peak disk ≈ `num_workers × max_pre_download × chunk_size` — size `max_cache_size` accordingly.
+
+The reader does **not** poll the cache directory for each chunk. After a download finishes, the downloader atomically `os.replace`s the temp file and sets an in-process `Event`. Compressed chunks set that Event only after decompress publishes the readable `.bin`. Other DataLoader workers still fall back to a short filesystem check (Events are per process).
 
 ```bash
 # Debugging download/delete races — force synchronous downloads
@@ -2149,6 +2151,9 @@ export LITDATA_ASYNC_CHUNK_PREFETCH=0
 
 # Keep max_pre_download=2 even with async enabled
 export LITDATA_ASYNC_MIN_PRE_DOWNLOAD=0
+
+# Cap overlapping remote GETs (default 8)
+export LITDATA_ASYNC_DOWNLOAD_CONCURRENCY=4
 ```
 
 ### Common environment variables
@@ -2158,6 +2163,7 @@ export LITDATA_ASYNC_MIN_PRE_DOWNLOAD=0
 | `LITDATA_CACHE_DIR` | `~/.lightning/chunks` | Default chunk cache directory |
 | `LITDATA_ASYNC_CHUNK_PREFETCH` | on for remote | `0`/`1` force async chunk download overlap |
 | `LITDATA_ASYNC_MIN_PRE_DOWNLOAD` | `4` | Floor for `max_pre_download` when async is on (`0` = no floor) |
+| `LITDATA_ASYNC_DOWNLOAD_CONCURRENCY` | `8` | Max in-flight chunk GETs per gather |
 | `LITDATA_OBSTORE_STREAM_MIN_CHUNK_MIB` | `8` | S3 obstore stream chunk size (MiB) |
 | `MAX_WAIT_TIME` | `120` | Seconds to wait for a chunk before error |
 | `FORCE_DOWNLOAD_TIME` | `30` | Seconds before force re-download of a missing chunk |

--- a/scripts/bench/bench_s3_remote.py
+++ b/scripts/bench/bench_s3_remote.py
@@ -83,6 +83,10 @@ def _fresh_cache(prefix: str) -> str:
 def bench_download(input_dir: str, n_chunks: int, drop_page_cache: bool = False) -> dict:
     """Compare serial sync downloads vs asyncio.gather on real remote chunks."""
     remote, chunks = _load_index(input_dir)
+    resolved = _resolve_dir(input_dir)
+    storage_options = {}
+    if getattr(resolved, "data_connection_id", None):
+        storage_options["data_connection_id"] = resolved.data_connection_id
     n_chunks = min(n_chunks, len(chunks))
     indexes = list(range(n_chunks))
     selected = chunks[:n_chunks]
@@ -94,8 +98,8 @@ def bench_download(input_dir: str, n_chunks: int, drop_page_cache: bool = False)
     serial_cache = _fresh_cache("litdata-s3-serial-")
     async_cache = _fresh_cache("litdata-s3-async-")
     try:
-        serial_dl = get_downloader(remote + "/", serial_cache, selected, {}, {})
-        async_dl = get_downloader(remote + "/", async_cache, selected, {}, {})
+        serial_dl = get_downloader(remote + "/", serial_cache, selected, storage_options, {})
+        async_dl = get_downloader(remote + "/", async_cache, selected, storage_options, {})
         print(f"downloader={type(serial_dl).__name__} native_adownload={downloader_supports_adownload(serial_dl)}")
 
         t0 = time.perf_counter()

--- a/scripts/bench/bench_streaming_e2e.py
+++ b/scripts/bench/bench_streaming_e2e.py
@@ -29,7 +29,6 @@ sys.path.insert(0, str(REPO_ROOT / "src"))
 
 os.environ.setdefault("LITDATA_TIMING", "1")
 
-from litdata.streaming import Cache  # noqa: E402
 from litdata.streaming.dataloader import StreamingDataLoader  # noqa: E402
 from litdata.streaming.dataset import StreamingDataset  # noqa: E402
 from litdata.streaming.timing import StreamingTimingStats  # noqa: E402

--- a/scripts/bench/bench_streaming_e2e.py
+++ b/scripts/bench/bench_streaming_e2e.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""End-to-end StreamingDataset bench: write, local read, and remote→local copy.
+
+The ``local:`` scheme forces PrepareChunksThread + LocalDownloader copies into a
+fresh cache, which is the same control flow as ``s3://`` without needing a bucket.
+
+  PYTHONPATH=src python scripts/bench/bench_streaming_e2e.py
+  PYTHONPATH=src python scripts/bench/bench_streaming_e2e.py --profile
+"""
+
+from __future__ import annotations
+
+import argparse
+import cProfile
+import os
+import pstats
+import shutil
+import sys
+import tempfile
+import time
+from io import BytesIO
+from pathlib import Path
+
+import numpy as np
+from PIL import Image as PILImage
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+os.environ.setdefault("LITDATA_TIMING", "1")
+
+from litdata.streaming import Cache  # noqa: E402
+from litdata.streaming.dataloader import StreamingDataLoader  # noqa: E402
+from litdata.streaming.dataset import StreamingDataset  # noqa: E402
+from litdata.streaming.timing import StreamingTimingStats  # noqa: E402
+from litdata.streaming.writer import BinaryWriter  # noqa: E402
+
+
+def _median(xs: list[float]) -> float:
+    xs = sorted(xs)
+    return xs[len(xs) // 2]
+
+
+def _write_mixed(out_dir: str, n: int, chunk_size: int) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    writer = BinaryWriter(out_dir, chunk_size=chunk_size)
+    for i in range(n):
+        writer[i] = {
+            "id": i,
+            "flag": i % 2 == 0,
+            "x": float(i),
+            "coords": [float(i), float(i + 1), float(i + 2)],
+            "label": f"cls-{i % 10}",
+        }
+    writer.done()
+    writer.merge()
+
+
+def _write_jpegs(out_dir: str, n: int, chunk_size: int, size: int) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    rng = np.random.RandomState(0)
+    frames = []
+    for _ in range(8):
+        arr = rng.randint(0, 256, (size, size, 3), dtype=np.uint8)
+        buf = BytesIO()
+        PILImage.fromarray(arr).save(buf, format="JPEG", quality=90)
+        frames.append(buf.getvalue())
+    writer = BinaryWriter(out_dir, chunk_size=chunk_size)
+    for i in range(n):
+        writer[i] = {"image": frames[i % len(frames)], "id": i}
+    writer.done()
+    writer.merge()
+
+
+def _iterate(input_dir: str, cache_dir: str | None, *, workers: int, batch_size: int, max_pre: int) -> dict:
+    StreamingTimingStats.reset_instance()
+    ds = StreamingDataset(
+        input_dir=input_dir,
+        cache_dir=cache_dir,
+        shuffle=False,
+        max_pre_download=max_pre,
+        max_cache_size="20GB",
+    )
+    loader = StreamingDataLoader(
+        ds,
+        batch_size=batch_size,
+        num_workers=workers,
+        prefetch_factor=2 if workers > 0 else None,
+    )
+    t0 = time.perf_counter()
+    n = 0
+    for batch in loader:
+        first = next(iter(batch.values())) if isinstance(batch, dict) else batch
+        n += int(first.shape[0]) if hasattr(first, "shape") else len(first)
+    elapsed = time.perf_counter() - t0
+    snap = StreamingTimingStats.instance().snapshot()
+    return {
+        "items": n,
+        "elapsed_s": elapsed,
+        "items_per_s": n / elapsed if elapsed else float("nan"),
+        "timing": snap,
+    }
+
+
+def _print_row(name: str, row: dict) -> None:
+    dl = row["timing"].get("chunk_download_s", {})
+    dec = row["timing"].get("item_decode_s", {})
+    print(
+        f"  {name:42s}  {row['elapsed_s'] * 1e3:8.1f} ms  "
+        f"{row['items_per_s']:8.0f} items/s  items={row['items']}  "
+        f"download_n={dl.get('count', 0)} download_mean={dl.get('mean_s', 0):.4f}s  "
+        f"decode_n={dec.get('count', 0)} decode_mean={dec.get('mean_s', 0) * 1e3:.3f}ms"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mixed", type=int, default=20000)
+    parser.add_argument("--jpegs", type=int, default=2000)
+    parser.add_argument("--jpeg-size", type=int, default=128)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--profile", action="store_true")
+    args = parser.parse_args()
+
+    tmp = tempfile.mkdtemp(prefix="litdata-e2e-")
+    mixed_dir = os.path.join(tmp, "mixed")
+    jpeg_dir = os.path.join(tmp, "jpegs")
+    try:
+        t0 = time.perf_counter()
+        _write_mixed(mixed_dir, args.mixed, chunk_size=256)
+        write_mixed = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        _write_jpegs(jpeg_dir, args.jpegs, chunk_size=32, size=args.jpeg_size)
+        write_jpeg = time.perf_counter() - t0
+        print(f"write mixed {args.mixed}        {write_mixed * 1e3:8.1f} ms")
+        print(f"write jpeg  {args.jpegs}x{args.jpeg_size}  {write_jpeg * 1e3:8.1f} ms")
+
+        rows: list[tuple[str, dict]] = []
+
+        def add(name: str, fn) -> None:
+            times = []
+            last = None
+            for _ in range(args.repeats):
+                last = fn()
+                times.append(last["elapsed_s"])
+            last = dict(last)
+            last["elapsed_s"] = _median(times)
+            last["items_per_s"] = last["items"] / last["elapsed_s"] if last["elapsed_s"] else float("nan")
+            rows.append((name, last))
+            _print_row(name, last)
+
+        add("local mixed w0", lambda: _iterate(mixed_dir, None, workers=0, batch_size=64, max_pre=4))
+        add("local mixed w2", lambda: _iterate(mixed_dir, None, workers=2, batch_size=64, max_pre=4))
+        add("local jpeg w0", lambda: _iterate(jpeg_dir, None, workers=0, batch_size=32, max_pre=4))
+
+        def remote_mixed() -> dict:
+            cache = tempfile.mkdtemp(prefix="litdata-e2e-cache-")
+            try:
+                return _iterate(f"local:{mixed_dir}", cache, workers=0, batch_size=64, max_pre=4)
+            finally:
+                shutil.rmtree(cache, ignore_errors=True)
+
+        def remote_mixed_w2() -> dict:
+            cache = tempfile.mkdtemp(prefix="litdata-e2e-cache-")
+            try:
+                return _iterate(f"local:{mixed_dir}", cache, workers=2, batch_size=64, max_pre=8)
+            finally:
+                shutil.rmtree(cache, ignore_errors=True)
+
+        add("remote→local mixed w0", remote_mixed)
+        add("remote→local mixed w2", remote_mixed_w2)
+
+        if args.profile:
+            cache = tempfile.mkdtemp(prefix="litdata-e2e-prof-")
+            prof = cProfile.Profile()
+            prof.enable()
+            _iterate(f"local:{mixed_dir}", cache, workers=0, batch_size=64, max_pre=4)
+            prof.disable()
+            shutil.rmtree(cache, ignore_errors=True)
+            stats = pstats.Stats(prof).sort_stats("tottime")
+            print("\n=== cProfile remote→local mixed w0 (top 25) ===")
+            stats.print_stats(25)
+
+        print("\n=== summary ===")
+        for name, row in rows:
+            print(f"{name:42s}  {row['elapsed_s'] * 1e3:8.1f} ms  {row['items_per_s']:8.0f} items/s")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Faster pytree flatten on the writer hot path: skip typing-generic `isinstance` and PIL JPEG probes on non-list/tuple nodes, skip namedtuple/JPEG probes on scalar leaves, and call `_get_node_type` once per node. After the first sample, `BinaryWriter` walks `tree_leaves` (non-generator collect) instead of rebuilding a `TreeSpec`, caches per-leaf byte sizes, and packs the size header with `struct` instead of NumPy. `BooleanSerializer.deserialize` reads the first byte instead of going through NumPy.
+- Faster pytree flatten on the writer hot path: skip typing-generic `isinstance` and PIL JPEG probes on non-list/tuple nodes, skip namedtuple/JPEG probes on scalar leaves, and call `_get_node_type` once per node. After the first sample, `BinaryWriter` walks `tree_leaves` (non-generator collect) instead of rebuilding a `TreeSpec`, caches per-leaf byte sizes, and packs the size header with `struct` instead of NumPy. When every leaf has a fixed size (int/float/bool), later samples reuse a cached size header and write into one buffer. `BooleanSerializer` advertises `size = 1`. Reader offset pairs and size headers use `struct` instead of NumPy.
 
 ## [0.2.70] - 2026-08-15
 

--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Faster pytree flatten on the writer hot path: skip typing-generic `isinstance` and PIL JPEG probes on non-list/tuple nodes, skip namedtuple/JPEG probes on scalar leaves, and call `_get_node_type` once per node. After the first sample, `BinaryWriter` walks `tree_leaves` (non-generator collect) instead of rebuilding a `TreeSpec`, caches per-leaf byte sizes, and packs the size header with `struct` instead of NumPy. When every leaf has a fixed size (int/float/bool), later samples reuse a cached size header and write into one buffer. `BooleanSerializer` advertises `size = 1`. Reader offset pairs and size headers use `struct` instead of NumPy.
+- Remote→local streaming: cap in-flight chunk GETs with `LITDATA_ASYNC_DOWNLOAD_CONCURRENCY` (default 8), poll chunk-ready Events every 20ms, and `posix_fadvise(WILLNEED)` downloaded cache files from the prefetch thread (mmap stays on the reader thread).
 
 ## [0.2.70] - 2026-08-15
 

--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Faster pytree flatten on the writer hot path: skip typing-generic `isinstance` and PIL JPEG probes on non-list/tuple nodes, skip namedtuple/JPEG probes on scalar leaves, and call `_get_node_type` once per node. After the first sample, `BinaryWriter` walks `tree_leaves` (non-generator collect) instead of rebuilding a `TreeSpec`, caches per-leaf byte sizes, and packs the size header with `struct` instead of NumPy. When every leaf has a fixed size (int/float/bool), later samples reuse a cached size header and write into one buffer. `BooleanSerializer` advertises `size = 1`. Reader offset pairs and size headers use `struct` instead of NumPy.
-- Remote→local streaming: cap in-flight chunk GETs with `LITDATA_ASYNC_DOWNLOAD_CONCURRENCY` (default 8), poll chunk-ready Events every 20ms, and `posix_fadvise(WILLNEED)` downloaded cache files from the prefetch thread (mmap stays on the reader thread).
+- Remote→local streaming: cap in-flight chunk GETs with `LITDATA_ASYNC_DOWNLOAD_CONCURRENCY` (default 8), drain the prefetch queue up to gather width when slots are free, signal file-ready with `Event.set` after the downloader's atomic `os.replace` (decompress publishes the readable `.bin`), and `posix_fadvise(WILLNEED)` downloaded cache files from the prefetch thread (mmap stays on the reader thread).
 
 ## [0.2.70] - 2026-08-15
 

--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Faster pytree flatten on the writer hot path: skip typing-generic `isinstance` and PIL JPEG probes on non-list/tuple nodes, skip namedtuple/JPEG probes on scalar leaves, and call `_get_node_type` once per node. After the first sample, `BinaryWriter` walks `tree_leaves` instead of rebuilding a `TreeSpec`. `BooleanSerializer.deserialize` reads the first byte instead of going through NumPy.
+- Faster pytree flatten on the writer hot path: skip typing-generic `isinstance` and PIL JPEG probes on non-list/tuple nodes, skip namedtuple/JPEG probes on scalar leaves, and call `_get_node_type` once per node. After the first sample, `BinaryWriter` walks `tree_leaves` (non-generator collect) instead of rebuilding a `TreeSpec`, caches per-leaf byte sizes, and packs the size header with `struct` instead of NumPy. `BooleanSerializer.deserialize` reads the first byte instead of going through NumPy.
 
 ## [0.2.70] - 2026-08-15
 

--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased] - YYYY-MM-DD
 
+### Changed
+
+- Faster pytree flatten on the writer hot path: skip typing-generic `isinstance` and PIL JPEG probes on non-list/tuple nodes, and call `_get_node_type` once per node. `BooleanSerializer.deserialize` reads the first byte instead of going through NumPy.
+
 ## [0.2.70] - 2026-08-15
 
 ### Added

--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased] - YYYY-MM-DD
 
+### Fixed
+
+- Prefetch accepts `numpy.int64` chunk indexes from shuffle (they were dropped by `isinstance(..., int)`), so force-download stays a last resort after `_FORCE_DOWNLOAD_TIME`. Concurrent `os.replace` of the same chunk is a no-op when the destination already exists.
+
 ### Changed
 
 - Faster pytree flatten on the writer hot path: skip typing-generic `isinstance` and PIL JPEG probes on non-list/tuple nodes, skip namedtuple/JPEG probes on scalar leaves, and call `_get_node_type` once per node. After the first sample, `BinaryWriter` walks `tree_leaves` (non-generator collect) instead of rebuilding a `TreeSpec`, caches per-leaf byte sizes, and packs the size header with `struct` instead of NumPy. When every leaf has a fixed size (int/float/bool), later samples reuse a cached size header and write into one buffer. `BooleanSerializer` advertises `size = 1`. Reader offset pairs and size headers use `struct` instead of NumPy.

--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Faster pytree flatten on the writer hot path: skip typing-generic `isinstance` and PIL JPEG probes on non-list/tuple nodes, and call `_get_node_type` once per node. `BooleanSerializer.deserialize` reads the first byte instead of going through NumPy.
+- Faster pytree flatten on the writer hot path: skip typing-generic `isinstance` and PIL JPEG probes on non-list/tuple nodes, skip namedtuple/JPEG probes on scalar leaves, and call `_get_node_type` once per node. After the first sample, `BinaryWriter` walks `tree_leaves` instead of rebuilding a `TreeSpec`. `BooleanSerializer.deserialize` reads the first byte instead of going through NumPy.
 
 ## [0.2.70] - 2026-08-15
 

--- a/src/litdata/streaming/async_prefetch.py
+++ b/src/litdata/streaming/async_prefetch.py
@@ -146,6 +146,7 @@ def _remote_join(remote_dir: str, filename: str) -> str:
 async def _adownload_file_to_path(downloader: Downloader, remote_filepath: str, local_filepath: str) -> None:
     """Fetch ``remote_filepath`` asynchronously and publish atomically."""
     if os.path.exists(local_filepath):
+        downloader._notify_published(local_filepath)
         return
     # Prefer streaming-to-disk when the backend overrides adownload_file.
     if type(downloader).adownload_file is not Downloader.adownload_file:
@@ -162,7 +163,7 @@ async def _adownload_file_to_path(downloader: Downloader, remote_filepath: str, 
         os.makedirs(os.path.dirname(local_filepath) or ".", exist_ok=True)
         with open(tmp_path, "wb") as f:
             f.write(data)
-        downloader._atomic_replace(tmp_path, local_filepath)
+        downloader._publish_file(tmp_path, local_filepath)
     except Exception:
         with contextlib.suppress(FileNotFoundError, PermissionError):
             os.remove(tmp_path)
@@ -185,7 +186,7 @@ async def _adownload_chunk_index(config: ChunksConfig, chunk_index: int) -> None
     )
 
     if os.path.exists(local_chunkpath):
-        config.try_decompress(local_chunkpath)
+        await asyncio.to_thread(config.try_decompress, local_chunkpath)
         if lazily_ref_counted:
             downloader._increment_local_lock(lock_path, chunk_index)
         return
@@ -199,7 +200,7 @@ async def _adownload_chunk_index(config: ChunksConfig, chunk_index: int) -> None
         # Overlap blocking SDK calls across threads when native async is unavailable.
         await asyncio.to_thread(downloader.download_chunk_from_index, chunk_index)
 
-    config.try_decompress(local_chunkpath)
+    await asyncio.to_thread(config.try_decompress, local_chunkpath)
 
 
 async def adownload_chunk_indexes(config: ChunksConfig, chunk_indexes: list[int]) -> None:

--- a/src/litdata/streaming/async_prefetch.py
+++ b/src/litdata/streaming/async_prefetch.py
@@ -54,6 +54,8 @@ _THREAD_LOOPS = threading.local()
 # Empirically, async gather on real S3 is bottlenecked when max_pre_download==2
 # (only 1–2 in-flight). Floor to 4 when the feature is enabled unless overridden.
 _DEFAULT_ASYNC_MIN_PRE_DOWNLOAD = 4
+# Cap in-flight GETs so a large drain batch does not open one connection per slot.
+_DEFAULT_ASYNC_DOWNLOAD_CONCURRENCY = 8
 
 
 def async_chunk_prefetch_enabled(remote_dir: str | None = None) -> bool:
@@ -79,6 +81,17 @@ def async_prefetch_min_pre_download() -> int:
     if raw is None:
         return _DEFAULT_ASYNC_MIN_PRE_DOWNLOAD
     return max(0, int(raw))
+
+
+def async_download_concurrency(n_chunks: int) -> int:
+    """How many remote chunk GETs to run at once inside ``asyncio.gather``.
+
+    Override with ``LITDATA_ASYNC_DOWNLOAD_CONCURRENCY`` (default 8). Always at
+    least 1 and at most ``n_chunks``.
+    """
+    raw = os.getenv("LITDATA_ASYNC_DOWNLOAD_CONCURRENCY")
+    limit = _DEFAULT_ASYNC_DOWNLOAD_CONCURRENCY if raw is None else max(1, int(raw))
+    return max(1, min(limit, max(1, n_chunks)))
 
 
 def apply_async_pre_download_floor(max_pre_download: int, remote_dir: str | None = None) -> int:
@@ -196,7 +209,17 @@ async def adownload_chunk_indexes(config: ChunksConfig, chunk_indexes: list[int]
     if len(chunk_indexes) == 1:
         await _adownload_chunk_index(config, chunk_indexes[0])
         return
-    await asyncio.gather(*[_adownload_chunk_index(config, idx) for idx in chunk_indexes])
+    limit = async_download_concurrency(len(chunk_indexes))
+    if limit >= len(chunk_indexes):
+        await asyncio.gather(*[_adownload_chunk_index(config, idx) for idx in chunk_indexes])
+        return
+    sem = asyncio.Semaphore(limit)
+
+    async def _one(idx: int) -> None:
+        async with sem:
+            await _adownload_chunk_index(config, idx)
+
+    await asyncio.gather(*[_one(idx) for idx in chunk_indexes])
 
 
 def _thread_event_loop() -> asyncio.AbstractEventLoop:

--- a/src/litdata/streaming/compression.py
+++ b/src/litdata/streaming/compression.py
@@ -54,27 +54,27 @@ class ZSTDCompressor(Compressor):
             raise ModuleNotFoundError(str(_ZSTD_AVAILABLE))
         self.level = level
         self.extension = "zstd"
+        self._zstd = None
+
+    def _zstd_mod(self):
+        if self._zstd is None:
+            if _PYTHON_GREATER_EQUAL_3_14:
+                from compression import zstd as mod
+            else:
+                import zstd as mod
+            self._zstd = mod
+        return self._zstd
 
     @property
     def name(self) -> str:
         return f"{self.extension}:{self.level}"
 
     def compress(self, data: bytes) -> bytes:
-        if _PYTHON_GREATER_EQUAL_3_14:
-            from compression import zstd
-        else:
-            import zstd
-
-        return zstd.compress(data, self.level)
+        return self._zstd_mod().compress(data, self.level)
 
     def decompress(self, data: bytes) -> bytes:
-        if _PYTHON_GREATER_EQUAL_3_14:
-            from compression import zstd
-        else:
-            import zstd
-
         with trace_span("decompress", CAT_DECOMPRESS):
-            return zstd.decompress(data)
+            return self._zstd_mod().decompress(data)
 
     def decompress_file(self, src: str, dst: str) -> None:
         if _PYTHON_GREATER_EQUAL_3_14:

--- a/src/litdata/streaming/compression.py
+++ b/src/litdata/streaming/compression.py
@@ -13,7 +13,7 @@
 
 import shutil
 from abc import ABC, abstractmethod
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from litdata.constants import _PYTHON_GREATER_EQUAL_3_14, _ZSTD_AVAILABLE
 from litdata.debugger import CAT_DECOMPRESS, trace_span
@@ -54,9 +54,9 @@ class ZSTDCompressor(Compressor):
             raise ModuleNotFoundError(str(_ZSTD_AVAILABLE))
         self.level = level
         self.extension = "zstd"
-        self._zstd = None
+        self._zstd: Any | None = None
 
-    def _zstd_mod(self):
+    def _zstd_mod(self) -> Any:
         if self._zstd is None:
             if _PYTHON_GREATER_EQUAL_3_14:
                 from compression import zstd as mod

--- a/src/litdata/streaming/compression.py
+++ b/src/litdata/streaming/compression.py
@@ -56,6 +56,11 @@ class ZSTDCompressor(Compressor):
         self.extension = "zstd"
         self._zstd: Any | None = None
 
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state["_zstd"] = None
+        return state
+
     def _zstd_mod(self) -> Any:
         if self._zstd is None:
             if _PYTHON_GREATER_EQUAL_3_14:

--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -503,6 +503,22 @@ class ChunksConfig:
             session_options,
         )
 
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        # threading.Lock / Event are not picklable (DataLoader spawn / deepcopy).
+        state["_file_published"] = {}
+        state["_file_published_lock"] = None
+        state["_on_chunk_file_ready"] = None
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self._file_published = {}
+        self._file_published_lock = threading.Lock()
+        self._on_chunk_file_ready = None
+        if self._downloader is not None:
+            self._downloader._on_file_published = self.notify_file_published
+
     def __len__(self) -> int:
         return self._length
 

--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -14,10 +14,11 @@
 import contextlib
 import logging
 import os
+import threading
 from collections import defaultdict
 from contextlib import suppress
 from time import sleep, time
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from filelock import FileLock, Timeout
 
@@ -92,10 +93,23 @@ class ChunksConfig:
         self._length = self._intervals[-1][-1] if len(self._intervals) > 0 else 0
         self._downloader = None
 
+        # In-process "file is visible" Events, set after atomic publish (download or decompress).
+        self._file_published: dict[str, threading.Event] = {}
+        self._file_published_lock = threading.Lock()
+        # PrepareChunksThread installs this so download/decompress publish can set chunk-ready.
+        self._on_chunk_file_ready: Callable[[int], None] | None = None
+        self._readable_name_to_index: dict[str, int] = {}
+        for chunk_index, cnk in enumerate(self._chunks):
+            readable = cnk["filename"]
+            if self._config.get("compression"):
+                readable = readable.replace(f".{self._config['compression']}", "")
+            self._readable_name_to_index[readable] = chunk_index
+
         if remote_dir:
             self._downloader = get_downloader(
                 remote_dir, cache_dir, self._chunks, self._storage_options, self._session_options
             )
+            self._downloader._on_file_published = self.notify_file_published
 
         self._compressor_name = self._config["compression"]
         self._compressor: Compressor | None = None
@@ -256,6 +270,30 @@ class ChunksConfig:
 
         return self._downloader.download_chunk_bytes_from_index(chunk_index, offset, length)
 
+    def notify_file_published(self, local_filepath: str) -> None:
+        """Mark ``local_filepath`` as atomically published and, if it is a readable chunk, signal ready."""
+        path = os.path.abspath(local_filepath)
+        with self._file_published_lock:
+            event = self._file_published.get(path)
+            if event is None:
+                event = threading.Event()
+                self._file_published[path] = event
+            event.set()
+        # Do not mark chunk-ready here. Compressed downloads publish a non-readable
+        # path first; the item loader must wait until decompress / _finalize.
+
+    def wait_file_published(self, local_filepath: str, timeout: float) -> bool:
+        """Wait for an in-process publish Event; fall back to ``exists`` for other workers."""
+        path = os.path.abspath(local_filepath)
+        with self._file_published_lock:
+            event = self._file_published.get(path)
+            if event is None:
+                event = threading.Event()
+                self._file_published[path] = event
+        if event.wait(timeout=timeout):
+            return True
+        return os.path.exists(path)
+
     def _remove_compressed_source(self, local_chunkpath: str, target_local_chunkpath: str) -> None:
         """Drop the compressed download once the decompressed chunk is on disk."""
         if local_chunkpath == target_local_chunkpath:
@@ -273,13 +311,12 @@ class ChunksConfig:
             self._remove_compressed_source(local_chunkpath, target_local_chunkpath)
             return
 
-        # Wait until either the decompressed target appears (another worker finished) or the
-        # compressed source exists. Cloud downloaders publish the compressed path atomically, so
-        # existence of that path means the download is complete — do NOT use chunk_size (item
-        # count) as a byte threshold.
+        # Wait until the downloader publishes the compressed file, or another worker
+        # publishes the decompressed target. Cross-process downloads still fall back to exists.
         start_time = time()
-        while not os.path.exists(local_chunkpath) and not os.path.exists(target_local_chunkpath):
-            sleep(0.1)
+        while not os.path.exists(target_local_chunkpath) and not os.path.exists(local_chunkpath):
+            self.wait_file_published(local_chunkpath, 0.05)
+            self.wait_file_published(target_local_chunkpath, 0.0)
             if (time() - start_time) > _MAX_WAIT_TIME:
                 raise ChunkWaitTimeoutError(local_chunkpath, time() - start_time)
 
@@ -307,6 +344,7 @@ class ChunksConfig:
                             f"({os.stat(tmp_path).st_size} < {expected_bytes})."
                         )
                     os.replace(tmp_path, target_local_chunkpath)
+                    self.notify_file_published(target_local_chunkpath)
                 except Exception:
                     with contextlib.suppress(FileNotFoundError, PermissionError):
                         os.remove(tmp_path)

--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -16,7 +16,6 @@ import logging
 import os
 import threading
 from collections import defaultdict
-from collections.abc import Callable
 from contextlib import suppress
 from time import time
 from typing import Any, Optional
@@ -97,14 +96,6 @@ class ChunksConfig:
         # In-process "file is visible" Events, set after atomic publish (download or decompress).
         self._file_published: dict[str, threading.Event] = {}
         self._file_published_lock = threading.Lock()
-        # PrepareChunksThread installs this so download/decompress publish can set chunk-ready.
-        self._on_chunk_file_ready: Callable[[int], None] | None = None
-        self._readable_name_to_index: dict[str, int] = {}
-        for chunk_index, cnk in enumerate(self._chunks):
-            readable = cnk["filename"]
-            if self._config.get("compression"):
-                readable = readable.replace(f".{self._config['compression']}", "")
-            self._readable_name_to_index[readable] = chunk_index
 
         if remote_dir:
             self._downloader = get_downloader(
@@ -280,8 +271,6 @@ class ChunksConfig:
                 event = threading.Event()
                 self._file_published[path] = event
             event.set()
-        # Do not mark chunk-ready here. Compressed downloads publish a non-readable
-        # path first; the item loader must wait until decompress / _finalize.
 
     def wait_file_published(self, local_filepath: str, timeout: float) -> bool:
         """Wait for an in-process publish Event; fall back to ``exists`` for other workers."""
@@ -508,14 +497,12 @@ class ChunksConfig:
         # threading.Lock / Event are not picklable (DataLoader spawn / deepcopy).
         state["_file_published"] = {}
         state["_file_published_lock"] = None
-        state["_on_chunk_file_ready"] = None
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
         self._file_published = {}
         self._file_published_lock = threading.Lock()
-        self._on_chunk_file_ready = None
         if self._downloader is not None:
             self._downloader._on_file_published = self.notify_file_published
 

--- a/src/litdata/streaming/config.py
+++ b/src/litdata/streaming/config.py
@@ -16,9 +16,10 @@ import logging
 import os
 import threading
 from collections import defaultdict
+from collections.abc import Callable
 from contextlib import suppress
-from time import sleep, time
-from typing import Any, Callable, Optional
+from time import time
+from typing import Any, Optional
 
 from filelock import FileLock, Timeout
 

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -20,7 +20,7 @@ import threading
 from abc import ABC
 from contextlib import suppress
 from time import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 from urllib import parse
 
 from filelock import FileLock, Timeout
@@ -85,7 +85,7 @@ async def _obstore_adownload_file(downloader: "Downloader", store: Any, key: str
         os.makedirs(os.path.dirname(local_filepath) or ".", exist_ok=True)
         resp = await obs.get_async(store, key)
         await _obstore_astream_resp_to_tmp(tmp_path, resp)
-        downloader._atomic_replace(tmp_path, local_filepath)
+        downloader._publish_file(tmp_path, local_filepath)
     except Exception:
         with suppress(FileNotFoundError, PermissionError):
             os.remove(tmp_path)
@@ -264,6 +264,9 @@ class Downloader(ABC):
         self._cache_dir = cache_dir
         self._chunks = chunks
         self._storage_options = storage_options or {}
+        # Set by ChunksConfig: called after an atomic publish so waiters can Event.wait
+        # instead of polling the filesystem.
+        self._on_file_published: Callable[[str], None] | None = None
 
     def __getstate__(self) -> dict[str, Any]:
         # Spawn workers must not inherit a live obstore S3Store / tokio runtime.
@@ -294,6 +297,7 @@ class Downloader(ABC):
         remote_chunkpath = os.path.join(self._remote_dir, chunk_filename)
 
         self.download_file(remote_chunkpath, local_chunkpath)
+        self._notify_published(local_chunkpath)
 
         emit_trace("download", "E", CAT_DOWNLOAD, chunk=chunk_index)
 
@@ -316,6 +320,17 @@ class Downloader(ABC):
     def _atomic_replace(tmp_path: str, local_filepath: str) -> None:
         """Publish a completed download by atomically replacing the destination path."""
         os.replace(tmp_path, local_filepath)
+
+    def _notify_published(self, local_filepath: str) -> None:
+        """Signal that ``local_filepath`` is visible (atomic rename finished, or already present)."""
+        callback = getattr(self, "_on_file_published", None)
+        if callback is not None:
+            callback(local_filepath)
+
+    def _publish_file(self, tmp_path: str, local_filepath: str) -> None:
+        """Atomically publish ``tmp_path`` and notify in-process waiters."""
+        self._atomic_replace(tmp_path, local_filepath)
+        self._notify_published(local_filepath)
 
     def download_bytes(self, remote_chunkpath: str, offset: int, length: int, local_chunkpath: str) -> bytes:
         """Download a specific range of bytes from the remote file.
@@ -353,6 +368,7 @@ class Downloader(ABC):
         :meth:`adownload_fileobj` + an atomic write.
         """
         if os.path.exists(local_filepath):
+            self._notify_published(local_filepath)
             return
         data = await self.adownload_fileobj(remote_filepath)
         if data is None:
@@ -365,7 +381,7 @@ class Downloader(ABC):
             os.makedirs(os.path.dirname(local_filepath) or ".", exist_ok=True)
             with open(tmp_path, "wb") as f:
                 f.write(data)
-            self._atomic_replace(tmp_path, local_filepath)
+            self._publish_file(tmp_path, local_filepath)
         except Exception:
             with contextlib.suppress(FileNotFoundError, PermissionError):
                 os.remove(tmp_path)
@@ -422,7 +438,7 @@ class S3Downloader(Downloader):
                         tmp_path,
                         Config=TransferConfig(use_threads=False),
                     )
-                self._atomic_replace(tmp_path, local_filepath)
+                self._publish_file(tmp_path, local_filepath)
             except Exception:
                 with suppress(FileNotFoundError, PermissionError):
                     os.remove(tmp_path)
@@ -531,7 +547,7 @@ class R2Downloader(Downloader):
                         ExtraArgs=extra_args,
                         Config=TransferConfig(use_threads=False),
                     )
-                    self._atomic_replace(tmp_path, local_filepath)
+                    self._publish_file(tmp_path, local_filepath)
                 except Exception:
                     with suppress(FileNotFoundError, PermissionError):
                         os.remove(tmp_path)
@@ -654,7 +670,7 @@ class GCPDownloader(Downloader):
             tmp_path = self._temp_download_path(local_filepath)
             try:
                 blob.download_to_filename(tmp_path)
-                self._atomic_replace(tmp_path, local_filepath)
+                self._publish_file(tmp_path, local_filepath)
             except Exception:
                 with suppress(FileNotFoundError, PermissionError):
                     os.remove(tmp_path)
@@ -772,7 +788,7 @@ class AzureDownloader(Downloader):
                 with open(tmp_path, "wb") as download_file:
                     blob_data = blob_client.download_blob()
                     blob_data.readinto(download_file)
-                self._atomic_replace(tmp_path, local_filepath)
+                self._publish_file(tmp_path, local_filepath)
             except Exception:
                 with suppress(FileNotFoundError, PermissionError):
                     os.remove(tmp_path)
@@ -848,6 +864,7 @@ class LocalDownloader(Downloader):
     async def adownload_file(self, remote_filepath: str, local_filepath: str) -> None:
         """Copy a local file into the cache path."""
         if os.path.exists(local_filepath):
+            self._notify_published(local_filepath)
             return
         self.download_file(remote_filepath, local_filepath)
 
@@ -866,13 +883,15 @@ class LocalDownloader(Downloader):
                 # make an atomic operation to be safe
                 temp_file_path = local_filepath + ".tmp"
                 shutil.copy(remote_filepath, temp_file_path)
-                os.rename(temp_file_path, local_filepath)
+                self._publish_file(temp_file_path, local_filepath)
         # FileLock leaves the lock path behind; remove it after release when we held it.
         # Delete only after the critical section so other waiters do not race a new inode
         # while we still expected exclusive access.
         if lock_acquired:
             with contextlib.suppress(Exception):
                 os.remove(lock_path)
+        if os.path.exists(local_filepath):
+            self._notify_published(local_filepath)
 
 
 class HFDownloader(Downloader):
@@ -925,7 +944,7 @@ class HFDownloader(Downloader):
             if downloaded_path != local_filepath and os.path.exists(downloaded_path):
                 temp_file_path = local_filepath + ".tmp"
                 shutil.copyfile(downloaded_path, temp_file_path)
-                os.rename(temp_file_path, local_filepath)
+                self._publish_file(temp_file_path, local_filepath)
 
 
 class LocalDownloaderWithCache(LocalDownloader):

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -274,6 +274,8 @@ class Downloader(ABC):
         state = self.__dict__.copy()
         state.pop("_store", None)
         state.pop("_store_pid", None)
+        # Bound method / lock-holding callback is process-local; rebound in ChunksConfig.__setstate__.
+        state.pop("_on_file_published", None)
         return state
 
     def _increment_local_lock(self, chunkpath: str, chunk_index: int) -> None:

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -18,9 +18,10 @@ import shutil
 import tempfile
 import threading
 from abc import ABC
+from collections.abc import Callable
 from contextlib import suppress
 from time import time
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, cast
 from urllib import parse
 
 from filelock import FileLock, Timeout

--- a/src/litdata/streaming/downloader.py
+++ b/src/litdata/streaming/downloader.py
@@ -322,7 +322,13 @@ class Downloader(ABC):
     @staticmethod
     def _atomic_replace(tmp_path: str, local_filepath: str) -> None:
         """Publish a completed download by atomically replacing the destination path."""
-        os.replace(tmp_path, local_filepath)
+        try:
+            os.replace(tmp_path, local_filepath)
+        except FileNotFoundError:
+            # Same-pid gather of a duplicate index, or another worker already published.
+            if os.path.exists(local_filepath):
+                return
+            raise
 
     def _notify_published(self, local_filepath: str) -> None:
         """Signal that ``local_filepath`` is visible (atomic rename finished, or already present)."""

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -292,14 +292,20 @@ class BaseItemLoader(ABC):
                 return
 
             if chunk_ready_provider is not None:
+                remaining = max_wait - (time() - start_time)
+                if remaining <= 0:
+                    raise ChunkWaitTimeoutError(chunk_filepath, time() - start_time)
                 event = chunk_ready_provider(chunk_index)
-                signaled = event.wait(timeout=0.02)
-                # Stale signal: chunk was ready once, then deleted / not yet re-published.
+                # Wake as soon as the downloader atomically publishes (or decompress finishes).
+                # Recheck prefetch crashes at least once a second.
+                signaled = event.wait(timeout=min(0.05, remaining))
                 if signaled and not (
                     os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes
                 ):
+                    # Stale signal after delete (clear_chunk_ready may have been skipped).
+                    # Chunk-ready is set only after decompress/finalize, so this is safe.
                     event.clear()
-                    sleep(0.1)
+                    sleep(0.05)
             else:
                 sleep(0.1)
 

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -293,7 +293,7 @@ class BaseItemLoader(ABC):
 
             if chunk_ready_provider is not None:
                 event = chunk_ready_provider(chunk_index)
-                signaled = event.wait(timeout=0.1)
+                signaled = event.wait(timeout=0.02)
                 # Stale signal: chunk was ready once, then deleted / not yet re-published.
                 if signaled and not (
                     os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes
@@ -438,7 +438,10 @@ class PyTreeLoader(BaseItemLoader):
         return intervals
 
     def pre_load_chunk(self, chunk_index: int, chunk_filepath: str) -> None:
-        if self._posix_fast and self._posix_willneed:
+        # Called from PrepareChunksThread. Only advise the page cache — do not
+        # mutate mmap state here (the reader thread owns ``_mapped``).
+        del chunk_index
+        if os.path.isfile(chunk_filepath) and (self._posix_willneed or not self._posix_fast):
             advise_willneed(chunk_filepath)
 
     def warm_posix_chunk(self, chunk_index: int, chunk_filepath: str) -> None:
@@ -746,8 +749,9 @@ class PyTreeLoader(BaseItemLoader):
         self._mmap = None
         self._open_handle = None
         for idx in list(self._mapped):
-            mm, _, _ = self._mapped.pop(idx)
-            self._close_mapping(idx, mm)
+            cached = self._mapped.pop(idx, None)
+            if cached is not None:
+                self._close_mapping(idx, cached[0])
 
     def close(self, chunk_index: int) -> None:
         """Close the open file handle / memory-map for the current chunk."""

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -802,7 +802,7 @@ class PyTreeLoader(BaseItemLoader):
         header_len = 4 * n
         out = bytearray(header_len + body_len)
         if n:
-            out[0:header_len] = np.asarray(sizes, dtype=np.uint32).tobytes()
+            out[0:header_len] = struct.pack("<" + "I" * n, *sizes)
         cursor = header_len
         for chunk, size in zip(data, sizes):
             out[cursor : cursor + size] = chunk

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -296,14 +296,8 @@ class BaseItemLoader(ABC):
                 if remaining <= 0:
                     raise ChunkWaitTimeoutError(chunk_filepath, time() - start_time)
                 event = chunk_ready_provider(chunk_index)
-                # Ask the prefetch thread for this chunk immediately. The Event only
-                # wakes us after mark_chunk_ready; if the prefetch window is full the
-                # download queue is not drained, but force-download still is.
-                if not requested_force_download and force_download_queue is not None:
-                    self.force_download(chunk_index)
-                    requested_force_download = True
-                # Wake as soon as the downloader atomically publishes (or decompress finishes).
-                # Recheck prefetch crashes at least once a second.
+                # Wait for prefetch to publish. Force-download is a last resort after
+                # ``_FORCE_DOWNLOAD_TIME`` (default 30s) — not on the first wait.
                 signaled = event.wait(timeout=min(1.0, remaining))
                 if signaled and not (
                     os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -214,6 +214,7 @@ class BaseItemLoader(ABC):
         # Fixed size-header layout: one little-endian uint32 per leaf.
         # Keep a format string (pickle-friendly) rather than a ``struct.Struct`` instance.
         self._sizes_fmt = "<" + "I" * len(self._data_format) if self._data_format else None
+        self._sizes_struct = struct.Struct(self._sizes_fmt) if self._sizes_fmt else None
 
     def force_download(self, chunk_index: int) -> None:
         force_download_queue = getattr(self, "_force_download_queue", None)
@@ -319,6 +320,8 @@ class BaseItemLoader(ABC):
         state["_chunk_ready_provider"] = None
         state["_force_download_queue"] = None
         state["_prefetch_error_provider"] = None
+        # ``struct.Struct`` is not picklable; rebuild from ``_sizes_fmt`` after unpickle.
+        state["_sizes_struct"] = None
         return state
 
     @functools.lru_cache(maxsize=128)
@@ -577,7 +580,7 @@ class PyTreeLoader(BaseItemLoader):
         # We want to read the `offset_start` and `offset_end` for the item we want to load
         # 2 uint32 (4 bytes each) => 8 bytes; are read to get the offset_start and offset_end
         pair = fp.read(8)
-        begin, end = np.frombuffer(pair, np.uint32)
+        begin, end = struct.unpack("<II", pair)
 
         fp.seek(begin)  # move the file pointer to the offset_start where the item starts
         return fp.read(end - begin)  # read the item
@@ -648,11 +651,16 @@ class PyTreeLoader(BaseItemLoader):
     def deserialize(self, raw_item_data: bytes | memoryview) -> "PyTree":
         """Deserialize the raw bytes into their python equivalent."""
         idx = self._shift_idx
-        sizes = struct.unpack_from(self._sizes_fmt, raw_item_data, 0) if self._sizes_fmt is not None else ()
-        data = []
-        for size, serializer in zip(sizes, self._serializers_list):
-            data_bytes = raw_item_data[idx : idx + size]
-            data.append(serializer.deserialize(data_bytes))
+        sizes_struct = getattr(self, "_sizes_struct", None)
+        if sizes_struct is not None:
+            sizes = sizes_struct.unpack_from(raw_item_data, 0)
+        elif self._sizes_fmt is not None:
+            sizes = struct.unpack_from(self._sizes_fmt, raw_item_data, 0)
+        else:
+            sizes = ()
+        data = [None] * len(sizes)
+        for i, (size, serializer) in enumerate(zip(sizes, self._serializers_list)):
+            data[i] = serializer.deserialize(raw_item_data[idx : idx + size])
             idx += size
         if self._unflatten is not None:
             return self._unflatten(data)
@@ -824,6 +832,7 @@ class PyTreeLoader(BaseItemLoader):
         state["_mmap_view"] = None
         # Compiled unflatten closures aren't picklable; rebuild after unpickle.
         state["_unflatten"] = None
+        state["_sizes_struct"] = None
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
@@ -842,6 +851,8 @@ class PyTreeLoader(BaseItemLoader):
         data_spec = getattr(self, "_data_spec", None)
         if isinstance(data_spec, TreeSpec):
             self._unflatten = _compile_treespec_unflatten(data_spec)
+        sizes_fmt = getattr(self, "_sizes_fmt", None)
+        self._sizes_struct = struct.Struct(sizes_fmt) if sizes_fmt else None
 
 
 class TokensLoader(BaseItemLoader):

--- a/src/litdata/streaming/item_loader.py
+++ b/src/litdata/streaming/item_loader.py
@@ -296,9 +296,15 @@ class BaseItemLoader(ABC):
                 if remaining <= 0:
                     raise ChunkWaitTimeoutError(chunk_filepath, time() - start_time)
                 event = chunk_ready_provider(chunk_index)
+                # Ask the prefetch thread for this chunk immediately. The Event only
+                # wakes us after mark_chunk_ready; if the prefetch window is full the
+                # download queue is not drained, but force-download still is.
+                if not requested_force_download and force_download_queue is not None:
+                    self.force_download(chunk_index)
+                    requested_force_download = True
                 # Wake as soon as the downloader atomically publishes (or decompress finishes).
                 # Recheck prefetch crashes at least once a second.
-                signaled = event.wait(timeout=min(0.05, remaining))
+                signaled = event.wait(timeout=min(1.0, remaining))
                 if signaled and not (
                     os.path.exists(chunk_filepath) and os.stat(chunk_filepath).st_size >= filesize_bytes
                 ):
@@ -309,7 +315,7 @@ class BaseItemLoader(ABC):
             else:
                 sleep(0.1)
 
-            # Always attempt force-download after the grace period (no-op without a queue).
+            # Retry force-download after the grace period if the first request was deferred.
             # Tests override ``force_download`` to assert this path is reached.
             if not requested_force_download and (time() - start_time) > _FORCE_DOWNLOAD_TIME:
                 if _DEBUG:

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -732,8 +732,8 @@ class PrepareChunksThread(Thread):
                     self._has_exited = True
                     return
 
-                if chunk_index is not None:
-                    batch = [chunk_index]
+                if isinstance(chunk_index, int):
+                    batch: list[int] = [chunk_index]
                     # Drain more pending indexes so asyncio.gather can overlap remote
                     # downloads. When over disk budget, download one at a time.
                     if self._async_prefetch() and not over_budget:
@@ -745,7 +745,8 @@ class PrepareChunksThread(Thread):
                             if nxt == _END_TOKEN:
                                 self._to_download_queue.put(_END_TOKEN)
                                 break
-                            batch.append(nxt)
+                            if isinstance(nxt, int):
+                                batch.append(nxt)
                     self._download_chunk_indexes(batch)
 
             if self._max_cache_size:

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -33,6 +33,7 @@ from litdata.debugger import CAT_CRASH, CAT_DOWNLOAD, CAT_READ, emit_trace, trac
 from litdata.streaming.async_prefetch import (
     apply_async_pre_download_floor,
     async_chunk_prefetch_enabled,
+    async_download_concurrency,
     close_thread_event_loop,
     download_chunk_indexes_concurrently,
 )
@@ -99,6 +100,7 @@ class PrepareChunksThread(Thread):
         self._to_download_queue: Queue = Queue()
         self._to_delete_queue: Queue = Queue()
         self._force_stop_event = Event()
+        self._end_requested = False
 
         # TODO: Find a real fix to this problem
         self._force_download_queue: Queue = Queue()
@@ -106,6 +108,8 @@ class PrepareChunksThread(Thread):
         # Per-chunk readiness signals for the in-process item-loader wait loop.
         self._chunk_ready: dict[int, Event] = {}
         self._chunk_ready_lock = Lock()
+        # Downloader/decompress atomic publish → set the same Events the item loader waits on.
+        self._config._on_chunk_file_ready = self.mark_chunk_ready
 
         self._rank = rank
         # Set when ``run()`` dies so the item-loader wait loop can fail fast with
@@ -132,6 +136,30 @@ class PrepareChunksThread(Thread):
     def _async_prefetch(self) -> bool:
         """True when this prepare thread should batch-download via asyncio."""
         return async_chunk_prefetch_enabled(self._config._remote_dir)
+
+    def _async_gather_width(self) -> int:
+        """How many queued chunk indexes to download together."""
+        if not self._async_prefetch():
+            return 1
+        return max(1, min(self._max_pre_download, async_download_concurrency(self._max_pre_download)))
+
+    def _free_prefetch_slots(self) -> int:
+        return max(0, self._max_pre_download - self._pre_download_counter)
+
+    def _should_start_download(self, *, over_budget: bool) -> bool:
+        """True when we should pull work from the download queue.
+
+        After the first fill, wait until enough slots are free to gather again.
+        Otherwise a nearly-full prefetch window refills one chunk at a time and
+        ``asyncio.gather`` never overlaps (seen on 80-chunk R2 zstd datasets).
+        """
+        if self._free_prefetch_slots() <= 0:
+            return False
+        # Always use a free slot. Waiting for a gather-sized hole deadlocks when
+        # the reader is blocked on the next undownloaded chunk (deletes are only
+        # queued after that load succeeds). Overlap still happens when several
+        # slots are free: `_run_loop` drains the queue up to gather width.
+        return True
 
     def get_ready_event(self, chunk_index: int) -> Event:
         """Return (creating if needed) the readiness event for ``chunk_index``."""
@@ -292,6 +320,7 @@ class PrepareChunksThread(Thread):
 
     def stop(self) -> None:
         """Receive the list of the chunk indices to download for the current epoch."""
+        self._end_requested = True
         self._to_download_queue.put(_END_TOKEN)
 
     def force_stop(self) -> None:
@@ -671,7 +700,6 @@ class PrepareChunksThread(Thread):
                 self._has_exited = True
                 return
 
-            can_download_more = self._pre_download_counter < self._max_pre_download
             over_budget = False
             if self._slot_budget_enabled():
                 # Prefer eviction when over the shared disk budget so multi-worker
@@ -680,15 +708,28 @@ class PrepareChunksThread(Thread):
                 if over_budget:
                     self._maybe_delete_chunks(timeout=0.0)
 
+            can_download_more = self._should_start_download(over_budget=over_budget)
+
             # Non-blocking force/delete polls while download work can still proceed, so we do not
             # pay ~0.2s of empty-queue sleep per chunk. When the prefetch buffer is full, keep a
             # short timeout so force-download requests are not blocked behind a long delete wait.
             side_timeout = 0.0 if can_download_more else _DEFAULT_TIMEOUT
 
+            # When the window is full, drain deletes before blocking on force-download
+            # so slots free and we can refill instead of sitting on an empty force queue.
+            if self._max_cache_size and not can_download_more:
+                self._maybe_delete_chunks(timeout=0.0)
+
             self._force_download(timeout=side_timeout)
 
             if can_download_more:
                 chunk_index = _get_from_queue(self._to_download_queue)
+            elif self._end_requested:
+                chunk_index = _END_TOKEN
+            else:
+                chunk_index = None
+
+            if can_download_more or chunk_index == _END_TOKEN:
                 if chunk_index == _END_TOKEN:
                     if self._max_cache_size:
                         self._drain_and_flush_deletes()
@@ -697,23 +738,18 @@ class PrepareChunksThread(Thread):
 
                 if chunk_index is not None:
                     batch = [chunk_index]
-                    # Optionally drain more pending indexes up to the prefetch budget so
-                    # asyncio.gather can overlap remote downloads. When over disk budget,
-                    # download one chunk at a time so deletes can catch up.
+                    # Drain more pending indexes so asyncio.gather can overlap remote
+                    # downloads. When over disk budget, download one at a time.
                     if self._async_prefetch() and not over_budget:
-                        slots_left = self._max_pre_download - self._pre_download_counter - 1
-                        while slots_left > 0:
-                            # Non-blocking drain: a 0.1s Empty wait per missing
-                            # slot would serialize gather and erase async overlap.
+                        target = min(self._free_prefetch_slots(), self._async_gather_width())
+                        while len(batch) < target:
                             nxt = _get_from_queue(self._to_download_queue, timeout=0.0)
                             if nxt is None:
                                 break
                             if nxt == _END_TOKEN:
-                                # Put END back so the next loop iteration exits cleanly.
                                 self._to_download_queue.put(_END_TOKEN)
                                 break
                             batch.append(nxt)
-                            slots_left -= 1
                     self._download_chunk_indexes(batch)
 
             if self._max_cache_size:

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -734,7 +734,7 @@ class PrepareChunksThread(Thread):
 
                 # Shuffle emits numpy.int64; do not use ``isinstance(..., int)``.
                 if chunk_index is not None:
-                    batch: list[int] = [chunk_index]
+                    batch: list[int] = [int(chunk_index)]
                     # Drain more pending indexes so asyncio.gather can overlap remote
                     # downloads. When over disk budget, download one at a time.
                     if self._async_prefetch() and not over_budget:
@@ -746,7 +746,7 @@ class PrepareChunksThread(Thread):
                             if nxt == _END_TOKEN:
                                 self._to_download_queue.put(_END_TOKEN)
                                 break
-                            batch.append(nxt)
+                            batch.append(int(nxt))
                     self._download_chunk_indexes(batch)
 
             if self._max_cache_size:

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -108,8 +108,6 @@ class PrepareChunksThread(Thread):
         # Per-chunk readiness signals for the in-process item-loader wait loop.
         self._chunk_ready: dict[int, Event] = {}
         self._chunk_ready_lock = Lock()
-        # Downloader/decompress atomic publish → set the same Events the item loader waits on.
-        self._config._on_chunk_file_ready = self.mark_chunk_ready
 
         self._rank = rank
         # Set when ``run()`` dies so the item-loader wait loop can fail fast with
@@ -602,6 +600,8 @@ class PrepareChunksThread(Thread):
         """Download one or more chunk indexes (sync, or concurrent when env-enabled)."""
         if not chunk_indexes:
             return
+        # Shuffle / queue can repeat an index; one GET per chunk per batch.
+        chunk_indexes = list(dict.fromkeys(int(idx) for idx in chunk_indexes))
         # Respect the shared disk budget before bringing new bytes onto disk.
         pending: list[int] = []
         deferred: list[int] = []
@@ -732,7 +732,8 @@ class PrepareChunksThread(Thread):
                     self._has_exited = True
                     return
 
-                if isinstance(chunk_index, int):
+                # Shuffle emits numpy.int64; do not use ``isinstance(..., int)``.
+                if chunk_index is not None:
                     batch: list[int] = [chunk_index]
                     # Drain more pending indexes so asyncio.gather can overlap remote
                     # downloads. When over disk budget, download one at a time.
@@ -745,8 +746,7 @@ class PrepareChunksThread(Thread):
                             if nxt == _END_TOKEN:
                                 self._to_download_queue.put(_END_TOKEN)
                                 break
-                            if isinstance(nxt, int):
-                                batch.append(nxt)
+                            batch.append(nxt)
                     self._download_chunk_indexes(batch)
 
             if self._max_cache_size:

--- a/src/litdata/streaming/reader.py
+++ b/src/litdata/streaming/reader.py
@@ -149,17 +149,13 @@ class PrepareChunksThread(Thread):
     def _should_start_download(self, *, over_budget: bool) -> bool:
         """True when we should pull work from the download queue.
 
-        After the first fill, wait until enough slots are free to gather again.
-        Otherwise a nearly-full prefetch window refills one chunk at a time and
-        ``asyncio.gather`` never overlaps (seen on 80-chunk R2 zstd datasets).
+        Use every free slot. Waiting for a gather-sized hole deadlocks when the
+        reader is blocked on the next undownloaded chunk (deletes are only queued
+        after that load succeeds). Overlap still happens when several slots are
+        free: ``_run_loop`` drains the queue up to gather width.
         """
-        if self._free_prefetch_slots() <= 0:
-            return False
-        # Always use a free slot. Waiting for a gather-sized hole deadlocks when
-        # the reader is blocked on the next undownloaded chunk (deletes are only
-        # queued after that load succeeds). Overlap still happens when several
-        # slots are free: `_run_loop` drains the queue up to gather width.
-        return True
+        del over_budget
+        return self._free_prefetch_slots() > 0
 
     def get_ready_event(self, chunk_index: int) -> Event:
         """Return (creating if needed) the readiness event for ``chunk_index``."""

--- a/src/litdata/streaming/serializers.py
+++ b/src/litdata/streaming/serializers.py
@@ -1578,7 +1578,7 @@ class BooleanSerializer(Serializer):
         Returns:
             The deserialized boolean value
         """
-        return bool(np.frombuffer(data, dtype=np.bool_)[0])
+        return data[0] != 0
 
     def can_serialize(self, item: Any) -> bool:
         """Check if the item can be serialized by this serializer.

--- a/src/litdata/streaming/serializers.py
+++ b/src/litdata/streaming/serializers.py
@@ -1558,6 +1558,8 @@ class FloatSerializer(NumericSerializer, Serializer):
 class BooleanSerializer(Serializer):
     """The BooleanSerializer serializes and deserializes boolean values to and from bytes."""
 
+    size = 1
+
     def serialize(self, item: bool) -> tuple[bytes, str | None]:
         """Serialize a boolean value to bytes.
 

--- a/src/litdata/streaming/writer.py
+++ b/src/litdata/streaming/writer.py
@@ -216,7 +216,7 @@ class BinaryWriter:
             self._fixed_header = None
             self._fixed_body_len = 0
             return
-        typed = [int(size) for size in sizes]
+        typed = [int(size) for size in sizes if size is not None]
         self._fixed_header = struct.pack("<" + "I" * len(typed), *typed)
         self._fixed_body_len = sum(typed)
 
@@ -233,6 +233,7 @@ class BinaryWriter:
         cursor = len(header)
         for element, serializer, size in zip(flattened, serializers, sizes):
             blob, _ = serializer.serialize(element)
+            assert size is not None
             end = cursor + size
             out[cursor:end] = blob
             cursor = end

--- a/src/litdata/streaming/writer.py
+++ b/src/litdata/streaming/writer.py
@@ -225,7 +225,9 @@ class BinaryWriter:
         header = self._fixed_header
         serializers = self._format_serializers
         sizes = self._format_fixed_sizes
-        assert header is not None and serializers is not None and sizes is not None
+        assert header is not None
+        assert serializers is not None
+        assert sizes is not None
         out = bytearray(len(header) + self._fixed_body_len)
         out[0 : len(header)] = header
         cursor = len(header)

--- a/src/litdata/streaming/writer.py
+++ b/src/litdata/streaming/writer.py
@@ -15,6 +15,7 @@ import copy
 import json
 import os
 import re
+import struct
 import warnings
 from dataclasses import dataclass
 from multiprocessing import Queue
@@ -100,6 +101,8 @@ class BinaryWriter:
         self._serializers_extra: dict[str, Serializer] = {}
         self._format_serializers: list[Serializer] | None = None
         self._format_fixed_sizes: list[int | None] | None = None
+        self._fixed_header: bytes | None = None
+        self._fixed_body_len: int = 0
         self._chunk_size = chunk_size
         self._chunk_bytes = _convert_bytes_to_int(chunk_bytes) if isinstance(chunk_bytes, str) else chunk_bytes
         self._compression = compression
@@ -197,11 +200,41 @@ class BinaryWriter:
             self._data_spec = data_spec
             self._format_serializers = [self._serializers_extra[name] for name in data_format]
             self._format_fixed_sizes = [getattr(serializer, "size", None) for serializer in self._format_serializers]
+            self._cache_fixed_item_layout()
+        elif self._fixed_header is not None:
+            return self._serialize_fixed_leaves(items)
         else:
             flattened = tree_leaves(items)
             self._serialize_with_data_format(flattened, sizes, data, self._data_format)
 
         return self._item_loader.encode_data(data, sizes, flattened)
+
+    def _cache_fixed_item_layout(self) -> None:
+        """If every leaf has a constant byte size, cache the size header for every later sample."""
+        sizes = self._format_fixed_sizes
+        if not sizes or any(size is None for size in sizes):
+            self._fixed_header = None
+            self._fixed_body_len = 0
+            return
+        typed = [int(size) for size in sizes]
+        self._fixed_header = struct.pack("<" + "I" * len(typed), *typed)
+        self._fixed_body_len = sum(typed)
+
+    def _serialize_fixed_leaves(self, items: Any) -> tuple[bytes, int | None]:
+        flattened = tree_leaves(items)
+        header = self._fixed_header
+        serializers = self._format_serializers
+        sizes = self._format_fixed_sizes
+        assert header is not None and serializers is not None and sizes is not None
+        out = bytearray(len(header) + self._fixed_body_len)
+        out[0 : len(header)] = header
+        cursor = len(header)
+        for element, serializer, size in zip(flattened, serializers, sizes):
+            blob, _ = serializer.serialize(element)
+            end = cursor + size
+            out[cursor:end] = blob
+            cursor = end
+        return bytes(out), None
 
     def _serialize(self, item: Any, sizes: list[int], data: list[bytes]) -> str:
         """Serialize a given item and append its size and bytes to the sizes and data array."""
@@ -226,10 +259,12 @@ class BinaryWriter:
             serializers = [self._serializers_extra[name] for name in data_format]
             self._format_serializers = serializers
             self._format_fixed_sizes = [getattr(serializer, "size", None) for serializer in serializers]
+            self._cache_fixed_item_layout()
         fixed_sizes = self._format_fixed_sizes
         if fixed_sizes is None:
             fixed_sizes = [getattr(serializer, "size", None) for serializer in serializers]
             self._format_fixed_sizes = fixed_sizes
+            self._cache_fixed_item_layout()
         for element, serializer, fixed in zip(item, serializers, fixed_sizes):
             serialized_item, _ = serializer.serialize(element)
             data.append(serialized_item)

--- a/src/litdata/streaming/writer.py
+++ b/src/litdata/streaming/writer.py
@@ -99,6 +99,7 @@ class BinaryWriter:
         self._serializers: dict[str, Serializer] = _get_serializers(serializers)
         self._serializers_extra: dict[str, Serializer] = {}
         self._format_serializers: list[Serializer] | None = None
+        self._format_fixed_sizes: list[int | None] | None = None
         self._chunk_size = chunk_size
         self._chunk_bytes = _convert_bytes_to_int(chunk_bytes) if isinstance(chunk_bytes, str) else chunk_bytes
         self._compression = compression
@@ -195,6 +196,7 @@ class BinaryWriter:
             self._data_format = data_format
             self._data_spec = data_spec
             self._format_serializers = [self._serializers_extra[name] for name in data_format]
+            self._format_fixed_sizes = [getattr(serializer, "size", None) for serializer in self._format_serializers]
         else:
             flattened = tree_leaves(items)
             self._serialize_with_data_format(flattened, sizes, data, self._data_format)
@@ -223,11 +225,15 @@ class BinaryWriter:
         if serializers is None:
             serializers = [self._serializers_extra[name] for name in data_format]
             self._format_serializers = serializers
-        for element, serializer in zip(item, serializers):
+            self._format_fixed_sizes = [getattr(serializer, "size", None) for serializer in serializers]
+        fixed_sizes = self._format_fixed_sizes
+        if fixed_sizes is None:
+            fixed_sizes = [getattr(serializer, "size", None) for serializer in serializers]
+            self._format_fixed_sizes = fixed_sizes
+        for element, serializer, fixed in zip(item, serializers, fixed_sizes):
             serialized_item, _ = serializer.serialize(element)
             data.append(serialized_item)
-            size = getattr(serializer, "size", None)
-            sizes.append(size if size is not None else len(serialized_item))
+            sizes.append(fixed if fixed is not None else len(serialized_item))
 
     def _create_chunk(self, filename: str, on_done: bool = False) -> bytes:
         """Creates a binary chunk file from serialized items."""

--- a/src/litdata/streaming/writer.py
+++ b/src/litdata/streaming/writer.py
@@ -28,7 +28,7 @@ from litdata.processing.utilities import get_worker_rank
 from litdata.streaming.compression import _COMPRESSORS, Compressor
 from litdata.streaming.item_loader import BaseItemLoader, ParquetLoader, PyTreeLoader
 from litdata.streaming.serializers import Serializer, _get_serializers
-from litdata.utilities._pytree import PyTree, tree_flatten, treespec_dumps
+from litdata.utilities._pytree import PyTree, tree_flatten, tree_leaves, treespec_dumps
 from litdata.utilities.encryption import Encryption, EncryptionLevel
 from litdata.utilities.env import _DistributedEnv, _WorkerEnv
 from litdata.utilities.format import _convert_bytes_to_int, _human_readable_bytes
@@ -174,14 +174,13 @@ class BinaryWriter:
 
     def serialize(self, items: Any) -> tuple[bytes, int | None]:
         """Serialize a dictionary into its binary format."""
-        # Flatten the items provided by the users
-        flattened, data_spec = tree_flatten(items)
-
-        # Collect the sizes and associated bytes for each item
+        # Flatten the items provided by the users. After the first sample the treespec is cached,
+        # so later writes only walk leaves (same order as ``tree_flatten``).
         sizes: list[int] = []
         data: list[bytes] = []
 
         if self._data_format is None:
+            flattened, data_spec = tree_flatten(items)
             data_format: list[str] = []
             for item in flattened:
                 data_format.append(self._serialize(item, sizes, data))
@@ -197,6 +196,7 @@ class BinaryWriter:
             self._data_spec = data_spec
             self._format_serializers = [self._serializers_extra[name] for name in data_format]
         else:
+            flattened = tree_leaves(items)
             self._serialize_with_data_format(flattened, sizes, data, self._data_format)
 
         return self._item_loader.encode_data(data, sizes, flattened)

--- a/src/litdata/utilities/_pytree.py
+++ b/src/litdata/utilities/_pytree.py
@@ -685,21 +685,34 @@ def _is_namedtuple_instance(tree: Any) -> bool:
     return all(type(entry) == str for entry in fields)
 
 def _is_jpeg_array(tree: Any) -> bool:
-    """Check if the tree is a list of jpeg images."""
+    """True when ``tree`` is a non-empty list/tuple of PIL JPEG images."""
+    typ = type(tree)
+    if typ is not list and typ is not tuple:
+        return False
+    if not tree:
+        return False
     if not _PIL_AVAILABLE:
-            return False
+        return False
 
     from PIL.JpegImagePlugin import JpegImageFile
-    return isinstance(tree, (List,Tuple)) and bool(tree) and all(isinstance(x, JpegImageFile) for x in tree)
+
+    return all(isinstance(x, JpegImageFile) for x in tree)
+
 
 def _get_node_type(tree: Any) -> Any:
+    typ = type(tree)
+    # Fast path: registered containers skip namedtuple / JPEG-list probes.
+    if typ in SUPPORTED_NODES:
+        if (typ is list or typ is tuple) and _is_jpeg_array(tree):
+            return "jpeg_array"
+        if typ is tuple and _is_namedtuple_instance(tree):
+            return namedtuple
+        return typ
     if _is_namedtuple_instance(tree):
         return namedtuple
-
     if _is_jpeg_array(tree):
         return "jpeg_array"
-
-    return type(tree)
+    return typ
 
 
 # A leaf is defined as anything that is not a Node.
@@ -868,11 +881,13 @@ def _tree_flatten_helper(
     leaves: List[Any],
     is_leaf: Optional[Callable[[PyTree], bool]] = None,
 ) -> TreeSpec:
-    if _is_leaf(tree, is_leaf=is_leaf):
+    if is_leaf is not None and is_leaf(tree):
         leaves.append(tree)
         return _LEAF_SPEC
-
     node_type = _get_node_type(tree)
+    if node_type not in SUPPORTED_NODES:
+        leaves.append(tree)
+        return _LEAF_SPEC
     flatten_fn = SUPPORTED_NODES[node_type].flatten_fn
     child_pytrees, context = flatten_fn(tree)
 
@@ -911,16 +926,17 @@ def tree_iter(
     is_leaf: Optional[Callable[[PyTree], bool]] = None,
 ) -> Iterable[Any]:
     """Get an iterator over the leaves of a pytree."""
-    if _is_leaf(tree, is_leaf=is_leaf):
+    if is_leaf is not None and is_leaf(tree):
         yield tree
-    else:
-        node_type = _get_node_type(tree)
-        flatten_fn = SUPPORTED_NODES[node_type].flatten_fn
-        child_pytrees, _ = flatten_fn(tree)
-
-        # Recursively flatten the children
-        for child in child_pytrees:
-            yield from tree_iter(child, is_leaf=is_leaf)
+        return
+    node_type = _get_node_type(tree)
+    if node_type not in SUPPORTED_NODES:
+        yield tree
+        return
+    flatten_fn = SUPPORTED_NODES[node_type].flatten_fn
+    child_pytrees, _context = flatten_fn(tree)
+    for child in child_pytrees:
+        yield from tree_iter(child, is_leaf=is_leaf)
 
 
 def tree_leaves(

--- a/src/litdata/utilities/_pytree.py
+++ b/src/litdata/utilities/_pytree.py
@@ -94,6 +94,16 @@ from typing import (
 
 from litdata.constants import _PIL_AVAILABLE
 
+if _PIL_AVAILABLE:
+    from PIL.JpegImagePlugin import JpegImageFile as _JpegImageFile
+else:
+    _JpegImageFile = None  # type: ignore[misc, assignment]
+
+# Scalars and buffers that dominate StreamingDataset samples. Skip namedtuple / JPEG probes.
+_FAST_LEAF_TYPES: FrozenSet[type] = frozenset(
+    {int, float, str, bool, bytes, bytearray, type(None), complex},
+)
+
 __all__ = [
     "PyTree",
     "Context",
@@ -689,24 +699,20 @@ def _is_jpeg_array(tree: Any) -> bool:
     typ = type(tree)
     if typ is not list and typ is not tuple:
         return False
-    if not tree:
+    if not tree or _JpegImageFile is None:
         return False
-    if not _PIL_AVAILABLE:
-        return False
-
-    from PIL.JpegImagePlugin import JpegImageFile
-
-    return all(isinstance(x, JpegImageFile) for x in tree)
+    return all(isinstance(x, _JpegImageFile) for x in tree)
 
 
 def _get_node_type(tree: Any) -> Any:
     typ = type(tree)
-    # Fast path: registered containers skip namedtuple / JPEG-list probes.
+    if typ in _FAST_LEAF_TYPES:
+        return typ
+    # Registered containers: namedtuple instances are a *subclass* of tuple, so
+    # ``type(point) is tuple`` is never true — only probe JPEG lists/tuples here.
     if typ in SUPPORTED_NODES:
         if (typ is list or typ is tuple) and _is_jpeg_array(tree):
             return "jpeg_array"
-        if typ is tuple and _is_namedtuple_instance(tree):
-            return namedtuple
         return typ
     if _is_namedtuple_instance(tree):
         return namedtuple
@@ -884,6 +890,10 @@ def _tree_flatten_helper(
     if is_leaf is not None and is_leaf(tree):
         leaves.append(tree)
         return _LEAF_SPEC
+    typ = type(tree)
+    if typ in _FAST_LEAF_TYPES:
+        leaves.append(tree)
+        return _LEAF_SPEC
     node_type = _get_node_type(tree)
     if node_type not in SUPPORTED_NODES:
         leaves.append(tree)
@@ -927,6 +937,10 @@ def tree_iter(
 ) -> Iterable[Any]:
     """Get an iterator over the leaves of a pytree."""
     if is_leaf is not None and is_leaf(tree):
+        yield tree
+        return
+    typ = type(tree)
+    if typ in _FAST_LEAF_TYPES:
         yield tree
         return
     node_type = _get_node_type(tree)

--- a/src/litdata/utilities/_pytree.py
+++ b/src/litdata/utilities/_pytree.py
@@ -953,12 +953,42 @@ def tree_iter(
         yield from tree_iter(child, is_leaf=is_leaf)
 
 
+def _collect_leaves(tree: PyTree, leaves: List[Any]) -> None:
+    """Append leaves to ``leaves`` without generator overhead (writer hot path)."""
+    typ = type(tree)
+    if typ in _FAST_LEAF_TYPES:
+        leaves.append(tree)
+        return
+    if typ is dict:
+        for value in tree.values():
+            _collect_leaves(value, leaves)
+        return
+    if typ is list or typ is tuple:
+        if _is_jpeg_array(tree):
+            leaves.append(tree)
+            return
+        for value in tree:
+            _collect_leaves(value, leaves)
+        return
+    node_type = _get_node_type(tree)
+    if node_type not in SUPPORTED_NODES:
+        leaves.append(tree)
+        return
+    child_pytrees, _context = SUPPORTED_NODES[node_type].flatten_fn(tree)
+    for child in child_pytrees:
+        _collect_leaves(child, leaves)
+
+
 def tree_leaves(
     tree: PyTree,
     is_leaf: Optional[Callable[[PyTree], bool]] = None,
 ) -> List[Any]:
     """Get a list of leaves of a pytree."""
-    return list(tree_iter(tree, is_leaf=is_leaf))
+    if is_leaf is not None:
+        return list(tree_iter(tree, is_leaf=is_leaf))
+    leaves: List[Any] = []
+    _collect_leaves(tree, leaves)
+    return leaves
 
 
 def tree_structure(

--- a/tests/streaming/test_async_prefetch.py
+++ b/tests/streaming/test_async_prefetch.py
@@ -204,11 +204,30 @@ def test_prepare_chunks_thread_batches_when_async_enabled(tmpdir, monkeypatch):
 
     monkeypatch.setattr(thread, "_download_chunk_indexes", _capture)
     thread.download([0, 1, 2])
-    thread._to_download_queue.put("END")
+    thread.stop()
     thread.run()
     assert called
     # First batch should include multiple indexes when async prefetch is on.
     assert len(called[0]) >= 2
+
+
+def test_should_start_download_refills_in_gather_batches(tmpdir, monkeypatch):
+    monkeypatch.setenv("LITDATA_ASYNC_CHUNK_PREFETCH", "1")
+    monkeypatch.setenv("LITDATA_ASYNC_MIN_PRE_DOWNLOAD", "0")
+    cache_dir = _seed_local_chunks(tmpdir, n_chunks=4, chunk_size=2)
+    cfg = ChunksConfig.load(cache_dir, _get_serializers(None), None, PyTreeLoader())
+    assert cfg is not None
+    cfg._remote_dir = "r2://bucket/data"
+    thread = PrepareChunksThread(cfg, MagicMock(), _DistributedEnv(1, 0, 1), max_pre_download=8)
+    assert thread._should_start_download(over_budget=False) is True
+    thread._pre_download_counter = 1
+    assert thread._should_start_download(over_budget=False) is True
+    thread._pre_download_counter = 7
+    assert thread._should_start_download(over_budget=False) is True
+    thread._pre_download_counter = 8
+    assert thread._should_start_download(over_budget=False) is False
+    thread._pre_download_counter = 4
+    assert thread._should_start_download(over_budget=False) is True
 
 
 def test_no_use_asyncio_on_streaming_dataloader():

--- a/tests/streaming/test_async_prefetch.py
+++ b/tests/streaming/test_async_prefetch.py
@@ -25,6 +25,7 @@ from litdata.streaming.async_prefetch import (
     adownload_chunk_indexes,
     apply_async_pre_download_floor,
     async_chunk_prefetch_enabled,
+    async_download_concurrency,
     async_prefetch_min_pre_download,
     download_chunk_indexes_concurrently,
     downloader_supports_adownload,
@@ -154,6 +155,16 @@ def test_adownload_chunk_indexes_overlap_latency(tmpdir):
     assert len(fake.calls) == 3
     for idx in indexes:
         assert os.path.exists(os.path.join(cache_dir, chunks[idx]["filename"]))
+
+
+def test_async_download_concurrency_caps_gather(monkeypatch):
+    monkeypatch.delenv("LITDATA_ASYNC_DOWNLOAD_CONCURRENCY", raising=False)
+    assert async_download_concurrency(3) == 3
+    assert async_download_concurrency(32) == 8
+    monkeypatch.setenv("LITDATA_ASYNC_DOWNLOAD_CONCURRENCY", "2")
+    assert async_download_concurrency(32) == 2
+    monkeypatch.setenv("LITDATA_ASYNC_DOWNLOAD_CONCURRENCY", "1")
+    assert async_download_concurrency(8) == 1
 
 
 def test_download_chunk_indexes_concurrently_single_uses_sync(tmpdir, monkeypatch):

--- a/tests/streaming/test_download_reader_overlap.py
+++ b/tests/streaming/test_download_reader_overlap.py
@@ -16,6 +16,7 @@ from litdata.streaming.dataset import StreamingDataset
 from litdata.streaming.downloader import S3Downloader
 from litdata.streaming.item_loader import PyTreeLoader
 from litdata.streaming.reader import _DEFAULT_TIMEOUT, PrepareChunksThread
+from litdata.streaming.sampler import ChunkedIndex
 from litdata.utilities.env import _DistributedEnv
 
 
@@ -159,6 +160,36 @@ def test_item_loader_clears_stale_ready_event(tmpdir):
     item = loader.load_item_from_chunk(2, 1, chunk_filepath, begin, filesize)
     assert item == 2
     # The wait loop may clear again after restore on a slow FS; the load is the contract.
+
+
+def test_atomic_publish_sets_file_and_chunk_ready_events(tmpdir):
+    """Downloader os.replace should set in-process Events instead of requiring FS polls."""
+    cache = Cache(str(tmpdir / "src"), chunk_size=2)
+    for i in range(2):
+        cache[i] = i
+    cache.done()
+    cache.merge()
+
+    reader = cache._reader
+    reader._try_load_config()
+    config = reader.config
+    chunk_filepath, _, _ = config[ChunkedIndex(0, chunk_index=0)]
+
+    dest = os.path.join(str(tmpdir / "dest"), os.path.basename(chunk_filepath))
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    tmp = dest + ".tmp"
+    with open(tmp, "wb") as f:
+        f.write(b"ready")
+
+    from litdata.streaming.downloader import LocalDownloader
+
+    dl = LocalDownloader(str(tmpdir / "src"), str(tmpdir / "dest"), [])
+    dl._on_file_published = config.notify_file_published
+    # Simulate the last step of a download: atomic publish of tmp → dest.
+    dl._publish_file(tmp, dest)
+
+    assert os.path.exists(dest)
+    assert config.wait_file_published(dest, timeout=0.0)
 
 
 def test_s3_downloader_does_not_publish_partial_final_path(monkeypatch, tmpdir):

--- a/tests/streaming/test_download_reader_overlap.py
+++ b/tests/streaming/test_download_reader_overlap.py
@@ -20,6 +20,36 @@ from litdata.streaming.sampler import ChunkedIndex
 from litdata.utilities.env import _DistributedEnv
 
 
+def test_run_loop_downloads_numpy_int64_chunk_indexes(monkeypatch, tmpdir):
+    """Shuffle queues numpy.int64; the prepare loop must not drop them as non-ints."""
+    import numpy as np
+
+    cache_dir = str(tmpdir / "cache")
+    os.makedirs(cache_dir)
+    config = MagicMock(spec=ChunksConfig)
+    config.num_bytes = 1024
+    config._cache_dir = cache_dir
+    config._remote_dir = "s3://bucket"
+    config.download_chunk_from_index = MagicMock()
+    item_loader = MagicMock()
+    env = _DistributedEnv(1, 0, 1)
+
+    thread = PrepareChunksThread(config, item_loader, env, max_cache_size=10_000, max_pre_download=4)
+    seen: list[list[int]] = []
+
+    def fake_download(chunk_indexes: list[int]) -> None:
+        seen.append(list(chunk_indexes))
+        thread._force_stop_event.set()
+
+    monkeypatch.setattr(thread, "_download_chunk_indexes", fake_download)
+    monkeypatch.setattr(thread, "_async_prefetch", lambda: False)
+    thread.download([np.int64(17), np.int64(18)])
+    thread.run()
+
+    assert seen, "prepare thread dropped numpy.int64 chunk indexes"
+    assert [int(x) for x in seen[0]] == [17]
+
+
 def test_prefetch_side_polls_are_nonblocking_when_download_work_available(monkeypatch, tmpdir):
     """Force/delete polls must use timeout=0 while the prefetch buffer can still accept downloads."""
     cache_dir = str(tmpdir / "cache")

--- a/tests/streaming/test_downloader.py
+++ b/tests/streaming/test_downloader.py
@@ -260,13 +260,13 @@ def test_download_with_cache(tmpdir, monkeypatch):
     try:
         local_downloader = LocalDownloaderWithCache(tmpdir, tmpdir, [])
         shutil_mock = MagicMock()
-        os_mock = MagicMock()
+        replace_mock = MagicMock()
         monkeypatch.setattr(shutil, "copy", shutil_mock)
-        monkeypatch.setattr(os, "rename", os_mock)
+        monkeypatch.setattr(os, "replace", replace_mock)
 
         local_downloader.download_file("local:a.txt", os.path.join(tmpdir, "a.txt"))
         shutil_mock.assert_called()
-        os_mock.assert_called()
+        replace_mock.assert_called()
     finally:
         os.remove("a.txt")
 

--- a/tests/streaming/test_item_loader.py
+++ b/tests/streaming/test_item_loader.py
@@ -16,6 +16,7 @@ from litdata.constants import (
 from litdata.streaming import Cache, item_loader
 from litdata.streaming.dataset import StreamingDataset
 from litdata.streaming.item_loader import ParquetLoader, PyTreeLoader, TokensLoader
+from litdata.streaming.sampler import ChunkedIndex
 from litdata.streaming.writer import index_parquet_dataset
 from litdata.utilities.shuffle import _get_shared_chunks
 
@@ -167,6 +168,20 @@ def test_compiled_unflatten_is_picklable_for_dataloader_workers(tmpdir):
     assert restored._unflatten is not None
     leaves = [1, 2.0]
     assert restored._unflatten(leaves) == loader._unflatten(leaves) == {"i": 1, "x": 2.0}
+
+
+def test_pre_load_chunk_does_not_mutate_mmap_from_prefetch_thread(tmpdir):
+    """PrepareChunksThread may only WILLNEED; mmap state stays on the reader thread."""
+    data_dir = _write_int_dataset(tmpdir, num_items=14, chunk_size=7)
+    dataset = StreamingDataset(data_dir)
+    _ = dataset[0]
+    loader = dataset.cache._reader._item_loader
+    assert isinstance(loader, PyTreeLoader)
+    loader.close(0)
+    chunk_path = dataset.cache._reader.config[ChunkedIndex(0, chunk_index=0)][0]
+    loader.pre_load_chunk(0, chunk_path)
+    assert loader._mapped == {}
+    assert loader._mmap is None
 
 
 def test_pytree_loader_mmap_matches_file_reads(tmpdir):

--- a/tests/streaming/test_item_loader.py
+++ b/tests/streaming/test_item_loader.py
@@ -20,6 +20,13 @@ from litdata.streaming.writer import index_parquet_dataset
 from litdata.utilities.shuffle import _get_shared_chunks
 
 
+def test_encode_data_size_header_is_little_endian_uint32():
+    packed, dim = PyTreeLoader.encode_data([b"ab", b"cdef"], [2, 4], ["ab", "cdef"])
+    assert dim is None
+    assert packed[:8] == (2).to_bytes(4, "little") + (4).to_bytes(4, "little")
+    assert packed[8:] == b"abcdef"
+
+
 def _write_int_dataset(tmpdir, num_items: int = 40, chunk_size: int = 7) -> str:
     """Write a small integer StreamingDataset and return its directory."""
     cache = Cache(str(tmpdir), chunk_size=chunk_size)

--- a/tests/streaming/test_media_types.py
+++ b/tests/streaming/test_media_types.py
@@ -183,6 +183,24 @@ def test_pytree_wrapper_is_single_leaf():
     assert isinstance(leaves[1], Image)
 
 
+def test_jpeg_array_flatten_is_single_leaf():
+    pytest.importorskip("PIL")
+    import io
+
+    from PIL import Image as PILImage
+
+    frames = []
+    for _ in range(3):
+        buf = io.BytesIO()
+        PILImage.new("RGB", (8, 8), color=(10, 20, 30)).save(buf, format="JPEG")
+        frames.append(PILImage.open(io.BytesIO(buf.getvalue())))
+    leaves, spec = tree_flatten({"index": 1, "images": frames})
+    assert spec.type is dict
+    assert len(leaves) == 2
+    assert leaves[0] == 1
+    assert leaves[1] is frames
+
+
 def test_serializers_registry_has_media_keys():
     for key in ("video", "audio", "image", "nifti", "mesh", "pdf", "text", "graph"):
         assert key in _SERIALIZERS

--- a/tests/streaming/test_serializer.py
+++ b/tests/streaming/test_serializer.py
@@ -684,6 +684,9 @@ def test_boolean_serializer():
     assert isinstance(data, bytes)
     assert serializer.deserialize(data) is False
 
+    assert serializer.size == 1
+    assert len(data) == 1
+
     # Test can_serialize method
     assert serializer.can_serialize(True)
     assert serializer.can_serialize(False)

--- a/tests/utilities/test_pytree.py
+++ b/tests/utilities/test_pytree.py
@@ -1,0 +1,179 @@
+# Copyright The Lightning AI team.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import OrderedDict, defaultdict, deque, namedtuple
+from typing import NamedTuple
+
+import pytest
+
+from litdata.utilities._pytree import (
+    tree_flatten,
+    tree_iter,
+    tree_leaves,
+    tree_map,
+    tree_unflatten,
+    treespec_dumps,
+    treespec_loads,
+)
+
+
+def _roundtrip(tree):
+    leaves, spec = tree_flatten(tree)
+    assert list(tree_iter(tree)) == leaves
+    assert tree_leaves(tree) == leaves
+    restored = tree_unflatten(leaves, spec)
+    assert restored == tree
+    assert treespec_loads(treespec_dumps(spec)).num_leaves == spec.num_leaves
+    assert tree_unflatten(leaves, treespec_loads(treespec_dumps(spec))) == tree
+    return leaves, spec
+
+
+def test_flatten_primitives_are_single_leaves():
+    for value in (0, 1, -3, 1.5, True, False, "hi", b"raw", None):
+        leaves, spec = tree_flatten(value)
+        assert leaves == [value]
+        assert spec.is_leaf()
+        assert tree_unflatten(leaves, spec) == value
+
+
+def test_flatten_nested_dict_list_tuple():
+    tree = {"i": 1, "coords": [1.0, 2.0], "flag": True, "meta": ("a", {"b": 3})}
+    leaves, spec = _roundtrip(tree)
+    assert leaves == [1, 1.0, 2.0, True, "a", 3]
+    assert spec.type is dict
+    assert spec.context == ["i", "coords", "flag", "meta"]
+    assert spec.num_leaves == 6
+
+
+def test_empty_containers():
+    for tree in ([], {}, (), OrderedDict(), defaultdict(int), deque()):
+        leaves, spec = tree_flatten(tree)
+        assert leaves == []
+        assert spec.num_leaves == 0
+        assert tree_unflatten(leaves, spec) == tree
+
+
+def test_ordered_dict_and_defaultdict_and_deque():
+    od = OrderedDict([("z", 1), ("a", 2)])
+    leaves, spec = _roundtrip(od)
+    assert leaves == [1, 2]
+    assert spec.type is OrderedDict
+
+    dd = defaultdict(int, {"x": 4})
+    leaves, spec = _roundtrip(dd)
+    assert leaves == [4]
+    assert spec.type is defaultdict
+    assert tree_unflatten(leaves, spec).default_factory is int
+
+    dq = deque([1, 2, 3], maxlen=5)
+    leaves, spec = _roundtrip(dq)
+    assert leaves == [1, 2, 3]
+    assert spec.type is deque
+    assert tree_unflatten(leaves, spec).maxlen == 5
+
+
+def test_namedtuple_is_a_node_not_a_tuple_of_leaves_only():
+    Point = namedtuple("Point", ["x", "y"])
+    point = Point(1, 2)
+    leaves, spec = tree_flatten(point)
+    assert leaves == [1, 2]
+    restored = tree_unflatten(leaves, spec)
+    assert restored == point
+    assert type(restored) is Point
+
+    class TypedPoint(NamedTuple):
+        x: int
+        y: int
+
+    typed = TypedPoint(3, 4)
+    leaves, spec = tree_flatten(typed)
+    assert leaves == [3, 4]
+    assert type(tree_unflatten(leaves, spec)) is TypedPoint
+
+
+def test_dict_and_list_subclasses_are_leaves():
+    class MyDict(dict):
+        pass
+
+    class MyList(list):
+        pass
+
+    wrapped = {"d": MyDict(a=1), "l": MyList([2, 3])}
+    leaves, spec = tree_flatten(wrapped)
+    assert len(leaves) == 2
+    assert leaves[0] is wrapped["d"]
+    assert leaves[1] is wrapped["l"]
+    assert tree_unflatten(leaves, spec) == wrapped
+
+
+def test_custom_is_leaf_stops_descent():
+    tree = {"keep": [1, 2], "split": [3, 4]}
+    leaves, spec = tree_flatten(tree, is_leaf=lambda x: isinstance(x, list) and x == [1, 2])
+    assert leaves == [[1, 2], 3, 4]
+    assert tree_unflatten(leaves, spec) == tree
+
+
+def test_tree_map_and_key_order():
+    tree = {"b": 2, "a": 1}
+    mapped = tree_map(lambda x: x * 10, tree)
+    assert mapped == {"b": 20, "a": 10}
+    assert list(mapped) == ["b", "a"]
+
+
+def test_treespec_dumps_stable_for_common_sample():
+    tree = {"i": 0, "coords": [0.0, 1.0], "flag": True}
+    _, spec = tree_flatten(tree)
+    dumped = treespec_dumps(spec)
+    assert treespec_dumps(treespec_loads(dumped)) == dumped
+    assert "builtins.dict" in dumped
+    assert "builtins.list" in dumped
+
+
+def test_jpeg_array_is_one_leaf():
+    pytest.importorskip("PIL")
+    import io
+
+    from PIL import Image as PILImage
+
+    frames = []
+    for _ in range(2):
+        buf = io.BytesIO()
+        PILImage.new("RGB", (4, 4)).save(buf, format="JPEG")
+        frames.append(PILImage.open(io.BytesIO(buf.getvalue())))
+    empty: list = []
+    mixed = [frames[0], "not-jpeg"]
+    tree = {"images": frames, "empty": empty, "mixed": mixed, "n": 1}
+    leaves, spec = tree_flatten(tree)
+    # Empty list is a node with zero leaves; JPEG list is a single leaf.
+    assert leaves == [frames, frames[0], "not-jpeg", 1]
+    restored = tree_unflatten(leaves, spec)
+    assert restored["images"] is frames
+    assert restored["empty"] == []
+
+
+def test_writer_leaves_match_flatten_after_first_sample(tmpdir):
+    from litdata.streaming.writer import BinaryWriter
+
+    samples = [{"i": i, "coords": [float(i), float(i + 1)], "flag": i % 2 == 0} for i in range(8)]
+    writer = BinaryWriter(str(tmpdir), chunk_size=8)
+    for i, sample in enumerate(samples):
+        writer[i] = sample
+    writer.done()
+    writer.merge()
+
+    from litdata.streaming.reader import BinaryReader
+    from litdata.streaming.sampler import ChunkedIndex
+
+    reader = BinaryReader(str(tmpdir))
+    for i, sample in enumerate(samples):
+        assert reader.read(ChunkedIndex(i, chunk_index=0)) == sample

--- a/tests/utilities/test_pytree.py
+++ b/tests/utilities/test_pytree.py
@@ -161,6 +161,24 @@ def test_jpeg_array_is_one_leaf():
     assert restored["empty"] == []
 
 
+def test_writer_fixed_size_layout_roundtrip(tmpdir):
+    from litdata.streaming.reader import BinaryReader
+    from litdata.streaming.sampler import ChunkedIndex
+    from litdata.streaming.writer import BinaryWriter
+
+    writer = BinaryWriter(str(tmpdir), chunk_size=8)
+    samples = [{"i": i, "flag": i % 2 == 0, "x": float(i)} for i in range(8)]
+    for i, sample in enumerate(samples):
+        writer[i] = sample
+    writer.done()
+    writer.merge()
+    assert writer._fixed_header is not None
+    assert writer._fixed_body_len == 8 + 1 + 8
+    reader = BinaryReader(str(tmpdir))
+    for i, sample in enumerate(samples):
+        assert reader.read(ChunkedIndex(i, chunk_index=0)) == sample
+
+
 def test_writer_leaves_match_flatten_after_first_sample(tmpdir):
     from litdata.streaming.writer import BinaryWriter
 


### PR DESCRIPTION
## Summary

Hot-path speedups for write, read, and remote prefetch — plus a prefetch bug that made the Event-based wait path fall back to force-download.

### Writer / reader
- Faster `tree_flatten` / `tree_iter`: skip typing-generic `isinstance` and PIL JPEG probes on non-list/tuple nodes and scalar leaves; call `_get_node_type` once per node.
- After the first sample, `BinaryWriter` walks `tree_leaves` instead of rebuilding a `TreeSpec`, caches per-leaf byte sizes, and packs the size header with `struct`. Fixed-size leaves (int/float/bool) reuse a cached header and write into one buffer.
- `BooleanSerializer` advertises `size = 1` and deserializes the first byte (no `np.frombuffer`). Reader offset pairs and size headers use `struct`.

### Remote streaming
- Cap in-flight chunk GETs with `LITDATA_ASYNC_DOWNLOAD_CONCURRENCY` (default 8) and drain the prefetch queue up to gather width when slots are free.
- Signal chunk-ready with `Event.set` after the downloader's atomic `os.replace` (decompress publishes the readable `.bin`). The item loader waits on that Event instead of polling the filesystem.
- `posix_fadvise(WILLNEED)` downloaded cache files from the prefetch thread (mmap stays on the reader thread).

### Prefetch correctness
- Shuffle queues `numpy.int64` chunk indexes. `isinstance(..., int)` dropped every prefetch, so the wait loop sat idle until `_FORCE_DOWNLOAD_TIME` (30s) and then force-downloaded. Prefetch now accepts those indexes; force-download stays a last resort.
- Concurrent `os.replace` of the same chunk is a no-op when the destination already exists (same-pid gather or another worker already published).

## Benchmark

Single-run (`n=1`) on this Lightning Studio. CPython 3.12.11, GIL on. Script: `scripts/bench/bench_s3_full_epochs.py`.

**ImageNet S3 stream** — `s3://…/lightning_data_search` (1,281,167 samples, 224 × 64MB JPEG chunks), 48 workers, batch 256, `max_pre_download=2`, cache wiped (`/cache/chunks`).

| Run | Epoch | Images/sec | Time | First batch |
|---|---|---:|---:|---:|
| `main` `d60e2ce` | 0 (cold) | **11,227** | 114.1 s | 6.87 s |
| PR before numpy fix (`5f8923c`) | 0 (cold) | 9,605 | 133.4 s | 3.95 s |
| PR before numpy fix (`5f8923c`) | 1 (warm) | 12,815 | 100.0 s | 1.40 s |
| PR after numpy fix | 0 (cold) | 11,589 | 110.6 s | 6.96 s |
| **PR as pushed** (`d5ce815`) | **0 (cold)** | **11,386** | **112.5 s** | **5.95 s** |

Cold epoch 0 is download-bound. The broken prefetch path was ~14% slower than `main`; the pushed tip is in the same ballpark as `main` (slightly faster on these two n=1 runs).

**Writer / deserialize (local microbench, earlier on this machine)**

| Workload | Before | After |
|---|---:|---:|
| Median `BinaryWriter` 4000 int/bool/float | ~69 ms | ~45 ms (~1.5×) |
| Bool deserialize 100k | ~54 ms | ~3 ms |

## Test plan
- [x] `tests/utilities/test_pytree.py`, `tests/streaming/test_writer.py`, JPEG array + boolean serializer tests
- [x] `tests/streaming/test_download_reader_overlap.py::test_run_loop_downloads_numpy_int64_chunk_indexes`
- [x] `test_reader_chunk_removal` / `_compressed`, zstd `test_streaming_dataset*` (local)
- [x] ImageNet epoch 0, 48 workers, cold cache (table above)
- [ ] CI on this PR