### PR TITLE
feat(streaming): add stdlib cProfile for the loader parent and worker 0

### DIFF
--- a/.claude/skills/litdata/reference/debugging.md
+++ b/.claude/skills/litdata/reference/debugging.md
@@ -23,6 +23,25 @@ loader = StreamingDataLoader(
 - Overwrites existing `result.json`. View in `chrome://tracing` or Perfetto.
 - Full user doc: README `#profile-loading`; cookbook: [using-litdata.md](using-litdata.md) §7.
 
+## StreamingDataLoader cProfile (main + worker 0)
+
+Stdlib function profile — no viztracer. Complementary to the Chrome trace above.
+
+```python
+loader = StreamingDataLoader(
+    StreamingDataset("s3://bucket/data"),
+    batch_size=64,
+    num_workers=4,
+    profile_cprofile=True,
+    profile_dir="./profiles",   # → cprofile_main.prof + cprofile_worker0.prof
+)
+```
+
+- No extra dependency. Raises if combined with `profile_batches`.
+- Rank 0 only. Worker file is worker **0**. `num_workers=0` writes main only.
+- Parent profiler starts after workers spawn so fork does not inherit an active cProfile.
+- Also writes `.txt` tottime/cumtime dumps. Open `.prof` with `python -m pstats`.
+
 ## Breakpoints inside worker processes
 
 Normal `breakpoint()` doesn't work in DataLoader or `optimize`/`map` worker subprocesses (no stdin). Use LitData's multiprocessing-safe pdb, which reopens `sys.stdin` under a lock (`utilities/breakpoint.py:33`, exported as `litdata.breakpoint`):

--- a/.claude/skills/litdata/reference/using-litdata.md
+++ b/.claude/skills/litdata/reference/using-litdata.md
@@ -225,6 +225,27 @@ StreamingDataLoader(
 
 `int` wraps `fetcher.fetch` and stops after skip+N fetches; `True` traces until the worker loop ends. Complementary to `enable_tracer()` + [Litracer](https://github.com/Lightning-AI/litracer) (pipeline events) — see [debugging.md](debugging.md). README: `#profile-loading`.
 
+### Profiling (`profile_cprofile`) — stdlib cProfile
+
+```python
+StreamingDataLoader(
+    dataset,
+    batch_size=64,
+    num_workers=4,
+    profile_cprofile=True,
+    profile_dir="./profiles",    # cprofile_main.prof + cprofile_worker0.prof (+ .txt)
+)
+```
+
+| Requirement | Detail |
+| ----------- | ------ |
+| Dep         | None (`cProfile` / `pstats` are stdlib) |
+| Scope       | Main process + worker **0** (rank 0). `num_workers=0` writes main only |
+| Output      | `{profile_dir}/cprofile_{main,worker0}.{prof,txt}` |
+| Conflict    | Raises if `profile_batches` is also set |
+
+Parent profiler starts after workers spawn (fork must not inherit an active cProfile). Inspect with `python -m pstats profiles/cprofile_worker0.prof`.
+
 ______________________________________________________________________
 
 ## 8. Cache, async prefetch & environment variables
@@ -529,7 +550,7 @@ ______________________________________________________________________
 
 ## 13. Debug & profile
 
-**DataLoader worker CPU** — `StreamingDataLoader(..., profile_batches=20, num_workers=4)` → viztracer `result.json` (§7 / README `#profile-loading`).
+**DataLoader worker CPU** — `StreamingDataLoader(..., profile_batches=20, num_workers=4)` → viztracer `result.json`; `profile_cprofile=True` → `cprofile_main.prof` + `cprofile_worker0.prof` (§7 / README `#profile-loading`).
 
 **LitData pipeline events** — `from litdata.debugger import enable_tracer` → `litdata_debug.log` → [Litracer](https://github.com/Lightning-AI/litracer) → Perfetto:
 

--- a/.claude/skills/litdata/reference/using-litdata.md
+++ b/.claude/skills/litdata/reference/using-litdata.md
@@ -237,12 +237,12 @@ StreamingDataLoader(
 )
 ```
 
-| Requirement | Detail |
-| ----------- | ------ |
-| Dep         | None (`cProfile` / `pstats` are stdlib) |
+| Requirement | Detail                                                                 |
+| ----------- | ---------------------------------------------------------------------- |
+| Dep         | None (`cProfile` / `pstats` are stdlib)                                |
 | Scope       | Main process + worker **0** (rank 0). `num_workers=0` writes main only |
-| Output      | `{profile_dir}/cprofile_{main,worker0}.{prof,txt}` |
-| Conflict    | Raises if `profile_batches` is also set |
+| Output      | `{profile_dir}/cprofile_{main,worker0}.{prof,txt}`                     |
+| Conflict    | Raises if `profile_batches` is also set                                |
 
 Parent profiler starts after workers spawn (fork must not inherit an active cProfile). Inspect with `python -m pstats profiles/cprofile_worker0.prof`.
 

--- a/README.md
+++ b/README.md
@@ -1085,7 +1085,8 @@ On **Vast / NFS / local disk**, POSIX-fast is on by default (`LITDATA_POSIX_FAST
 | All usual `torch.utils.data.DataLoader` kwargs | `batch_size`, `num_workers`, `collate_fn`, `pin_memory`, … |
 | `shuffle` / `drop_last` | Forwarded to the streaming dataset |
 | `profile_batches` | `int` / `True` / `False` — viztracer worker trace (see [Profile data loading](#profile-loading)) |
-| `profile_skip_batches` / `profile_dir` | Warm-up skip count; output dir for `result.json` |
+| `profile_cprofile` | `True` — stdlib cProfile of the main process + worker 0 (see [Profile data loading](#profile-loading)) |
+| `profile_skip_batches` / `profile_dir` | Warm-up skip count; output dir for viztracer / cProfile files |
 | `multiprocessing_context` | Use **`"spawn"`** (or `"forkserver"`) with `ParquetLoader` + `num_workers>0` on Linux |
 
 Prefer `StreamingDataLoader` over a plain PyTorch `DataLoader` for optimized / combined / parallel datasets (resume + correct batch metadata).
@@ -2051,7 +2052,32 @@ Only **worker 0** is instrumented. When an `int` is used, the tracer wraps `fetc
 
 - Delete or change `profile_dir` between runs — LitData removes an existing `result.json` before starting.
 - Pair with a wiped chunk cache if you care about **cold** epoch behavior (`litdata cache clear`).
-- For deeper LitData internals (download / read / delete timeline), use `enable_tracer()` + [Litracer](https://github.com/Lightning-AI/litracer) instead — see [Debug & Profile LitData](#debug-profile). That path is complementary: viztracer = DataLoader worker CPU timeline; Litracer = LitData pipeline events.
+### cProfile (main + worker 0)
+
+Stdlib statistical profile of **the parent process** (queue wait, unpickle, collate handoff) and **worker 0** (fetch, decode, transforms). No extra package.
+
+```python
+loader = StreamingDataLoader(
+    dataset,
+    batch_size=64,
+    num_workers=4,
+    profile_cprofile=True,
+    profile_dir="./profiles",
+)
+
+for batch in loader:
+    train_step(batch)
+# writes profiles/cprofile_main.prof + cprofile_worker0.prof (and .txt summaries)
+```
+
+```bash
+python -m pstats profiles/cprofile_worker0.prof
+# then: sort tottime   stats 30
+```
+
+Do not set `profile_cprofile` and `profile_batches` together — both install a `sys.setprofile` hook. With `num_workers=0` only the main file is written. The parent profiler starts **after** workers spawn so fork does not inherit an active cProfile.
+
+- For deeper LitData internals (download / read / delete timeline), use `enable_tracer()` + [Litracer](https://github.com/Lightning-AI/litracer) instead — see [Debug & Profile LitData](#debug-profile). That path is complementary: viztracer = DataLoader worker CPU timeline; cProfile = function self/cum time; Litracer = LitData pipeline events.
 
 </details>
 

--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased] - YYYY-MM-DD
 
+### Added
+
+- `StreamingDataLoader(..., profile_cprofile=True)` writes stdlib cProfile stats for the main process and worker 0 (`cprofile_main.prof` / `cprofile_worker0.prof` plus `.txt` summaries). No extra dependency. Cannot be combined with `profile_batches` (viztracer).
+
 ### Fixed
 
 - Prefetch accepts `numpy.int64` chunk indexes from shuffle (they were dropped by `isinstance(..., int)`), so force-download stays a last resort after `_FORCE_DOWNLOAD_TIME`. Concurrent `os.replace` of the same chunk is a no-op when the destination already exists.

--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -8,9 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased] - YYYY-MM-DD
 
+## [0.2.71] - 2026-08-15
+
 ### Added
 
-- `StreamingDataLoader(..., profile_cprofile=True)` writes stdlib cProfile stats for the main process and worker 0 (`cprofile_main.prof` / `cprofile_worker0.prof` plus `.txt` summaries). No extra dependency. Cannot be combined with `profile_batches` (viztracer).
+- `StreamingDataLoader(..., profile_cprofile=True)` writes stdlib cProfile stats for the main process and worker 0 (`cprofile_main.prof` / `cprofile_worker0.prof` plus `.txt` summaries). No extra dependency. Cannot be combined with `profile_batches` (viztracer). ([#885](https://github.com/Lightning-AI/litData/pull/885))
 
 ### Fixed
 

--- a/src/litdata/__about__.py
+++ b/src/litdata/__about__.py
@@ -14,7 +14,7 @@
 
 import time
 
-__version__ = "0.2.70"
+__version__ = "0.2.71"
 __author__ = "Lightning AI et al."
 __author_email__ = "pytorch@lightning.ai"
 __license__ = "Apache-2.0"

--- a/src/litdata/streaming/dataloader.py
+++ b/src/litdata/streaming/dataloader.py
@@ -12,9 +12,11 @@
 # limitations under the License.
 
 import asyncio
+import cProfile
 import inspect
 import logging
 import os
+import pstats
 from collections.abc import Callable
 from copy import deepcopy
 from importlib import reload
@@ -55,6 +57,38 @@ from litdata.utilities.base import (
 from litdata.utilities.env import _DistributedEnv
 
 logger = logging.getLogger("litdata.streaming.dataloader")
+
+_CPROFILE_MAIN_STEM = "cprofile_main"
+_CPROFILE_WORKER_STEM = "cprofile_worker0"
+
+
+def _cprofile_output_dir(profile_dir: str | None) -> str:
+    path = os.path.abspath(profile_dir or os.getcwd())
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _dump_cprofile(profiler: cProfile.Profile, stem: str) -> None:
+    """Write ``{stem}.prof`` and a short ``{stem}.txt`` tottime/cumtime dump."""
+    profiler.disable()
+    prof_path = f"{stem}.prof"
+    txt_path = f"{stem}.txt"
+    profiler.dump_stats(prof_path)
+    with open(txt_path, "w", encoding="utf-8") as handle:
+        handle.write(
+            "Prefer tottime (self time). cumtime mixes threads in the same process "
+            "(worker 0 includes fetch + prefetch + collate) and over-counts waits.\n"
+            "C extensions (JPEG decode, upsample, S3/obstore) appear on the Python caller.\n\n"
+        )
+        stats = pstats.Stats(profiler, stream=handle)
+        stats.strip_dirs()
+        handle.write("--- tottime ---\n")
+        stats.sort_stats("tottime").print_stats(40)
+        handle.write("\n--- cumtime ---\n")
+        stats.sort_stats("cumtime").print_stats(40)
+        handle.write("\n--- litdata ---\n")
+        stats.sort_stats("tottime").print_stats("litdata", 40)
+    print(f"[litdata] cProfile wrote {prof_path} and {txt_path}", flush=True)
 
 
 def _equal_items(data_1: Any, data_2: Any) -> bool:
@@ -463,6 +497,57 @@ class _ProfileWorkerLoop:
             tracer.save()
 
 
+class _CProfileWorkerLoop:
+    """cProfile worker 0's DataLoader loop (stdlib; no viztracer)."""
+
+    def __init__(self, profile_dir: str) -> None:
+        self._profile_dir = profile_dir
+
+    def __call__(
+        self,
+        dataset_kind: Any,
+        dataset: Any,
+        index_queue: Any,
+        data_queue: Any,
+        done_event: Any,
+        auto_collation: Any,
+        collate_fn: Any,
+        drop_last: Any,
+        base_seed: Any,
+        init_fn: Any,
+        worker_id: Any,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        from torch.utils.data._utils import worker
+
+        profiler: cProfile.Profile | None = None
+        if worker_id == 0:
+            profiler = cProfile.Profile()
+            profiler.enable()
+
+        reloaded_worker = reload(worker)
+        try:
+            reloaded_worker._worker_loop(
+                dataset_kind,
+                dataset,
+                index_queue,
+                data_queue,
+                done_event,
+                auto_collation,
+                collate_fn,
+                drop_last,
+                base_seed,
+                init_fn,
+                worker_id,
+                *args,
+                **kwargs,
+            )
+        finally:
+            if profiler is not None:
+                _dump_cprofile(profiler, os.path.join(self._profile_dir, _CPROFILE_WORKER_STEM))
+
+
 class _StreamingMultiProcessingDataLoaderIter(_MultiProcessingDataLoaderIter):
     def __init__(self, loader: DataLoader) -> None:
         self._loader = loader
@@ -472,17 +557,42 @@ class _StreamingMultiProcessingDataLoaderIter(_MultiProcessingDataLoaderIter):
             else []
         )
         self._num_workers = loader.num_workers
+        self._cprofile: cProfile.Profile | None = None
+        self._orig_worker_loop: Any = None
 
         distributed_env = _DistributedEnv.detect()
+        profile_cprofile = bool(getattr(self._loader, "_profile_cprofile", False))
 
-        if self._loader._profile_batches and distributed_env.global_rank == 0 and _VIZ_TRACKER_AVAILABLE:
+        if distributed_env.global_rank == 0:
             from torch.utils.data._utils import worker
 
-            worker._worker_loop = _ProfileWorkerLoop(
-                self._loader._profile_batches, self._loader._profile_skip_batches, self._loader._profile_dir
-            )
+            if self._loader._profile_batches and _VIZ_TRACKER_AVAILABLE:
+                worker._worker_loop = _ProfileWorkerLoop(
+                    self._loader._profile_batches, self._loader._profile_skip_batches, self._loader._profile_dir
+                )
+            elif profile_cprofile:
+                self._orig_worker_loop = worker._worker_loop
+                worker._worker_loop = _CProfileWorkerLoop(_cprofile_output_dir(self._loader._profile_dir))
 
+        # Workers fork/spawn here. Enable the parent profiler only after that so
+        # the child does not inherit an active cProfile (one profiler per process).
         super().__init__(loader)
+
+        if profile_cprofile and distributed_env.global_rank == 0:
+            self._cprofile = cProfile.Profile()
+            self._cprofile.enable()
+
+    def _shutdown_workers(self) -> None:
+        if self._cprofile is not None:
+            stem = os.path.join(_cprofile_output_dir(self._loader._profile_dir), _CPROFILE_MAIN_STEM)
+            _dump_cprofile(self._cprofile, stem)
+            self._cprofile = None
+        if self._orig_worker_loop is not None:
+            from torch.utils.data._utils import worker
+
+            worker._worker_loop = self._orig_worker_loop
+            self._orig_worker_loop = None
+        super()._shutdown_workers()
 
     def _try_put_index(self) -> None:
         # Used to restart on the right DataLoader worker
@@ -610,6 +720,9 @@ class StreamingDataLoader(DataLoader):
         profile_skip_batches (int): How many batches to skip before recording
         profile_batches (int, bool, optional): Whether to record data loading profile and generate a result.json file.
         profile_dir (int, bool,  optional): Where to store the recorded trace when profile_batches is enabled.
+        profile_cprofile (bool, optional): Write stdlib cProfile stats for the main process and
+            worker 0 (``cprofile_main.prof`` / ``cprofile_worker0.prof``). Cannot be combined
+            with ``profile_batches`` (both use ``sys.setprofile``).
 
     """
 
@@ -624,6 +737,7 @@ class StreamingDataLoader(DataLoader):
         profile_batches: bool | int = False,
         profile_skip_batches: int = 0,
         profile_dir: str | None = None,
+        profile_cprofile: bool = False,
         prefetch_factor: int | None = None,
         shuffle: bool | None = None,
         drop_last: bool | None = None,
@@ -668,6 +782,11 @@ class StreamingDataLoader(DataLoader):
 
         shuffle = None
 
+        if profile_batches and profile_cprofile:
+            raise ValueError(
+                "`profile_batches` (viztracer) and `profile_cprofile` both install a profiler; enable only one of them."
+            )
+
         if profile_batches and not _VIZ_TRACKER_AVAILABLE:
             raise ModuleNotFoundError("To use profile_batches, viztracer is required. Run `pip install viztracer`")
 
@@ -684,6 +803,8 @@ class StreamingDataLoader(DataLoader):
         self._profile_batches = profile_batches
         self._profile_skip_batches = profile_skip_batches
         self._profile_dir = profile_dir
+        self._profile_cprofile = profile_cprofile
+        self._cprofile_main: cProfile.Profile | None = None
         self._num_samples_yielded_streaming = 0
         self._num_samples_yielded_wrapper: dict[int, list[int]] = {}
         self._num_cycles: dict[int, list[int]] = {}
@@ -734,54 +855,68 @@ class StreamingDataLoader(DataLoader):
         self.dataset.set_epoch(self.current_epoch)
         emit_trace("dataloader", "B", CAT_EPOCH, epoch=self.current_epoch)
         batch_idx = 0
+        if self._profile_cprofile and self.num_workers == 0:
+            self._cprofile_main = cProfile.Profile()
+            self._cprofile_main.enable()
 
-        if isinstance(self.dataset, StreamingDataset):
-            assert self.batch_size
-            timing = StreamingTimingStats.instance()
-            for batch in super().__iter__():
-                emit_trace("batch", "B", CAT_BATCH, batch=batch_idx, epoch=self.current_epoch)
-                t0 = timing.start()
-                self._latest_worker_idx = next(self._worker_idx_iter)  # type: ignore
-                self._num_samples_yielded_streaming += self.batch_size
-                timing.record("dataloader_yield_s", t0)
-                yield batch
-                emit_trace("batch", "E", CAT_BATCH, batch=batch_idx, epoch=self.current_epoch)
-                batch_idx += 1
-        else:
-            self.dataset._set_use_streaming_dataloader(True)
-            assert self.batch_size
-            # TODO: Inject a custom collate function to avoid collating the __NUM_SAMPLES_YIELDED__ key
-            for batch in super().__iter__():
-                emit_trace("batch", "B", CAT_BATCH, batch=batch_idx, epoch=self.current_epoch)
-                self._latest_worker_idx = next(self._worker_idx_iter)  # type: ignore
-                if isinstance(batch, dict) and __NUM_SAMPLES_YIELDED_KEY__ in batch:
-                    self._num_samples_yielded_wrapper[self._latest_worker_idx] = [
-                        sample[-1].item() if self.batch_size > 1 else sample.item()
-                        for sample in batch[__NUM_SAMPLES_YIELDED_KEY__]
-                    ]
-
-                    if __NUM_CYCLES_KEY__ in batch:
-                        self._num_cycles[self._latest_worker_idx] = [
-                            cycle[-1].item() if self.batch_size > 1 else cycle.item()
-                            for cycle in batch[__NUM_CYCLES_KEY__]
-                        ]
-                        self.dataset.update_epoch_counters(self._num_cycles[self._latest_worker_idx])
-
-                    yield batch[__SAMPLES_KEY__]
-                else:
+        try:
+            if isinstance(self.dataset, StreamingDataset):
+                assert self.batch_size
+                timing = StreamingTimingStats.instance()
+                for batch in super().__iter__():
+                    emit_trace("batch", "B", CAT_BATCH, batch=batch_idx, epoch=self.current_epoch)
+                    t0 = timing.start()
+                    self._latest_worker_idx = next(self._worker_idx_iter)  # type: ignore
+                    self._num_samples_yielded_streaming += self.batch_size
+                    timing.record("dataloader_yield_s", t0)
                     yield batch
-                emit_trace("batch", "E", CAT_BATCH, batch=batch_idx, epoch=self.current_epoch)
-                batch_idx += 1
+                    emit_trace("batch", "E", CAT_BATCH, batch=batch_idx, epoch=self.current_epoch)
+                    batch_idx += 1
+            else:
+                self.dataset._set_use_streaming_dataloader(True)
+                assert self.batch_size
+                # TODO: Inject a custom collate function to avoid collating the __NUM_SAMPLES_YIELDED__ key
+                for batch in super().__iter__():
+                    emit_trace("batch", "B", CAT_BATCH, batch=batch_idx, epoch=self.current_epoch)
+                    self._latest_worker_idx = next(self._worker_idx_iter)  # type: ignore
+                    if isinstance(batch, dict) and __NUM_SAMPLES_YIELDED_KEY__ in batch:
+                        self._num_samples_yielded_wrapper[self._latest_worker_idx] = [
+                            sample[-1].item() if self.batch_size > 1 else sample.item()
+                            for sample in batch[__NUM_SAMPLES_YIELDED_KEY__]
+                        ]
 
-        # NOTE: `restore` is intentionally *not* cleared in a `finally` block here. Breaking out of
-        # this generator early (or letting it get garbage-collected, which throws `GeneratorExit` at
-        # the last `yield`) must leave `restore` untouched: callers that explicitly resumed from a
-        # checkpoint (`load_state_dict`) rely on `restore` staying `True` across such early exits so
-        # that the *next* `__iter__` call keeps skipping `reset_state_dict()` and replays from the
-        # loaded state (see `_StreamingMultiProcessingDataLoaderIter._try_put_index`). `restore` is
-        # only toggled back to `False` here, once the loop above completes a full epoch normally.
-        emit_trace("dataloader", "E", CAT_EPOCH, epoch=self.current_epoch)
-        self.restore = False
+                        if __NUM_CYCLES_KEY__ in batch:
+                            self._num_cycles[self._latest_worker_idx] = [
+                                cycle[-1].item() if self.batch_size > 1 else cycle.item()
+                                for cycle in batch[__NUM_CYCLES_KEY__]
+                            ]
+                            self.dataset.update_epoch_counters(self._num_cycles[self._latest_worker_idx])
+
+                        yield batch[__SAMPLES_KEY__]
+                    else:
+                        yield batch
+                    emit_trace("batch", "E", CAT_BATCH, batch=batch_idx, epoch=self.current_epoch)
+                    batch_idx += 1
+
+            # NOTE: `restore` is intentionally *not* cleared in a `finally` block here. Breaking out of
+            # this generator early (or letting it get garbage-collected, which throws `GeneratorExit` at
+            # the last `yield`) must leave `restore` untouched: callers that explicitly resumed from a
+            # checkpoint (`load_state_dict`) rely on `restore` staying `True` across such early exits so
+            # that the *next* `__iter__` call keeps skipping `reset_state_dict()` and replays from the
+            # loaded state (see `_StreamingMultiProcessingDataLoaderIter._try_put_index`). `restore` is
+            # only toggled back to `False` here, once the loop above completes a full epoch normally.
+            emit_trace("dataloader", "E", CAT_EPOCH, epoch=self.current_epoch)
+            self.restore = False
+        finally:
+            self._dump_cprofile_main()
+
+    def _dump_cprofile_main(self) -> None:
+        """Flush the in-process cProfile started for ``num_workers == 0``."""
+        profiler = self._cprofile_main
+        if profiler is None:
+            return
+        self._cprofile_main = None
+        _dump_cprofile(profiler, os.path.join(_cprofile_output_dir(self._profile_dir), _CPROFILE_MAIN_STEM))
 
     def __len__(self) -> int:
         if self._dataset_kind == _DatasetKind.Iterable:

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -106,6 +106,61 @@ def test_streaming_dataloader():
     }
 
 
+def test_profile_cprofile_conflicts_with_profile_batches(tmpdir):
+    dataset = TestCombinedStreamingDataset(
+        [TestStatefulDataset(4, 1), TestStatefulDataset(4, -1)],
+        42,
+        weights=(0.5, 0.5),
+        iterate_over_all=False,
+    )
+    with pytest.raises(ValueError, match="profile_cprofile"):
+        StreamingDataLoader(
+            dataset,
+            batch_size=2,
+            num_workers=1,
+            profile_batches=True,
+            profile_cprofile=True,
+            profile_dir=str(tmpdir),
+        )
+
+
+def test_profile_cprofile_main_and_worker(tmpdir):
+    dataset = TestCombinedStreamingDataset(
+        [TestStatefulDataset(8, 1), TestStatefulDataset(8, -1)],
+        42,
+        weights=(0.5, 0.5),
+        iterate_over_all=False,
+    )
+    dataloader = StreamingDataLoader(
+        dataset, batch_size=2, num_workers=1, profile_cprofile=True, profile_dir=str(tmpdir)
+    )
+    batches = list(dataloader)
+    assert len(batches) > 0
+    main_prof = os.path.join(tmpdir, "cprofile_main.prof")
+    worker_prof = os.path.join(tmpdir, "cprofile_worker0.prof")
+    assert os.path.exists(main_prof)
+    assert os.path.exists(worker_prof)
+    assert os.path.exists(os.path.join(tmpdir, "cprofile_main.txt"))
+    assert os.path.exists(os.path.join(tmpdir, "cprofile_worker0.txt"))
+    assert os.path.getsize(main_prof) > 0
+    assert os.path.getsize(worker_prof) > 0
+
+
+def test_profile_cprofile_num_workers_zero(tmpdir):
+    dataset = TestCombinedStreamingDataset(
+        [TestStatefulDataset(6, 1), TestStatefulDataset(6, -1)],
+        42,
+        weights=(0.5, 0.5),
+        iterate_over_all=False,
+    )
+    dataloader = StreamingDataLoader(
+        dataset, batch_size=2, num_workers=0, profile_cprofile=True, profile_dir=str(tmpdir)
+    )
+    assert list(dataloader)
+    assert os.path.exists(os.path.join(tmpdir, "cprofile_main.prof"))
+    assert not os.path.exists(os.path.join(tmpdir, "cprofile_worker0.prof"))
+
+
 @pytest.mark.skip(reason="Profiling patches torch which leads to undesired test interactions")
 @pytest.mark.skipif(not _VIZ_TRACKER_AVAILABLE, reason="viz tracker required")
 @pytest.mark.parametrize("profile", [2, True])


### PR DESCRIPTION
## Summary
- Add `StreamingDataLoader(..., profile_cprofile=True)` to write stdlib cProfile stats for the parent process and worker 0 (`cprofile_main.prof` / `cprofile_worker0.prof` plus `.txt` summaries). No extra dependency.
- Reject combining `profile_cprofile` with `profile_batches` (both install `sys.setprofile`). Start the parent profiler after workers spawn so fork does not inherit an active cProfile; with `num_workers=0` only the main file is written.
- Document the flag in the README, changelog, and LitData skill references.

## Test plan
- [x] `pytest tests/streaming/test_dataloader.py::test_profile_cprofile_conflicts_with_profile_batches tests/streaming/test_dataloader.py::test_profile_cprofile_main_and_worker tests/streaming/test_dataloader.py::test_profile_cprofile_num_workers_zero`
- [ ] Confirm `profile_cprofile=True` + `num_workers>0` writes both `.prof` files and `python -m pstats` can `sort tottime`
- [ ] Confirm `num_workers=0` writes only `cprofile_main.prof`
- [ ] Confirm constructing the loader with both `profile_batches` and `profile_cprofile` raises


Made with [Cursor](https://cursor.com)