### PR TITLE
fix(streaming): send S3 temp-credential reads to the bucket's real endpoint

### DIFF
--- a/src/litdata/streaming/client.py
+++ b/src/litdata/streaming/client.py
@@ -341,8 +341,7 @@ class S3Client:
     def _create_client_from_temp_credentials(self, data_connection_id: str) -> None:
         """Create an S3 client backed by temporary project-role credentials for a data connection.
 
-        Used for S3 connections available on non-AWS providers. Unlike R2 there is no custom
-        endpoint — this is real AWS S3, so botocore resolves the bucket region on first use.
+        Used for S3 connections available on non-AWS providers.
         """
         temp_credentials = _login_and_get_temp_bucket_credentials(
             data_connection_id, force_refresh=self._force_refresh_credentials
@@ -354,6 +353,17 @@ class S3Client:
         # data_connection_id is our own metadata; drop it before handing options to boto3.
         storage_options = {k: v for k, v in self._storage_options.items() if k != "data_connection_id"}
 
+        # Inside a Studio, AWS_CONFIG_FILE points the default profile at Lightning Storage, and
+        # botocore applies that endpoint and region to any client built here — sending these AWS
+        # keys to Cloudflare, which rejects them as InvalidAccessKeyId. The control plane reports
+        # where the bucket actually lives, so set both rather than letting the SDK resolve them.
+        # Older control planes omit these fields; nothing to correct with, so leave them unset.
+        resolved: dict[str, Any] = {}
+        if temp_credentials.get("endpoint"):
+            resolved["endpoint_url"] = temp_credentials["endpoint"]
+        if temp_credentials.get("region"):
+            resolved["region_name"] = temp_credentials["region"]
+
         session = boto3.Session(**self._session_options)
         self._client = session.client(
             "s3",
@@ -362,6 +372,7 @@ class S3Client:
                 "aws_secret_access_key": temp_credentials["secretAccessKey"],
                 "aws_session_token": temp_credentials["sessionToken"],
                 "config": botocore.config.Config(retries={"max_attempts": 1000, "mode": "adaptive"}),
+                **resolved,
                 **storage_options,
             },
         )

--- a/tests/streaming/test_client.py
+++ b/tests/streaming/test_client.py
@@ -371,7 +371,7 @@ def test_s3_client_uses_temp_credentials_with_data_connection_id(monkeypatch):
     botocore = mock.MagicMock()
     monkeypatch.setattr(client, "botocore", botocore)
 
-    # The S3 temp-credentials response has no accountId (real AWS S3, no custom endpoint).
+    # A control plane predating the endpoint/region fields — there is nothing to correct with.
     temp_credentials = {
         "accessKeyId": "test-access-key",
         "secretAccessKey": "test-secret-key",
@@ -390,6 +390,77 @@ def test_s3_client_uses_temp_credentials_with_data_connection_id(monkeypatch):
         aws_session_token="test-session-token",
         config=botocore.config.Config(retries={"max_attempts": 1000, "mode": "adaptive"}),
         region_name="us-west-2",
+    )
+
+
+def test_s3_client_uses_endpoint_and_region_from_temp_credentials(monkeypatch):
+    """Both must reach boto3, or the request never arrives at AWS.
+
+    A Studio's AWS_CONFIG_FILE points the default profile at Lightning Storage, so a client
+    built without an explicit endpoint sends these AWS keys to Cloudflare, and one built
+    without an explicit region signs for `auto`.
+    """
+    boto3_session = mock.MagicMock()
+    boto3 = mock.MagicMock(Session=boto3_session)
+    monkeypatch.setattr(client, "boto3", boto3)
+
+    botocore = mock.MagicMock()
+    monkeypatch.setattr(client, "botocore", botocore)
+
+    temp_credentials = {
+        "accessKeyId": "test-access-key",
+        "secretAccessKey": "test-secret-key",
+        "sessionToken": "test-session-token",
+        "region": "us-west-2",
+        "endpoint": "https://s3.us-west-2.amazonaws.com",
+    }
+    monkeypatch.setattr(client, "_login_and_get_temp_bucket_credentials", mock.MagicMock(return_value=temp_credentials))
+
+    s3_client = client.S3Client(storage_options={"data_connection_id": "test-connection"})
+    assert s3_client.client
+
+    boto3_session().client.assert_called_with(
+        "s3",
+        aws_access_key_id="test-access-key",
+        aws_secret_access_key="test-secret-key",
+        aws_session_token="test-session-token",
+        config=botocore.config.Config(retries={"max_attempts": 1000, "mode": "adaptive"}),
+        endpoint_url="https://s3.us-west-2.amazonaws.com",
+        region_name="us-west-2",
+    )
+
+
+def test_s3_client_storage_options_win_over_temp_credentials(monkeypatch):
+    """A caller who names a region keeps it — the control plane's value is a default, not an override."""
+    boto3_session = mock.MagicMock()
+    boto3 = mock.MagicMock(Session=boto3_session)
+    monkeypatch.setattr(client, "boto3", boto3)
+
+    botocore = mock.MagicMock()
+    monkeypatch.setattr(client, "botocore", botocore)
+
+    temp_credentials = {
+        "accessKeyId": "test-access-key",
+        "secretAccessKey": "test-secret-key",
+        "sessionToken": "test-session-token",
+        "region": "us-west-2",
+        "endpoint": "https://s3.us-west-2.amazonaws.com",
+    }
+    monkeypatch.setattr(client, "_login_and_get_temp_bucket_credentials", mock.MagicMock(return_value=temp_credentials))
+
+    s3_client = client.S3Client(
+        storage_options={"data_connection_id": "test-connection", "region_name": "eu-west-1"},
+    )
+    assert s3_client.client
+
+    boto3_session().client.assert_called_with(
+        "s3",
+        aws_access_key_id="test-access-key",
+        aws_secret_access_key="test-secret-key",
+        aws_session_token="test-session-token",
+        config=botocore.config.Config(retries={"max_attempts": 1000, "mode": "adaptive"}),
+        endpoint_url="https://s3.us-west-2.amazonaws.com",
+        region_name="eu-west-1",
     )
 
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lit-data/blob/main/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes reads on S3 data connections failing with `InvalidAccessKeyId` from inside a Studio.

Inside a Studio, `AWS_CONFIG_FILE` points the default profile at Lightning Storage. botocore applies that `endpoint_url` and `region = auto` to any client built in the process — including one handed explicit AWS keys — so reads on an S3 data connection were signed for the wrong region and sent to Cloudflare. Cloudflare rejects an AWS key as `InvalidAccessKeyId`, an error that says nothing about the endpoint, which is why this reads as an auth problem rather than a routing one.

The control plane now reports the bucket's `region` and `endpoint` alongside the temporary credentials, so `_create_client_from_temp_credentials` passes both to boto3 rather than letting the SDK resolve them. Supplying the endpoint alone isn't enough: with `region = auto` still inherited the request is then rejected by AWS instead.

* Resolved values go in ahead of `**storage_options`, so a caller naming its own region or endpoint still wins — the control plane supplies a default, not an override.
* Control planes that don't return the fields are unaffected, so this is safe to release ahead of the backend rollout.
* Also drops a docstring line claiming "there is no custom endpoint — this is real AWS S3, so botocore resolves the bucket region on first use", which was the faulty assumption behind the bug.

Two tests cover the new behaviour: one that both values reach boto3, one that an explicit `region_name` from the caller still wins. Both fail without the change.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Yes 🙃

<sub>— Claude Opus 5, on direct instruction; text not reviewed</sub>

Made with [Cursor](https://cursor.com)