### PR TITLE
[3/n] Sync CODEOWNERS with the current maintainer roster

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
 # Each line is a file pattern followed by one or more owners.
 
-# These owners will be the default owners for everything in the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for review when someone opens a pull request.
-* @tchaton @lantiga @justusschock
+# Default owners for everything in the repo. Unless a later match takes precedence,
+# these owners are requested for review when someone opens a pull request.
+* @tchaton @bhimrazy @deependujha @pwgardipee @dhedey
 
 # CI/CD and configs
-/.github/       @tchaton @justusschock
-*.yml           @tchaton @justusschock
+/.github/       @tchaton @bhimrazy @pwgardipee @dhedey
+*.yml           @tchaton @pwgardipee @dhedey
 
-/src            @tchaton @lantiga @justusschock
+/src            @tchaton @pwgardipee @dhedey

--- a/README.md
+++ b/README.md
@@ -2923,6 +2923,8 @@ Papers that train or stream with LitData (`optimize` / `StreamingDataset`). Scho
 * Thomas Chaton ([tchaton](https://github.com/tchaton))
 * Bhimraj Yadav ([bhimrazy](https://github.com/bhimrazy))
 * Deependu ([deependujha](https://github.com/deependujha))
+* Peyton Gardipee ([pwgardipee](https://github.com/pwgardipee))
+* David Edey ([dhedey](https://github.com/dhedey))
 
 
 ## Emeritus Maintainers


### PR DESCRIPTION
## What does this PR do?

Addresses item 3 of the [PyTorch ecosystem review](https://github.com/pytorch-fdn/ecosystem/issues/82#issuecomment-5583699347): CODEOWNERS named maintainers the README lists as Emeritus, and omitted the active ones.

- `.github/CODEOWNERS`: drop @lantiga and @justusschock, add the current maintainers, and scope CI/config and `/src` ownership.
- `README.md`: add @pwgardipee and @dhedey to Maintainers, matching the roster in the ecosystem application.