### PR TITLE
chore: bump version 0.2.72

### DIFF
--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -8,14 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased] - YYYY-MM-DD
 
+## [0.2.72] - 2026-08-24
+
 ### Fixed
 
-- Temporary S3/R2 credential refresh no longer kills a run on a single control-plane blip. The `/v1/auth/login` POST is now retried (urllib3 excludes POST from its default `allowed_methods`, so it never was), a failed refresh keeps serving the current credentials and retries on a timer instead of re-requesting on every read, refreshes are jittered per process so forked DataLoader workers stop stampeding, and the default refresh interval moved from 55 to 45 minutes to leave a usable grace period inside the 1 hour credential TTL. Creating the first client now waits out a control-plane outage instead of failing the job, while missing configuration, rejected credentials and local errors such as a bad `storage_options` key still fail immediately. Also fixes `_CustomRetryAdapter` never applying its default request timeout, because `requests` always passes `timeout` explicitly as `None`, and declares the `urllib3 >=1.26` floor that `streaming/client.py` has always needed for its direct `Retry` import.
-- Multi-node `FullShuffle` epoch ≥ 2 keeps each node's unique chunk set when that shard fits in `max_cache_size` (in-chunk permute is seeded by the global chunk id). If it does not fit, chunks are re-scheduled across nodes.
-
-### Changed
-
-- `StreamingDataset` / `Cache` `max_cache_size`: `None` uses 75% of free disk (leave ≥50GB when possible). `"100G"` / `"50GB"` pins bytes; `0.90` (or `MAX_CACHE_SIZE=0.90`) uses that fraction of currently free space.
+- Temporary S3/R2 credential refresh no longer kills a run on a single control-plane blip. The `/v1/auth/login` POST is now retried (urllib3 excludes POST from its default `allowed_methods`, so it never was), a failed refresh keeps serving the current credentials and retries on a timer instead of re-requesting on every read, refreshes are jittered per process so forked DataLoader workers stop stampeding, and the default refresh interval moved from 55 to 45 minutes to leave a usable grace period inside the 1 hour credential TTL. Creating the first client now waits out a control-plane outage instead of failing the job, while missing configuration, rejected credentials and local errors such as a bad `storage_options` key still fail immediately. Also fixes `_CustomRetryAdapter` never applying its default request timeout, because `requests` always passes `timeout` explicitly as `None`, and declares the `urllib3 >=1.26` floor that `streaming/client.py` has always needed for its direct `Retry` import. ([#891](https://github.com/Lightning-AI/litData/pull/891))
+- `NumpySerializer` / `NoHeaderNumpySerializer` copy on deserialize, so arrays are writable (`np.frombuffer` returns a read-only view, which made `torch.from_numpy` warn on every collate) and no longer alias an mmap the cache can unmap underneath them. ([#887](https://github.com/Lightning-AI/litData/pull/887))
 
 ## [0.2.71] - 2026-08-15
 
@@ -26,11 +24,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Prefetch accepts `numpy.int64` chunk indexes from shuffle (they were dropped by `isinstance(..., int)`), so force-download stays a last resort after `_FORCE_DOWNLOAD_TIME`. Concurrent `os.replace` of the same chunk is a no-op when the destination already exists.
+- Multi-node `FullShuffle` epoch ≥ 2 keeps each node's unique chunk set when that shard fits in `max_cache_size` (in-chunk permute is seeded by the global chunk id). If it does not fit, chunks are re-scheduled across nodes. ([#886](https://github.com/Lightning-AI/litData/pull/886))
 
 ### Changed
 
 - Faster pytree flatten on the writer hot path: skip typing-generic `isinstance` and PIL JPEG probes on non-list/tuple nodes, skip namedtuple/JPEG probes on scalar leaves, and call `_get_node_type` once per node. After the first sample, `BinaryWriter` walks `tree_leaves` (non-generator collect) instead of rebuilding a `TreeSpec`, caches per-leaf byte sizes, and packs the size header with `struct` instead of NumPy. When every leaf has a fixed size (int/float/bool), later samples reuse a cached size header and write into one buffer. `BooleanSerializer` advertises `size = 1`. Reader offset pairs and size headers use `struct` instead of NumPy.
 - Remote→local streaming: cap in-flight chunk GETs with `LITDATA_ASYNC_DOWNLOAD_CONCURRENCY` (default 8), drain the prefetch queue up to gather width when slots are free, signal file-ready with `Event.set` after the downloader's atomic `os.replace` (decompress publishes the readable `.bin`), and `posix_fadvise(WILLNEED)` downloaded cache files from the prefetch thread (mmap stays on the reader thread).
+- `StreamingDataset` / `Cache` `max_cache_size`: `None` uses 75% of free disk (leave ≥50GB when possible). `"100G"` / `"50GB"` pins bytes; `0.90` (or `MAX_CACHE_SIZE=0.90`) uses that fraction of currently free space. ([#886](https://github.com/Lightning-AI/litData/pull/886))
 
 ## [0.2.70] - 2026-08-15
 

--- a/src/litdata/__about__.py
+++ b/src/litdata/__about__.py
@@ -14,7 +14,7 @@
 
 import time
 
-__version__ = "0.2.71"
+__version__ = "0.2.72"
 __author__ = "Lightning AI et al."
 __author_email__ = "pytorch@lightning.ai"
 __license__ = "Apache-2.0"


### PR DESCRIPTION
## What does this PR do?

Bumps to `0.2.72` for release.

Contents since v0.2.71:

- S3/R2 credential refresh reliability (#891)
- Deserialized numpy arrays are copied so they are writable (#887)

Also fixes the changelog. #886 put its two entries under `[unreleased]`, but #886 is the commit `v0.2.71` was tagged at — so that work shipped in 0.2.71, not in this release. Moved them into the `[0.2.71]` section. #887 had no entry at all; added one.

## PR review

Anyone in the community is free to review the PR once the tests have passed.

## Did you have fun?

Always 🙃
