### PR TITLE
Reduce optimize/map worker memory by omitting the input list from recipe pickle

### DIFF
--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased] - YYYY-MM-DD
 
+### Changed
+
+- `optimize` / `map` no longer pickle the full input list into every spawned worker. ([#890](https://github.com/Lightning-AI/litData/pull/890))
+
 ## [0.2.72] - 2026-08-24
 
 ### Fixed

--- a/src/litdata/processing/functions.py
+++ b/src/litdata/processing/functions.py
@@ -147,6 +147,17 @@ class LambdaMapRecipe(MapRecipe):
         self._contains_device = "device" in params
         self._contains_is_last = "is_last" in params
 
+    def __getstate__(self) -> dict[str, Any]:
+        """Drop the full input sequence when pickling into spawn workers.
+
+        The parent already shards items onto per-worker queues. Workers only need
+        ``prepare_item``; keeping ``_inputs`` in the pickle would duplicate the list
+        once per process.
+        """
+        state = self.__dict__.copy()
+        state["_inputs"] = None
+        return state
+
     def prepare_structure(self, _: str | None) -> Any:
         return self._inputs
 
@@ -209,6 +220,17 @@ class LambdaDataChunkRecipe(DataChunkRecipe):
         self.check_fn()
 
         self.prepare_item = self._prepare_item_generator if self.is_generator else self._prepare_item  # type: ignore
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Drop the full input sequence when pickling into spawn workers.
+
+        The parent already shards items onto per-worker queues. Workers only need
+        ``prepare_item``; keeping ``_inputs`` in the pickle would duplicate the list
+        once per process.
+        """
+        state = self.__dict__.copy()
+        state["_inputs"] = None
+        return state
 
     def check_fn(self) -> None:
         if (

--- a/tests/processing/test_data_processor.py
+++ b/tests/processing/test_data_processor.py
@@ -1,6 +1,7 @@
 import json
 import multiprocessing as mp
 import os
+import pickle
 import random
 import sys
 import tempfile
@@ -47,7 +48,7 @@ from litdata.processing.data_processor import (
     _wait_for_file_to_exist,
     resolve_keep_data_ordered,
 )
-from litdata.processing.functions import LambdaMapRecipe, _get_input_dir, map, optimize
+from litdata.processing.functions import LambdaDataChunkRecipe, LambdaMapRecipe, _get_input_dir, map, optimize
 from litdata.streaming import StreamingDataLoader, StreamingDataset, resolver
 from litdata.streaming.cache import Cache, Dir
 from litdata.streaming.serializers import _torchcodec_usable
@@ -1346,6 +1347,24 @@ def test_data_processing_optimize_class_yield(monkeypatch, tmpdir):
 
     cache = Cache(output_dir, chunk_size=1)
     assert len(cache) == 5
+
+
+def _noop_map_item(item: Any, output_dir: str) -> None:
+    return None
+
+
+def test_lambda_recipe_pickle_drops_inputs():
+    inputs = [bytearray(1024)]
+    chunk_recipe = LambdaDataChunkRecipe(str, inputs, 1, None, None)
+    map_recipe = LambdaMapRecipe(_noop_map_item, inputs)
+    pickled_chunk = pickle.loads(pickle.dumps(chunk_recipe))  # noqa: S301
+    pickled_map = pickle.loads(pickle.dumps(map_recipe))  # noqa: S301
+
+    assert chunk_recipe.prepare_structure(None) is inputs
+    assert map_recipe.prepare_structure(None) is inputs
+    assert pickled_chunk.prepare_structure(None) is None
+    assert pickled_map.prepare_structure(None) is None
+    assert pickled_chunk.prepare_item(123) == "123"
 
 
 def test_lambda_transform_recipe(monkeypatch):


### PR DESCRIPTION
## Summary
- Under spawn, `LambdaDataChunkRecipe` / `LambdaMapRecipe` were pickled into every worker with the full `inputs` list, so memory scaled with worker count (OpenImages-scale lists OOM). `__getstate__` now drops `_inputs`; workers already get their shard via queues.
- Same idea as [#890](https://github.com/Lightning-AI/litData/pull/890) (thanks @senarvi). That PR was blocked by ruff S301 on `pickle.loads` in the test; this adds `# noqa: S301` like the rest of the suite, rebases onto current `main`, and applies the same skip for `map`.

## Test plan
- [x] `pytest tests/processing/test_data_processor.py::test_lambda_recipe_pickle_drops_inputs`
- [ ] CI green (pre-commit + pytester)


Made with [Cursor](https://cursor.com)