### PR TITLE
fix(processing): preserve checkpoint paths without UUIDs

### DIFF
--- a/src/litdata/processing/utilities.py
+++ b/src/litdata/processing/utilities.py
@@ -14,6 +14,7 @@
 import io
 import json
 import os
+import re
 import tempfile
 import urllib
 from collections.abc import Callable
@@ -202,8 +203,7 @@ def remove_uuid_from_filename(filepath: str) -> str:
     if not filepath.__contains__(".checkpoints"):
         return filepath
 
-    # uuid is of 32 characters, '.json' is 5 characters and '-' is 1 character
-    return filepath[:-38] + ".json"
+    return re.sub(r"(checkpoint-\d+)-[0-9a-fA-F]{32}\.json$", r"\1.json", filepath)
 
 
 def construct_storage_options(storage_options: dict[str, Any], input_dir: Dir) -> dict[str, Any]:

--- a/tests/processing/test_utilities.py
+++ b/tests/processing/test_utilities.py
@@ -1,6 +1,8 @@
 import json
 from unittest.mock import MagicMock
 
+import pytest
+
 from litdata.processing import utilities as utilities_module
 from litdata.processing.utilities import (
     extract_rank_and_index_from_filename,
@@ -98,25 +100,22 @@ def test_read_index_file_content(tmpdir, monkeypatch):
 
 
 def test_remove_uuid_from_filename():
-    filepaths = [
-        "checkpoint-0-9fe2c4e93f654fdbb24c02b15259716c.json",
-        "checkpoint-1-9fe2c4e93f654fdbb24c02b15259716c.json",
-        "checkpoint-2-9fe2c4e93f654fdbb24c02b15259716c.json",
-        "checkpoint-101-9fe2c4e93f654fdbb24c02b15259716c.json",
-        "checkpoint-12-9fe2c4e93f654fdbb24c02b15259716c.json",
-        "checkpoint-267-9fe2c4e93f654fdbb24c02b15259716c.json",
-    ]
+    checkpoint_dir = "output/data/train/.checkpoints"
+    uuid = "9fe2c4e93f654fdbb24c02b15259716c"
 
-    expected = [
-        "checkpoint-0.json",
-        "checkpoint-1.json",
-        "checkpoint-2.json",
-        "checkpoint-101.json",
-        "checkpoint-12.json",
-        "checkpoint-267.json",
-    ]
+    for rank in (0, 1, 2, 12, 101, 267):
+        filepath = f"{checkpoint_dir}/checkpoint-{rank}-{uuid}.json"
+        assert remove_uuid_from_filename(filepath) == f"{checkpoint_dir}/checkpoint-{rank}.json"
 
-    for idx, filepath in enumerate(filepaths):
-        filepath = ".checkpoints/" + filepath
-        result = remove_uuid_from_filename(filepath)
-        assert result == ".checkpoints/" + expected[idx]
+
+@pytest.mark.parametrize(
+    "filepath",
+    [
+        "output/data/train/.checkpoints/checkpoint-0.json",
+        "input/data/val/.checkpoints/config.json",
+        "output/data/train/.checkpoints/checkpoint-0-not-a-uuid.json",
+        "output/data/train/checkpoint-0-9fe2c4e93f654fdbb24c02b15259716c.json",
+    ],
+)
+def test_remove_uuid_from_filename_leaves_other_paths_unchanged(filepath):
+    assert remove_uuid_from_filename(filepath) == filepath


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #888. Checkpoint writers now produce stable filenames such as `checkpoint-0.json`, but `remove_uuid_from_filename()` still removed the final 38 characters from every path under `.checkpoints`. This truncated the output prefix and wrote checkpoint objects outside their intended directory.

This change only removes the suffix when the filename actually matches `checkpoint-<rank>-<32-character hexadecimal UUID>.json`. Stable checkpoint filenames and unrelated files remain unchanged.

Regression tests cover legacy UUID filenames, stable checkpoint names, configuration files, malformed UUID suffixes, and paths outside the checkpoint directory.

Validation:

- `8 passed` in `tests/processing/test_utilities.py`
- Ruff lint and formatting checks pass

## PR review

Anyone in the community is free to review the PR once the tests have passed.

## Did you have fun?

Yes 🙃