### PR TITLE
Reduce optimize worker memory by excluding full input list from recipe serialization

### DIFF
--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - `StreamingDataset` / `Cache` `max_cache_size`: `None` uses 75% of free disk (leave ≥50GB when possible). `"100G"` / `"50GB"` pins bytes; `0.90` (or `MAX_CACHE_SIZE=0.90`) uses that fraction of currently free space.
+- `optimize` no longer serializes its full input list into every spawned worker process.
 
 ## [0.2.71] - 2026-08-15
 

--- a/src/litdata/processing/functions.py
+++ b/src/litdata/processing/functions.py
@@ -210,6 +210,18 @@ class LambdaDataChunkRecipe(DataChunkRecipe):
 
         self.prepare_item = self._prepare_item_generator if self.is_generator else self._prepare_item  # type: ignore
 
+    def __getstate__(self) -> dict[str, Any]:
+        """Exclude the full input sequence from the serialized data that will be passed to the workers.
+
+        The parent process passes each worker only the items it is responsible for processing. Worker processes do not
+        need the original full input sequence stored on this recipe. With the ``spawn`` multiprocessing start method,
+        the recipe is pickled into every worker process. Keeping the complete ``_inputs`` sequence in that pickle could
+        multiply peak memory by the worker count.
+        """
+        state = self.__dict__.copy()
+        state["_inputs"] = None
+        return state
+
     def check_fn(self) -> None:
         if (
             isinstance(self._fn, (partial, FunctionType))

--- a/tests/processing/test_data_processor.py
+++ b/tests/processing/test_data_processor.py
@@ -1,6 +1,7 @@
 import json
 import multiprocessing as mp
 import os
+import pickle
 import random
 import sys
 import tempfile
@@ -47,7 +48,7 @@ from litdata.processing.data_processor import (
     _wait_for_file_to_exist,
     resolve_keep_data_ordered,
 )
-from litdata.processing.functions import LambdaMapRecipe, _get_input_dir, map, optimize
+from litdata.processing.functions import LambdaDataChunkRecipe, LambdaMapRecipe, _get_input_dir, map, optimize
 from litdata.streaming import StreamingDataLoader, StreamingDataset, resolver
 from litdata.streaming.cache import Cache, Dir
 from litdata.streaming.serializers import _torchcodec_usable
@@ -1346,6 +1347,19 @@ def test_data_processing_optimize_class_yield(monkeypatch, tmpdir):
 
     cache = Cache(output_dir, chunk_size=1)
     assert len(cache) == 5
+
+
+def test_lambda_data_chunk_recipe_pickle():
+    inputs = [bytearray(1024 * 1024)]
+    data_recipe = LambdaDataChunkRecipe(str, inputs, 1, None, None)
+    worker_recipe = pickle.loads(pickle.dumps(data_recipe))
+
+    # The original recipe instance (in the parent process) keeps the full input sequence.
+    assert data_recipe.prepare_structure(None) is inputs
+    # The deserialized worker copy drops `_inputs` to avoid duplicating large input lists.
+    assert worker_recipe.prepare_structure(None) is None
+    # Worker execution still uses the callable path and returns the expected transformed value.
+    assert worker_recipe.prepare_item(123) == "123"
 
 
 def test_lambda_transform_recipe(monkeypatch):


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? I couldn't open an issue.
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

I would have opened an issue, but it's restricted, so I'll describe the issue here and propose a simple solution.

I run out of memory when trying to optimize the huge OpenImages dataset. A lot of memory is wasted, copying the input list to every worker. Under spawn multiprocessing, the optimize recipe is being pickled and sent to every worker process. Currently it contains the full inputs list, so memory is scaled with the number of workers. This change fixes that by customizing recipe serialization so that worker processes no longer receive that list.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
