### PR TITLE
Restore PyTorch worker loop after profiling setup

### DIFF
--- a/src/litdata/streaming/dataloader.py
+++ b/src/litdata/streaming/dataloader.py
@@ -558,25 +558,30 @@ class _StreamingMultiProcessingDataLoaderIter(_MultiProcessingDataLoaderIter):
         )
         self._num_workers = loader.num_workers
         self._cprofile: cProfile.Profile | None = None
-        self._orig_worker_loop: Any = None
 
         distributed_env = _DistributedEnv.detect()
         profile_cprofile = bool(getattr(self._loader, "_profile_cprofile", False))
+        from torch.utils.data._utils import worker
+
+        original_worker_loop: Any = None
 
         if distributed_env.global_rank == 0:
-            from torch.utils.data._utils import worker
-
             if self._loader._profile_batches and _VIZ_TRACKER_AVAILABLE:
+                original_worker_loop = worker._worker_loop
                 worker._worker_loop = _ProfileWorkerLoop(
                     self._loader._profile_batches, self._loader._profile_skip_batches, self._loader._profile_dir
                 )
             elif profile_cprofile:
-                self._orig_worker_loop = worker._worker_loop
+                original_worker_loop = worker._worker_loop
                 worker._worker_loop = _CProfileWorkerLoop(_cprofile_output_dir(self._loader._profile_dir))
 
         # Workers fork/spawn here. Enable the parent profiler only after that so
         # the child does not inherit an active cProfile (one profiler per process).
-        super().__init__(loader)
+        try:
+            super().__init__(loader)
+        finally:
+            if original_worker_loop is not None:
+                worker._worker_loop = original_worker_loop
 
         if profile_cprofile and distributed_env.global_rank == 0:
             self._cprofile = cProfile.Profile()
@@ -587,11 +592,6 @@ class _StreamingMultiProcessingDataLoaderIter(_MultiProcessingDataLoaderIter):
             stem = os.path.join(_cprofile_output_dir(self._loader._profile_dir), _CPROFILE_MAIN_STEM)
             _dump_cprofile(self._cprofile, stem)
             self._cprofile = None
-        if self._orig_worker_loop is not None:
-            from torch.utils.data._utils import worker
-
-            worker._worker_loop = self._orig_worker_loop
-            self._orig_worker_loop = None
         super()._shutdown_workers()
 
     def _try_put_index(self) -> None:

--- a/tests/streaming/test_dataloader.py
+++ b/tests/streaming/test_dataloader.py
@@ -125,16 +125,25 @@ def test_profile_cprofile_conflicts_with_profile_batches(tmpdir):
 
 
 def test_profile_cprofile_main_and_worker(tmpdir):
+    from torch.utils.data._utils import worker
+
     dataset = TestCombinedStreamingDataset(
         [TestStatefulDataset(8, 1), TestStatefulDataset(8, -1)],
         42,
         weights=(0.5, 0.5),
         iterate_over_all=False,
     )
+    original_worker_loop = worker._worker_loop
     dataloader = StreamingDataLoader(
         dataset, batch_size=2, num_workers=1, profile_cprofile=True, profile_dir=str(tmpdir)
     )
-    batches = list(dataloader)
+    dataloader_iter = iter(dataloader)
+    try:
+        first_batch = next(dataloader_iter)
+        assert worker._worker_loop is original_worker_loop
+        batches = [first_batch, *dataloader_iter]
+    finally:
+        dataloader_iter.close()
     assert len(batches) > 0
     main_prof = os.path.join(tmpdir, "cprofile_main.prof")
     worker_prof = os.path.join(tmpdir, "cprofile_worker0.prof")
@@ -161,10 +170,11 @@ def test_profile_cprofile_num_workers_zero(tmpdir):
     assert not os.path.exists(os.path.join(tmpdir, "cprofile_worker0.prof"))
 
 
-@pytest.mark.skip(reason="Profiling patches torch which leads to undesired test interactions")
 @pytest.mark.skipif(not _VIZ_TRACKER_AVAILABLE, reason="viz tracker required")
 @pytest.mark.parametrize("profile", [2, True])
 def test_dataloader_profiling(profile, tmpdir, monkeypatch):
+    from torch.utils.data._utils import worker
+
     monkeypatch.setattr(streaming_dataloader_module, "_VIZ_TRACKER_AVAILABLE", True)
 
     dataset = TestCombinedStreamingDataset(
@@ -173,13 +183,17 @@ def test_dataloader_profiling(profile, tmpdir, monkeypatch):
         weights=(0.5, 0.5),
         iterate_over_all=False,
     )
+    original_worker_loop = worker._worker_loop
     dataloader = StreamingDataLoader(
         dataset, batch_size=2, profile_batches=profile, profile_dir=str(tmpdir), num_workers=1
     )
     dataloader_iter = iter(dataloader)
-    batches = []
-    for batch in dataloader_iter:
-        batches.append(batch)
+    try:
+        next(dataloader_iter)
+        assert worker._worker_loop is original_worker_loop
+        assert list(dataloader_iter)
+    finally:
+        dataloader_iter.close()
 
     assert os.path.exists(os.path.join(tmpdir, "result.json"))
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a GitHub issue? Approved in #240.
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Did you make sure to update the docs? No documentation change is needed because this fixes internal cleanup behavior.
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #240.

LitData temporarily replaces PyTorch's process-global worker loop when VizTracer or cProfile worker profiling is enabled. The replacement was previously kept until iterator shutdown, so creating another data loader in the same process could inherit LitData's profiling worker loop.

This change restores the original worker loop in a `finally` block immediately after multiprocessing workers are initialized. The workers still receive the profiling loop, while the parent process is restored even when initialization raises. The profiling regressions now assert restoration as soon as the iterator starts.

## Validation

- `pytest tests/streaming/test_dataloader.py`: 21 passed, 12 skipped
- focused cProfile and VizTracer profiling tests: 2 passed
- `ruff check` and `ruff format --check`: passed
- `python -m py_compile` and `git diff --check`: passed

## AI assistance

This contribution was developed with AI assistance. The issue scope, implementation, regression behavior, full affected test file, style checks, and final diff were independently reviewed and verified before submission.

## PR review

Anyone in the community is free to review the PR once the tests have passed.

## Did you have fun?

Yes 🙃