### PR TITLE
chore: bump version 0.2.73

### DIFF
--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -8,9 +8,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased] - YYYY-MM-DD
 
+## [0.2.73] - 2026-08-31
+
 ### Changed
 
 - `optimize` / `map` no longer pickle the full input list into every spawned worker. ([#890](https://github.com/Lightning-AI/litData/pull/890))
+
+### Fixed
+
+- Multi-node `optimize(mode="append")` no longer repeats existing chunks once per node in the merged `index.json`. ([#866](https://github.com/Lightning-AI/litData/pull/866))
+- Restore PyTorch's process-global DataLoader worker loop after VizTracer/cProfile setup, so a later loader in the same process does not inherit LitData's profiling worker. ([#893](https://github.com/Lightning-AI/litData/pull/893))
 
 ## [0.2.72] - 2026-08-24
 

--- a/src/litdata/__about__.py
+++ b/src/litdata/__about__.py
@@ -14,7 +14,7 @@
 
 import time
 
-__version__ = "0.2.72"
+__version__ = "0.2.73"
 __author__ = "Lightning AI et al."
 __author_email__ = "pytorch@lightning.ai"
 __license__ = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump `__version__` to `0.2.73`.
- Move changelog entries since `0.2.72` into `[0.2.73]` and add the missing ones for multi-node append (`#866`) and DataLoader worker-loop restore (`#893`).

## Test plan
- [ ] Confirm `__about__.py` is `0.2.73`
- [ ] Changelog section `[0.2.73]` lists `#890`, `#866`, `#893`


Made with [Cursor](https://cursor.com)