### PR TITLE
fix(streaming): copy deserialized numpy arrays so they are writable

### DIFF
--- a/src/litdata/streaming/serializers.py
+++ b/src/litdata/streaming/serializers.py
@@ -477,7 +477,7 @@ class NumpySerializer(Serializer):
             shape.append(np.frombuffer(data[8 + 4 * shape_idx : 8 + 4 * (shape_idx + 1)], np.uint32).item())
 
         # deserialize the numpy array bytes
-        tensor = np.frombuffer(data[8 + 4 * shape_size : len(data)], dtype=dtype)
+        tensor = np.frombuffer(data[8 + 4 * shape_size : len(data)], dtype=dtype).copy()
         if tensor.shape == shape:
             return tensor
         return np.reshape(tensor, shape)
@@ -503,7 +503,7 @@ class NoHeaderNumpySerializer(Serializer):
 
     def deserialize(self, data: bytes) -> np.ndarray:
         assert self._dtype
-        return np.frombuffer(data, dtype=self._dtype)
+        return np.frombuffer(data, dtype=self._dtype).copy()
 
     def can_serialize(self, item: np.ndarray) -> bool:
         return isinstance(item, np.ndarray) and len(item.shape) == 1

--- a/tests/streaming/test_serializer.py
+++ b/tests/streaming/test_serializer.py
@@ -255,6 +255,7 @@ def test_numpy_serializer():
             data, _ = serializer_tensor.serialize(tensor)
             deserialized_tensor = serializer_tensor.deserialize(data)
             assert deserialized_tensor.dtype == dtype
+            assert deserialized_tensor.flags.writeable
             np.testing.assert_equal(tensor, deserialized_tensor)
 
 
@@ -290,6 +291,7 @@ def test_assert_no_header_numpy_serializer():
     serializer.setup(name)
     assert serializer._dtype == np.dtype("float64")
     new_t = serializer.deserialize(data)
+    assert new_t.flags.writeable
     np.testing.assert_equal(t, new_t)
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #818.

`NumpySerializer.deserialize` and `NoHeaderNumpySerializer.deserialize` return `np.frombuffer(...)` directly. `np.frombuffer` wraps its input as a read-only view, so every numpy array coming out of a `StreamingDataset` is non-writable and the default collate's `torch.from_numpy` warns on it:

> UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior.

The warning is the visible symptom, but the view is the bigger problem. On the `PyTreeLoader` fast path, `_slice_item_bytes` returns a `memoryview` over a live `mmap.ACCESS_READ` mapping and passes it straight to the serializer, so the returned array aliases a mapped chunk file that `_close_mapping` / `_evict_mapped_chunks` can unmap under LRU pressure. That's the same hazard `TokensLoader` already guards against, with the same idiom, in `item_loader.py`:

```python
# Copy out of the memmap. ``close()`` unmaps the previous chunk on the next sample, and
# DataLoader may still be pickling the last items — a view into a closed mmap is SIGSEGV.
data = np.frombuffer(buffer, dtype=self._dtype, count=self._block_size, offset=offset).copy()
```

So this just applies that existing pattern to the two numpy serializers.

### Cost

One extra `memcpy` per numpy field per item: ~1 µs for a 3 KB embedding or CIFAR-sized image, ~240 µs for a 3 MB array. On the non-mmap path the slice of the source `bytes` already costs about the same, so for those callers it is roughly a doubling of an existing copy rather than a new one. `setflags(write=True)` isn't an option — numpy refuses it on a bytes-backed array — and `frombuffer(bytearray(...))` costs the identical copy.

### Scope

Only the two numpy deserializers change. I left the torch serializers and the `warnings.filterwarnings("ignore", message=".*The given buffer is not writable.*")` in `reader.py` alone: that one targets `torch.frombuffer`'s different "given buffer is not writable" message and looks deliberate, and it never covered the numpy warning in #818. Happy to follow up if you'd like the tensor path to match.

While in here I noticed `if tensor.shape == shape` in `NumpySerializer.deserialize` compares a tuple against a list, so it is always `False` and the `np.reshape` path always runs. Harmless, and left alone to keep this diff to the reported bug. The `.copy()` sits before that branch, so it holds either way.

### Tests

Added a `flags.writeable` assertion to the two existing numpy serializer tests rather than a new test: `test_numpy_serializer` already loops over every supported dtype and five shapes, so it pins writability across all of them, and keeping the two serializers in separate tests means a failure says which one broke. Both assertions fail on `main` and pass here.

`test_serializer.py`, `test_item_loader.py` and `test_reader.py` are green locally (72 passed, 4 skipped), as are `ruff`, `ruff format`, `codespell` and `mypy`. I also ran the reporter's reproducer from #818 end to end: the warning fires on `main` and is gone with this change.

I used an AI assistant while working on this. I reproduced the bug, verified the tests fail without the fix, and reviewed the change myself.

---
Used AI assistance on this; I reviewed and tested the change myself.