### PR TITLE
chore: bump version to 0.2.75

### DIFF
--- a/src/litdata/CHANGELOG.md
+++ b/src/litdata/CHANGELOG.md
@@ -8,9 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased] - YYYY-MM-DD
 
+## [0.2.75] - 2026-09-01
+
 ### Fixed
 
-- Auto ``batch_decode`` is 1 for JPEG / image / audio (and other per-item media). A 16-row window plus ``item_shuffle_window=256`` was re-decoding each ImageNet JPEG ~16×. Cheap leaves (text, ints, small tensors) still batch. ([#897](https://github.com/Lightning-AI/litData/pull/897) follow-up)
+- Shuffled JPEG (and other per-item media) streaming no longer re-decodes the same image ~16×. Auto-windowing stays on for cheap leaves (text, ints, small tensors); JPEG / image / audio / video use ``batch_decode=1`` so ImageNet-style epochs keep full decode speed. ([#899](https://github.com/Lightning-AI/litData/pull/899))
 
 ## [0.2.74] - 2026-09-01
 

--- a/src/litdata/__about__.py
+++ b/src/litdata/__about__.py
@@ -14,7 +14,7 @@
 
 import time
 
-__version__ = "0.2.74"
+__version__ = "0.2.75"
 __author__ = "Lightning AI et al."
 __author_email__ = "pytorch@lightning.ai"
 __license__ = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump LitData **0.2.74 → 0.2.75** after [#899](https://github.com/Lightning-AI/litData/pull/899) (JPEG / per-item media shuffle decode fix) landed on `main` since `v0.2.74`.
- Changelog: `[0.2.75] - 2026-09-01` sales note for shuffled JPEG no-window. Version is only in `src/litdata/__about__.py` + `src/litdata/CHANGELOG.md`.
- Hub streaming ([#897](https://github.com/Lightning-AI/litData/pull/897)) already shipped in **0.2.74** ([#898](https://github.com/Lightning-AI/litData/pull/898)).

## Test plan
- [ ] Confirm `main` stays **0.2.74** until this PR merges
- [ ] Confirm `__version__ == "0.2.75"` and CHANGELOG `[0.2.75]` after merge
- [ ] Do not merge until ready to cut the 0.2.75 release


Made with [Cursor](https://cursor.com)